### PR TITLE
Fix typo in n1.csv and n2.csv

### DIFF
--- a/src/n1.csv
+++ b/src/n1.csv
@@ -2274,7 +2274,7 @@ expression,reading,meaning,tags
 誠に,まことに,"indeed, really (very polite), absolutely",JLPT_1 JLPT Genki_Ln.20 Genki
 まさしく,まさしく,"surely, no doubt, evidently",JLPT_1 JLPT
 勝る,まさる,"to excel, to surpass, to out-rival",JLPT_1 JLPT
-～増し,～増し,~increase,JLPT_1 JLPT
+～増し,～まし,~increase,JLPT_1 JLPT
 交える,まじえる,"to mix, to converse with, to cross (swords)",JLPT_1 JLPT
 真下,ました,"right under, directly below",JLPT_1 JLPT
 まして,まして,"still more, still less (with neg. verb), to say nothing of",JLPT_1 JLPT

--- a/src/n2.csv
+++ b/src/n2.csv
@@ -668,7 +668,7 @@ expression,reading,meaning,tags
 ～国,～こく,nation of ~,JLPT JLPT_2
 国王,こくおう,king,JLPT JLPT_2
 国立,こくりつ,national,JLPT JLPT_2
-ご苦労様,ごくろうさま,Thank you for your had work,JLPT JLPT_2
+ご苦労様,ごくろうさま,Thank you for your hard work,JLPT JLPT_2
 焦げる,こげる,"to burn, to be burned",JLPT JLPT_2
 凍える,こごえる,"to freeze, to be chilled, to be frozen",JLPT JLPT_2
 心当たり,こころあたり,"having some knowledge of, happening to know",JLPT JLPT_2


### PR DESCRIPTION
Found some typos in n1.csv and n2.csv

### 1.

```
～増し,～増し,~increase,JLPT_1 JLPT
```

Should be (missing kana)

```
～増し,～まし,~increase,JLPT_1 JLPT
```

### 2.

```
ご苦労様,ごくろうさま,Thank you for your had work,JLPT JLPT_2
```

Should be (typo)

```
ご苦労様,ごくろうさま,Thank you for your hard work,JLPT JLPT_2
```

---

I also found some strange definitions for 2 words. Maybe we could discuss if should be added to PR

### n1.csv

```
擦る,かする,"to rub, to chafe",JLPT_1 JLPT
```

My dictionary says (when 擦る reads as かする)

```
1. to graze (e.g. bullet), to scratch, to touch lightly
2. to take a percentage, to exploit, to squeeze
```

### n3.csv

```
異,い,objection,JLPT_1 JLPT JLPT_3
```

I did not find any dictionary that translates the single kanji 異 as "objection"