### PR TITLE
Add and store GUIDs for all notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
       run: |
         black scripts --check
         npm run lint
+        scripts/guid-enforce.py check
 
     - name: Set Git Tag
       if: startsWith(github.ref, 'refs/tags/')

--- a/scripts/generate-decks.py
+++ b/scripts/generate-decks.py
@@ -59,9 +59,12 @@ def createDeckFromCsv(id, name, description, csvPath):
         lineCount = 0
         for row in reader:
             if lineCount > 0:
-                note = genanki.Note(model=model, fields=row[0:3], tags=row[3].split())
+                note = genanki.Note(
+                    model=model, fields=row[0:3], tags=row[3].split(), guid=row[4]
+                )
                 deck.add_note(note)
             lineCount += 1
+    csvFile.close()
     return genanki.Package(deck)
 
 

--- a/scripts/guid-enforce.py
+++ b/scripts/guid-enforce.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+import csv
+import genanki
+import os
+import sys
+
+csvFiles = [
+    "src/n5.csv",
+    "src/n4.csv",
+    "src/n3.csv",
+    "src/n2.csv",
+    "src/n1.csv",
+]
+
+
+def findMissingGuids(csvPath, callback, overwrite):
+    newCsv = []
+    hasChangedData = False
+    with open(csvPath, mode="r", newline="") as csvFile:
+        reader = csv.reader(csvFile)
+        lineCount = 0
+        for row in reader:
+            if lineCount > 0 and row[4].strip() == "":
+                newRow = callback(row, lineCount)
+                if newRow != None:
+                    hasChangedData = True
+                    newCsv.append(newRow)
+                else:
+                    newCsv.append(row)
+            else:
+                newCsv.append(row)
+            lineCount += 1
+    csvFile.close()
+    if overwrite and hasChangedData:
+        with open(csvPath, "r+", newline="") as csvFile:
+            writer = csv.writer(csvFile)
+            writer.writerows(newCsv)
+
+            # Remove trailing newline from end of file
+            csvFile.seek(0)
+            content = csvFile.read()
+            content = content.rstrip()
+            csvFile.seek(0)
+            csvFile.write(content)
+            csvFile.truncate()
+            csvFile.close()
+        csvFile.close()
+
+
+def checkForMissingGuids(csvPath):
+    ctx = {
+        "hasMissingGuids": 0,
+    }
+
+    def callback(row, lineCount):
+        ctx["hasMissingGuids"] = 1
+        print("Missing guid on line " + str(lineCount + 1) + " of " + csvPath)
+        print(row)
+
+    findMissingGuids(csvPath, callback, False)
+    return ctx["hasMissingGuids"]
+
+
+def fixMissingGuids(csvPath):
+    def callback(row, lineCount):
+        newRow = row.copy()
+        newRow[4] = genanki.guid_for(row[0], row[1], row[2])
+        print("Fixed guid on line " + str(lineCount + 1) + " of " + csvPath)
+        return newRow
+
+    findMissingGuids(csvPath, callback, True)
+
+
+if __name__ == "__main__":
+    command = sys.argv[1] if len(sys.argv) > 1 else ""
+
+    if command == "check" or command == "":
+        hasMissingGuids = False
+        for csvPath in csvFiles:
+            result = checkForMissingGuids(csvPath)
+            if result == 1:
+                hasMissingGuids = True
+        if hasMissingGuids:
+            print("Missing guids found in one or more csv files")
+            print("Run `scripts/guid-enforce.py fix` to fix them")
+            sys.exit(1)
+        sys.exit(0)
+
+    if command == "fix":
+        for csvPath in csvFiles:
+            fixMissingGuids(csvPath)
+        sys.exit(0)
+
+    print("Unknown command: " + command)
+    sys.exit(1)

--- a/src/n1.csv
+++ b/src/n1.csv
@@ -1,2700 +1,2700 @@
-expression,reading,meaning,tags
-現像,げんぞう,developing (film),JLPT_1 JLPT
-原則,げんそく,"principle, general rule",JLPT_1 JLPT
-見地,けんち,point of view,JLPT_1 JLPT
-現地,げんち,"actual place, local",JLPT_1 JLPT
-限定,げんてい,"limit, restriction",JLPT_1 JLPT
-原点,げんてん,"origin (coordinates, starting point)",JLPT_1 JLPT
-原典,げんてん,"original, source",JLPT_1 JLPT
-原爆,げんばく,atomic bomb,JLPT_1 JLPT
-原文,げんぶん,"the text, original",JLPT_1 JLPT
-厳密,げんみつ,"strict, close",JLPT_1 JLPT
-賢明,けんめい,"wisdom, intelligence, prudence",JLPT_1 JLPT
-倹約,けんやく,"thrift, economy, frugality",JLPT_1 JLPT
-原油,げんゆ,crude oil,JLPT_1 JLPT
-兼用,けんよう,"multi-use, combined use",JLPT_1 JLPT
-権力,けんりょく,"(political) power, authority, influence",JLPT_1 JLPT
-言論,げんろん,"discussion, speech",JLPT_1 JLPT
-故～,こ～,"deceased, late",JLPT_1 JLPT
-語彙,ごい,"vocabulary, glossary",JLPT_1 JLPT
-恋する,こいする,"to fall in love with, to love",JLPT_1 JLPT
-甲,こう,1st in rank; shell,JLPT_1 JLPT
-～光,～こう,light,JLPT_1 JLPT
-好意,こうい,"good will, favor, courtesy",JLPT_1 JLPT
-行為,こうい,"act, deed, conduct",JLPT_1 JLPT
-合意,ごうい,"agreement, consent, mutual understanding",JLPT_1 JLPT
-工学,こうがく,engineering,JLPT_1 JLPT
-抗議,こうぎ,"protest, objection",JLPT_1 JLPT
-合議,ごうぎ,"consultation, conference",JLPT_1 JLPT
-皇居,こうきょ,Imperial Palace,JLPT_1 JLPT
-好況,こうきょう,"prosperous conditions, healthy economy",JLPT_1 JLPT
-鉱業,こうぎょう,mining industry,JLPT_1 JLPT
-興業,こうぎょう,starting a business; industry,JLPT_1 JLPT
-高原,こうげん,"tableland, plateau",JLPT_1 JLPT
-交互,こうご,"mutual, reciprocal, alternate",JLPT_1 JLPT
-煌々と,こうこうと,brightly,JLPT_1 JLPT
-考古学,こうこがく,archeology,JLPT_1 JLPT
-工作,こうさく,"handicraft, maneuvering",JLPT_1 JLPT
-耕作,こうさく,"cultivation, farming",JLPT_1 JLPT
-鉱山,こうざん,mine,JLPT_1 JLPT
-講習,こうしゅう,"short course, training",JLPT_1 JLPT
-口述,こうじゅつ,verbal statement,JLPT_1 JLPT
-控除,こうじょ,"subsidy, deduction",JLPT_1 JLPT
-交渉,こうしょう,negotiation,JLPT_1 JLPT Intermediate_Japanese_Ln.8 Intermediate_Japanese
-高尚,こうしょう,"high, noble, refined",JLPT_1 JLPT
-向上,こうじょう,"rise, improvement, progress",JLPT_1 JLPT
-行進,こうしん,"march, parade",JLPT_1 JLPT
-香辛料,こうしんりょう,spices,JLPT_1 JLPT
-降水,こうすい,"rainfall, precipitation",JLPT_1 JLPT
-洪水,こうずい,flood,JLPT_1 JLPT
-合成,ごうせい,"synthetic, mixed",JLPT_1 JLPT
-公然,こうぜん,openly,JLPT_1 JLPT
-抗争,こうそう,"dispute, resistance",JLPT_1 JLPT
-構想,こうそう,"plan, plot, idea, conception",JLPT_1 JLPT
-後退,こうたい,"retreat, backspace",JLPT_1 JLPT
-光沢,こうたく,"luster, glossy finish (of photographs)",JLPT_1 JLPT
-公団,こうだん,public corporation,JLPT_1 JLPT
-好調,こうちょう,"satisfactory, in good shape",JLPT_1 JLPT
-口頭,こうとう,oral,JLPT_1 JLPT
-講読,こうどく,reading,JLPT_1 JLPT
-購読,こうどく,subscription,JLPT_1 JLPT
-購入,こうにゅう,"purchase, buy",JLPT_1 JLPT
-公認,こうにん,"official recognition, authorization",JLPT_1 JLPT
-光熱費,こうねつひ,cost of fuel and light,JLPT_1 JLPT
-購買,こうばい,"purchase, buy",JLPT_1 JLPT
-好評,こうひょう,"popularity, favorable reputation",JLPT_1 JLPT
-交付,こうふ,"delivering, furnishing (with copies)",JLPT_1 JLPT
-公募,こうぼ,"public appeal, public contribution",JLPT_1 JLPT
-巧妙,こうみょう,"ingenious, skillful, clever",JLPT_1 JLPT
-公用,こうよう,"government business, public use, public expense",JLPT_1 JLPT
-小売,こうり,retail,JLPT_1 JLPT
-効率,こうりつ,efficiency,JLPT_1 JLPT
-公立,こうりつ,public institution,JLPT_1 JLPT
-護衛,ごえい,"guard, convoy, escort",JLPT_1 JLPT
-コーナー,コーナー,corner,JLPT_1 JLPT
-小柄,こがら,"small, diminutive",JLPT_1 JLPT
-小切手,こぎって,"cheque, check",JLPT_1 JLPT
-国産,こくさん,domestic products,JLPT_1 JLPT
-国定,こくてい,"state-sponsored, national",JLPT_1 JLPT
-告白,こくはく,"confession, acknowledgment",JLPT_1 JLPT
-国防,こくぼう,national defense,JLPT_1 JLPT
-国有,こくゆう,national ownership,JLPT_1 JLPT
-極楽,ごくらく,paradise,JLPT_1 JLPT
-国連,こくれん,"U.N., United Nations",JLPT_1 JLPT
-焦げ茶,こげちゃ,dark brown,JLPT_1 JLPT
-語源,ごげん,"word root, word derivation, etymology",JLPT_1 JLPT
-心地,ここち,"feeling, sensation, mood",JLPT_1 JLPT
-心得,こころえ,"knowledge, information",JLPT_1 JLPT
-心掛け,こころがけ,"readiness, intention, aim",JLPT_1 JLPT
-心掛ける,こころがける,"to bear in mind, to aim to do",JLPT_1 JLPT
-志,こころざし,"will, intention, motive",JLPT_1 JLPT
-志す,こころざす,"to plan, to intend, to aspire to",JLPT_1 JLPT
-心強い,こころづよい,"heartening, reassuring",JLPT_1 JLPT
-心細い,こころぼそい,"helpless, hopeless, discouraging",JLPT_1 JLPT
-試み,こころみ,"trial, experiment",JLPT_1 JLPT
-試みる,こころみる,"to try, to test",JLPT_1 JLPT
-快い,こころよい,"pleasant, agreeable",JLPT_1 JLPT
-誤差,ごさ,error,JLPT_1 JLPT
-ございます (かん),ございます (かん),"to be (polite, to exist)",JLPT_1 JLPT
-孤児,こじ,orphan,JLPT_1 JLPT
-こじれる,こじれる,"to get complicated, to grow worse",JLPT_1 JLPT
-こす (みずを～),こす (みずを～),"to strain, to filter",JLPT_1 JLPT
-梢,こずえ,treetop,JLPT_1 JLPT
-個性,こせい,"individuality, personality, idiosyncrasy",JLPT_1 JLPT
-戸籍,こせき,"census, family register",JLPT_1 Intermediate_Japanese_Ln.14 JLPT Intermediate_Japanese
-古代,こだい,ancient times,JLPT_1 JLPT
-こたつ,こたつ,"table with heater, (originally) charcoal brazier in a floor well",JLPT_1 JLPT
-こだわる,こだわる,"to fuss over, to be particular about",JLPT_1 JLPT
-誇張,こちょう,exaggeration,JLPT_1 JLPT
-こつ (をつかむ),こつ (をつかむ),"secret, trick, hang",JLPT_1 JLPT
-滑稽,こっけい,"funny, humorous, comical",JLPT_1 JLPT
-国交,こっこう,diplomatic relations,JLPT_1 JLPT
-骨董品,こっとうひん,curio,JLPT_1 JLPT
-固定,こてい,"fixation, fixing (e.g., salary, capital)",JLPT_1 JLPT
-事柄,ことがら,"matter, thing, affair, circumstance",JLPT_1 JLPT
-孤独,こどく,"isolation, loneliness, solitude",JLPT_1 JLPT
-ことごとく,ことごとく,"altogether, entirely",JLPT_1 JLPT
-言付け,ことづけ,to leave a message,JLPT_1 JLPT
-殊に,ことに,"especially, above all",JLPT_1 JLPT
-粉々,こなごな,in very small pieces,JLPT_1 JLPT
-好ましい,このましい,"nice, likable, desirable",JLPT_1 JLPT
-碁盤,ごばん,Go board,JLPT_1 JLPT
-個別,こべつ,particular case,JLPT_1 JLPT
-ごまかす,ごまかす,"to deceive, to falsify, to misrepresent",JLPT_1 JLPT
-細やか,こまやか,"meager, modest",JLPT_1 JLPT
-コマーシャル,コマーシャル,a commercial,JLPT_1 JLPT
-込める,こめる,"to include, to put into",JLPT_1 JLPT
-コメント,コメント,comment,JLPT_1 JLPT
-籠もる,こもる,"to seclude oneself, to be confined in",JLPT_1 JLPT
-固有,こゆう,"characteristic, tradition, peculiar",JLPT_1 JLPT
-暦,こよみ,"calendar, almanac",JLPT_1 JLPT
-凝らす,こらす,"to concentrate, to devote, to peer into",JLPT_1 JLPT
-ごらんなさい (かん),ごらんなさい (かん),"look, (please) try to do",JLPT_1 JLPT
-孤立,こりつ,"isolation, helplessness",JLPT_1 JLPT
-懲りる,こりる,"to learn by experience, to be disgusted with",JLPT_1 JLPT
-凝る,こる,"to stiffen, to harden",JLPT_1 JLPT
-根気,こんき,"patience; perseverance, energy",JLPT_1 JLPT
-根拠,こんきょ,"basis, foundation",JLPT_1 JLPT
-混血,こんけつ,"mixed race, mixed parentage",JLPT_1 JLPT
-コンタクト (レンズ),コンタクト (レンズ),contact; contact lens,JLPT_1 JLPT
-昆虫,こんちゅう,"insect, bug",JLPT_1 JLPT
-根底,こんてい,"root, basis, foundation",JLPT_1 JLPT
-混同,こんどう,"confusion, mixing, merger",JLPT_1 JLPT
-コントラスト,コントラスト,contrast,JLPT_1 JLPT
-コントロール,コントロール,control,JLPT_1 JLPT
-コンパス,コンパス,compass,JLPT_1 JLPT
-根本,こんぽん,"foundation, root, base",JLPT_1 JLPT
-財,ざい,"fortune, riches",JLPT_1 JLPT
-再会,さいかい,"meeting again, reunion",JLPT_1 JLPT
-災害,さいがい,"calamity, disaster, misfortune",JLPT_1 JLPT
-細菌,さいきん,"bacillus, bacterium, germ",JLPT_1 JLPT
-細工,さいく,"work, craftsmanship, trick",JLPT_1 JLPT
-採掘,さいくつ,mining,JLPT_1 JLPT
-サイクル,サイクル,cycle,JLPT_1 JLPT
-採決,さいけつ,"vote, roll call",JLPT_1 JLPT
-再建,さいけん,(temple or shrine) rebuilding,JLPT_1 JLPT
-再現,さいげん,"reproduction, return, revival",JLPT_1 JLPT
-財源,ざいげん,"source of funds, resources, finances",JLPT_1 JLPT
-在庫,ざいこ,"stockpile, stock",JLPT_1 JLPT
-採算,さいさん,profit,JLPT_1 JLPT
-サイズ,サイズ,size,JLPT_1 JLPT
-再生,さいせい,"playback, regeneration, resuscitation",JLPT_1 JLPT
-財政,ざいせい,"economy, financial affairs",JLPT_1 JLPT
-最善,さいぜん,the very best,JLPT_1 JLPT
-採択,さいたく,"adoption, selection, choice",JLPT_1 JLPT
-栽培,さいばい,cultivation,JLPT_1 JLPT
-再発,さいはつ,"return, relapse, reoccurrence",JLPT_1 JLPT
-細胞,さいぼう,cell,JLPT_1 JLPT
-採用,さいよう,"use, adopt",JLPT_1 JLPT
-遮る,さえぎる,"to interrupt, to intercept, to obstruct",JLPT_1 JLPT
-さえずる,さえずる,"to sing, to chirp, to twitter",JLPT_1 JLPT
-冴える,さえる,"to be clear, to be bright, to be skillful",JLPT_1 JLPT
-竿,さお,"rod, pole (e.g., for drying laundry)",JLPT_1 JLPT
-栄える,さかえる,"to flourish, to prosper, to thrive",JLPT_1 JLPT
-差額,さがく,"balance, difference, margin",JLPT_1 JLPT
-杯,さかずき,wine cup,JLPT_1 JLPT
-逆立ち,さかだち,"handstand, headstand",JLPT_1 JLPT
-さきに (いぜん),さきに (いぜん),"before, earlier than, previously",JLPT_1 JLPT
-詐欺,さぎ,"fraud, swindle",JLPT_1 JLPT
-削減,さくげん,"cut, reduction",JLPT_1 JLPT
-錯誤,さくご,mistake,JLPT_1 JLPT
-作戦,さくせん,"military operations, tactics, strategy",JLPT_1 JLPT
-叫び,さけび,"shout, scream, outcry",JLPT_1 JLPT
-捧げる,ささげる,"to lift up, to give, to offer",JLPT_1 JLPT
-差し掛かる,さしかかる,"to come near to, to approach",JLPT_1 JLPT
-指図,さしず,"instruction, mandate",JLPT_1 JLPT
-差し出す,さしだす,"to present, to submit, to hold out",JLPT_1 JLPT
-差し支える,さしつかえる,"to interfere, to hinder",JLPT_1 JLPT
-授ける,さずける,"to grant, to award, to teach",JLPT_1 JLPT
-摩する,さする,"to rub, to stroke",JLPT_1 JLPT
-さぞ (さぞや。さぞかし),さぞ (さぞや。さぞかし),"I am sure, certainly, no doubt",JLPT_1 JLPT
-定まる,さだまる,"to become settled, to be fixed",JLPT_1 JLPT
-定める,さだめる,"to decide, to determine",JLPT_1 JLPT
-座談会,ざだんかい,"symposium, round-table discussion",JLPT_1 JLPT
-雑,ざつ,"rough, crude",JLPT_1 JLPT
-雑貨,ざっか,"miscellaneous goods, general goods",JLPT_1 JLPT
-殺人,さつじん,murder,JLPT_1 JLPT
-察する,さっする,"to guess, to sense, to judge",JLPT_1 JLPT
-雑談,ざつだん,"chatting, idle talk",JLPT_1 JLPT
-さっと,さっと,"suddenly, smoothly",JLPT_1 JLPT
-さっぱりする,さっぱりする,to refresh,JLPT_1 JLPT
-悟る,さとる,"to attain enlightenment, to understand",JLPT_1 JLPT
-最中,さなか,"in the middle of, midst",JLPT_1 JLPT
-座標,ざひょう,coordinates,JLPT_1 JLPT
-さほど,さほど,"not so, not that much",JLPT_1 JLPT
-サボる,サボる,to cut (skip) classes; to loaf on the job; to idle away one's time,JLPT Genki_Ln.11 Intermediate_Japanese JLPT_1 Intermediate_Japanese_Ln.13 Genki
-様,さま,state; way (a person does something); Mr. or Mrs.,JLPT_1 JLPT Intermediate_Japanese Intermediate_Japanese_Ln.11
-寒気,さむけ,"chill, shiver, cold",JLPT_1 JLPT
-侍,さむらい,samurai,JLPT_1 JLPT Intermediate_Japanese_Ln.7 Intermediate_Japanese
-さも,さも,"with gusto, with satisfaction",JLPT_1 JLPT
-作用,さよう,"operation, effect, function",JLPT_1 JLPT
-さらう (こどもを～),さらう (こどもを～),to kidnap,JLPT_1 JLPT
-障る,さわる,"to hinder, to interfere with, to affect",JLPT_1 JLPT
-酸,さん,acid,JLPT_1 JLPT
-山岳,さんがく,mountains,JLPT_1 JLPT
-参議院,さんぎいん,House of Councilors,JLPT_1 JLPT
-産休,さんきゅう,maternity leave,JLPT_1 JLPT
-サンキュー,サンキュー,thank you,JLPT_1 JLPT
-残金,ざんきん,remaining money,JLPT_1 JLPT
-産後,さんご,"postpartum, after childbirth",JLPT_1 JLPT
-残酷,ざんこく,"cruelty, harshness",JLPT_1 JLPT
-産出,さんしゅつ,"yield, produce",JLPT_1 JLPT
-参照,さんしょう,"reference, consultation, consultation",JLPT_1 JLPT
-参上,さんじょう,"calling on, visiting",JLPT_1 JLPT
-残高,ざんだか,"(bank) balance, remainder",JLPT_1 JLPT
-サンタクロース,サンタクロース,Santa Claus,JLPT_1 JLPT Intermediate_Japanese_Ln.8 Intermediate_Japanese
-桟橋,さんばし,"wharf, jetty, pier",JLPT_1 JLPT
-賛美,さんび,"praise, adoration, glorification",JLPT_1 JLPT
-山腹,さんぷく,"hillside, mountainside",JLPT_1 JLPT
-産婦人科,さんふじんか,maternity and gynecology department,JLPT_1 JLPT
-産物,さんぶつ,"product, result, fruit",JLPT_1 JLPT
-山脈,さんみゃく,mountain range,JLPT_1 JLPT
-仕上がり,しあがり,"finish, end, completion",JLPT_1 JLPT
-仕上,しあげ,"end, finishing touches",JLPT_1 JLPT
-仕上げる,しあげる,"to finish up, to complete",JLPT_1 JLPT
-飼育,しいく,"breeding, raising, rearing",JLPT_1 JLPT
-強いて,しいて,"to dare, to insist",JLPT_1 JLPT
-シート,シート,seat; sheet,JLPT_1 JLPT
-ジーパン,ジーパン,jeans,JLPT_1 JLPT
-仕入れる,しいれる,"to lay in stock, to replenish stock, to procure",JLPT_1 JLPT
-強いる,しいる,"to force, to compel, to coerce",JLPT_1 JLPT
-潮,しお,tide,JLPT_1 JLPT
-歯科,しか,dentistry,JLPT_1 JLPT
-自我,じが,"self, ego",JLPT_1 JLPT
-自覚,じかく,self-conscious,JLPT_1 JLPT
-仕掛,しかけ,"device, trick, mechanism",JLPT_1 JLPT
-仕掛ける,しかける,"to lay, to set, to wage",JLPT_1 JLPT
-しかしながら,しかしながら,"however, nevertheless",JLPT_1 JLPT
-色彩,しきさい,color,JLPT_1 JLPT
-式場,しきじょう,"ceremonial hall, place of ceremony (e.g., marriage)",JLPT_1 JLPT
-しきたり,しきたり,"custom, conventional practice, tradition",JLPT_1 JLPT
-事業,じぎょう,"project, enterprise, business",JLPT_1 JLPT
-軽蔑,けいべつ,"scorn, disdain",JLPT_1 JLPT
-経歴,けいれき,"personal history, career",JLPT_1 JLPT
-経路,けいろ,"course, route, channel",JLPT_1 JLPT
-けがらわしい,けがらわしい,"filthy, unfair",JLPT_1 JLPT
-劇団,げきだん,"troupe, theatrical company",JLPT_1 JLPT
-激励,げきれい,encouragement,JLPT_1 JLPT
-ゲスト,ゲスト,guest,JLPT_1 JLPT
-獣,けだもの,"beast, brute",JLPT_1 JLPT
-決,けつ,"decision, vote",JLPT_1 JLPT
-決意,けつい,"decision, determination",JLPT_1 JLPT
-結核,けっかく,tuberculosis,JLPT_1 JLPT
-決議,けつぎ,"resolution, vote, decision",JLPT_1 JLPT
-結合,けつごう,"combination, union",JLPT_1 JLPT
-決算,けっさん,"balance sheet, settlement of accounts",JLPT_1 JLPT
-月謝,げっしゃ,monthly tuition fee,JLPT_1 JLPT
-決勝,けっしょう,finals (in sports),JLPT_1 JLPT
-結晶,けっしょう,"crystal, crystallization",JLPT_1 JLPT
-結成,けっせい,formation,JLPT_1 JLPT
-結束,けっそく,"union, unity",JLPT_1 JLPT
-げっそり,げっそり,"being disheartened, losing weight",JLPT_1 JLPT
-決断,けつだん,"decision, determination",JLPT_1 JLPT
-月賦,げっぷ,monthly installment,JLPT_1 JLPT
-欠乏,けつぼう,shortage,JLPT_1 JLPT
-蹴飛ばす,けとばす,"to kick away, to kick (someone)",JLPT_1 JLPT
-けなす,けなす,to speak ill of,JLPT_1 JLPT
-煙たい,けむたい,"smoky, feeling awkward",JLPT_1 JLPT
-煙る,けむる,"to smoke (e.g., fire)",JLPT_1 JLPT
-獣,けもの,"beast, brute",JLPT_1 JLPT
-家来,けらい,"retainer, retinue, servant",JLPT_1 JLPT
-下痢,げり,diarrhea,JLPT_1 JLPT Intermediate_Japanese_Ln.12 Intermediate_Japanese
-権威,けんい,"authority, power, influence",JLPT_1 JLPT
-兼業,けんぎょう,holding two jobs at the same time,JLPT_1 Intermediate_Japanese_Ln.14 JLPT Intermediate_Japanese
-原形,げんけい,"original form, base form",JLPT_1 JLPT
-原型,げんけい,"prototype, model, archetypal",JLPT_1 JLPT
-権限,けんげん,"power, authority, jurisdiction",JLPT_1 JLPT
-現行,げんこう,"present, current, in operation",JLPT_1 JLPT
-健在,けんざい,"in good health, well",JLPT_1 JLPT
-原作,げんさく,original work,JLPT_1 JLPT
-検事,けんじ,public prosecutor,JLPT_1 JLPT
-原子,げんし,atom,JLPT_1 JLPT
-元首,げんしゅ,"ruler, sovereign",JLPT_1 JLPT
-原書,げんしょ,original document,JLPT_1 JLPT
-懸賞,けんしょう,"offering prizes, winning, reward",JLPT_1 JLPT
-健全,けんぜん,"health, soundness, wholesome",JLPT_1 JLPT
-元素,げんそ,element,JLPT_1 JLPT
-同調,どうちょう,"sympathy, agree with, alignment",JLPT_1 JLPT
-到底,とうてい,(cannot) possibly,JLPT_1 JLPT
-動的,どうてき,"dynamic, kinetic",JLPT_1 JLPT
-尊い,とうとい,"precious, valuable, noble",JLPT_1 JLPT
-貴い,とうとい,"precious, valuable, noble",JLPT_1 JLPT
-同等,どうとう,"equality, equal, same rank",JLPT_1 JLPT
-堂々,どうどう,"magnificent, grand, impressive",JLPT_1 JLPT
-尊ぶ,とうとぶ,"to value, to prize, to esteem",JLPT_1 JLPT
-どうにか,どうにか,"in some way or other, one way or another",JLPT_1 JLPT
-投入,とうにゅう,"throw, investment, making (an electrical circuit)",JLPT_1 JLPT
-導入,どうにゅう,"introduction, bringing in, leading in",JLPT_1 JLPT Intermediate_Japanese_Ln.12 Intermediate_Japanese
-当人,とうにん,"the one concerned, the said person",JLPT_1 JLPT
-同封,どうふう,"enclosure (e.g., in a letter)",JLPT_1 JLPT
-逃亡,とうぼう,escape,JLPT_1 JLPT
-冬眠,とうみん,"hibernation, winter sleep",JLPT_1 JLPT
-同盟,どうめい,"alliance, union, league",JLPT_1 JLPT
-どうやら,どうやら,"it seems like, somehow or other",JLPT_1 JLPT
-動力,どうりょく,"power, motive power, dynamic force",JLPT_1 JLPT
-登録,とうろく,"registration, register, record",JLPT_1 JLPT
-討論,とうろん,discussion; debate,JLPT_1 JLPT Intermediate_Japanese_Ln.15 Intermediate_Japanese
-遠ざかる,とおざかる,to go far off,JLPT_1 JLPT
-遠回り,とおまわり,"detour, roundabout way",JLPT_1 JLPT
-トーン,トーン,tone,JLPT_1 JLPT
-とかく,とかく,"anyhow, anyway, in any case",JLPT_1 JLPT
-とがめる,とがめる,"to blame, to rebuke",JLPT_1 JLPT
-時折,ときおり,sometimes,JLPT_1 JLPT
-とぎれる,とぎれる,"to pause, to be interrupted",JLPT_1 JLPT
-研ぐ,とぐ,"to sharpen, to grind, to polish",JLPT_1 JLPT
-特技,とくぎ,special talent; skill,JLPT_1 JLPT Intermediate_Japanese_Ln.8 Intermediate_Japanese
-独裁,どくさい,"dictatorship, despotism",JLPT_1 JLPT
-特産,とくさん,"specialty, special product",JLPT_1 JLPT
-独自,どくじ,"original, peculiar, characteristic",JLPT_1 JLPT
-特集,とくしゅう,"feature (e.g., newspaper, special edition, report)",JLPT_1 JLPT
-独占,どくせん,monopoly,JLPT_1 JLPT
-独創,どくそう,originality,JLPT_1 JLPT
-得点,とくてん,"score, points made",JLPT_1 JLPT
-特派,とくは,"send specially, special envoy",JLPT_1 JLPT
-特有,とくゆう,"characteristic (of, peculiar (to))",JLPT_1 JLPT
-とげ (をさす),とげ (をさす),thorn,JLPT_1 JLPT
-遂げる,とげる,"to accomplish, to achieve, to carry out",JLPT_1 JLPT
-～どころか,～どころか,"rather, far from",JLPT_1 JLPT
-年頃,としごろ,"age, marriageable age, adolescence",JLPT_1 JLPT
-戸締り,とじまり,"closing up, locking the doors",JLPT_1 JLPT
-途上,とじょう,"en/in route, half way",JLPT_1 JLPT
-土台,どだい,"foundation, base, basis",JLPT_1 JLPT
-途絶える,とだえる,"to stop, to cease, to come to an end",JLPT_1 JLPT
-特許,とっきょ,"special permission, patent",JLPT_1 JLPT
-特権,とっけん,"privilege, special right",JLPT_1 JLPT
-とっさに,とっさに,at once,JLPT_1 JLPT
-突如,とつじょ,"suddenly, all of a sudden",JLPT_1 JLPT
-とって,とって,"handle, grip, knob",JLPT_1 JLPT
-突破,とっぱ,"breaking through, breakthrough, penetration",JLPT_1 JLPT
-土手,どて,"embankment, bank",JLPT_1 JLPT
-届,とどけ,"report, notification, registration",JLPT_1 JLPT
-滞る,とどこおる,"to stagnate, to be delayed",JLPT_1 JLPT
-整える,ととのえる,"to put in order, to arrange, to adjust; to get ready, to prepare; to raise money",JLPT_1 JLPT
-止める,とどめる,"to end, to stop, to cease, to resign",JLPT_1 JLPT
-唱える,となえる,"to recite, to chant, to call upon",JLPT_1 JLPT
-殿様,とのさま,feudal lord,JLPT_1 JLPT
-土俵,どひょう,arena,JLPT_1 JLPT
-扉,とびら,"door, opening",JLPT_1 JLPT
-溝,どぶ,"ditch, drain, gap",JLPT_1 JLPT
-徒歩,とほ,"walking, going on foot",JLPT_1 JLPT
-土木,どぼく,public works,JLPT_1 JLPT
-とぼける,とぼける,"to play dumb, to feign ignorance, to play innocent, to have a blank facial expression; to play the fool; to be in one's dotage",JLPT_1 JLPT
-乏しい,とぼしい,"meager, scarce, hard up, poor",JLPT_1 JLPT
-富,とみ,"wealth, fortune",JLPT_1 JLPT
-富む,とむ,"to be rich, to become rich",JLPT_1 JLPT
-共稼ぎ,ともかせぎ,"working together, (husband and wife) earning a living together",JLPT_1 JLPT
-伴う,ともなう,"to accompany, to bring with",JLPT_1 JLPT
-共働き,ともばたらき,dual income (husband and wife both working),JLPT_1 Intermediate_Japanese_Ln.14 JLPT Intermediate_Japanese
-ドライ,ドライ,dry,JLPT_1 JLPT
-ドライクリーニング,ドライクリーニング,dry cleaning,JLPT_1 JLPT
-ドライバー,ドライバー,"driver, screwdriver",JLPT_1 JLPT
-ドライブイン,ドライブイン,drive in,JLPT_1 JLPT
-トラブル,トラブル,trouble (sometimes used as a verb),JLPT_1 JLPT
-トランジスター,トランジスター,transistor,JLPT_1 JLPT
-とりあえず,とりあえず,"at once, first of all, for the time being",JLPT_1 JLPT
-取扱,とりあつかい,"treatment, handling, management",JLPT_1 JLPT
-取り扱う,とりあつかう,"to treat, to handle, to deal in",JLPT_1 JLPT
-鳥居,とりい,Shinto shrine archway,JLPT_1 JLPT
-取り替え,とりかえ,"swap, exchange",JLPT_1 JLPT
-取り組む,とりくむ,"to tackle, to engage in a bout, to come to grips with",JLPT_1 JLPT
-取締り,とりしまり,"control, crackdown, supervision",JLPT_1 JLPT
-取り締まる,とりしまる,"to crack down, to control, to supervise",JLPT_1 JLPT
-取り調べる,とりしらべる,"to investigate, to examine",JLPT_1 JLPT
-取り立てる,とりたてる,"to collect, to extort",JLPT_1 JLPT
-取り次ぐ,とりつぐ,"to act as an agent for, to announce (someone), to convey (a message)",JLPT_1 JLPT
-取り付ける,とりつける,"to furnish, to install; to get someone's agreement",JLPT_1 JLPT
-取り除く,とりのぞく,"to remove, to take away, to set apart",JLPT_1 JLPT
-取引,とりひき,"transactions, dealings, business",JLPT_1 JLPT
-取り巻く,とりまく,"to surround, to circle, to enclose",JLPT_1 JLPT
-取り混ぜる,とりまぜる,"to mix, to put together",JLPT_1 JLPT
-取り戻す,とりもどす,"to take back, to regain",JLPT_1 JLPT
-取り寄せる,とりよせる,"to order, to send away for",JLPT_1 JLPT
-ドリル,ドリル,drill,JLPT_1 JLPT
-副,とりわけ,"especially, above all",JLPT_1 JLPT
-とろける,とろける,melt; to be enchanted with,JLPT_1 JLPT
-鈍感,どんかん,"thickheadedness, stolidity",JLPT_1 JLPT
-とんだ,とんだ,"terrible, awful, serious, absolutely not",JLPT_1 JLPT
-度忘れ,どわすれ,"lapse of memory, forget for a moment",JLPT_1 JLPT
-問屋,とんや,wholesale store,JLPT_1 JLPT
-内閣,ないかく,"cabinet, (government)",JLPT_1 JLPT
-乃至,ないし,"from...to, between...and, or",JLPT_1 JLPT
-内緒,ないしょ,"secrecy, privacy, secret",JLPT_1 JLPT
-内心,ないしん,"innermost thoughts, real intention, inmost heart",JLPT_1 JLPT
-内蔵,ないぞう,internal organ; built-in,JLPT_1 JLPT
-ナイター,ナイター,"game under lights (e.g., baseball), night game",JLPT_1 JLPT
-内部,ないぶ,"interior, inside, internal",JLPT_1 JLPT
-内乱,ないらん,"civil war, domestic conflict",JLPT_1 JLPT
-内陸,ないりく,inland,JLPT_1 JLPT
-苗,なえ,rice seedling,JLPT_1 JLPT
-なおさら,なおさら,"all the more, still less",JLPT_1 JLPT
-流し,ながし,sink,JLPT_1 JLPT
-長々,ながなが,"long, drawn-out, very long",JLPT_1 JLPT
-中程,なかほど,"middle, midway",JLPT_1 JLPT
-渚,なぎさ,"water's edge, beach, shore",JLPT_1 JLPT
-嘆く,なげく,"to sigh, to lament, to grieve",JLPT_1 JLPT
-投げ出す,なげだす,"to abandon, to throw out",JLPT_1 JLPT
-仲人,なこうど,"go-between, matchmaker",JLPT_1 JLPT
-和やか,なごやか,"mild, calm, harmonious",JLPT_1 JLPT
-名残,なごり,"remains, traces, memory",JLPT_1 JLPT
-情け,なさけ,"sympathy, compassion",JLPT_1 JLPT
-情無い,なさけない,"miserable, pitiable, shameful",JLPT_1 JLPT
-情深い,なさけぶかい,"tender-hearted, compassionate",JLPT_1 JLPT
-詰る,なじる,"to rebuke, to scold, to tell off",JLPT_1 JLPT
-名高い,なだかい,"famous, celebrated, well-known",JLPT_1 JLPT
-雪崩,なだれ,avalanche,JLPT_1 JLPT
-懐く,なつく,to become emotionally attached,JLPT_1 JLPT
-名付ける,なづける,to name,JLPT_1 JLPT
-何気ない,なにげない,"casual, unconcerned",JLPT_1 JLPT
-なにとぞ,なにとぞ,"please, kindly, by all means",JLPT_1 JLPT
-なにより,なにより,"most, best",JLPT_1 JLPT
-ナプキン,ナプキン,napkin,JLPT_1 JLPT
-名札,なふだ,"name plate, name tag",JLPT_1 JLPT
-生臭い,なまぐさい,"smelling of fish or blood, fish or meat",JLPT_1 JLPT
-生温い,なまぬるい,"lukewarm, halfhearted",JLPT_1 JLPT
-生身,なまみ,"living flesh, flesh and blood, the quick",JLPT_1 JLPT
-鉛,なまり,lead (the metal),JLPT_1 JLPT
-滑らか,なめらか,"smoothness, glassiness",JLPT_1 JLPT
-嘗める,なめる,to lick; to experience; to make fun of,JLPT_1 JLPT
-悩ましい,なやましい,"seductive, melancholy, languid",JLPT_1 JLPT
-悩ます,なやます,"to bother, to harass, to molest",JLPT_1 JLPT
-悩み,なやみ,"trouble(s), worry, distress",JLPT_1 JLPT Genki_Ln.19 Genki
-並びに,ならびに,and,JLPT_1 JLPT
-成り立つ,なりたつ,"to consist of; to be practical (logical, feasible, viable), to be concluded, to hold true",JLPT_1 JLPT
-なるたけ,なるたけ,"as much as possible, if possible",JLPT_1 JLPT
-慣れ,なれ,"practice, experience",JLPT_1 JLPT
-馴々しい,なれなれしい,"familiar, make free with",JLPT_1 JLPT
-～なんか,～なんか,in the least ~,JLPT_1 JLPT
-ナンセンス,ナンセンス,nonsense,JLPT_1 JLPT
-何だか,なんだか,"a little, somewhat, somehow",JLPT_1 JLPT Intermediate_Japanese Intermediate_Japanese_Ln.11
-なんだかんだ,なんだかんだ,something or other,JLPT_1 JLPT
-なんなり,なんなり,"anything, whatever",JLPT_1 JLPT
-荷,に,"load, baggage, cargo",JLPT_1 JLPT
-似通う,にかよう,to resemble closely,JLPT_1 JLPT
-にきび,にきび,"pimple, acne",JLPT_1 JLPT
-賑わう,にぎわう,"to prosper, to flourish, to be crowded with people",JLPT_1 JLPT
-憎しみ,にくしみ,hatred,JLPT_1 JLPT
-肉親,にくしん,"blood relationship, blood relative",JLPT_1 JLPT
-肉体,にくたい,"the body, the flesh",JLPT_1 JLPT
-逃げ出す,にげだす,"to run away, to escape from",JLPT_1 JLPT
-西日,にしび,westering sun,JLPT_1 JLPT
-滲む,にじむ,"to run, to blur, to spread",JLPT_1 JLPT
-にせ物,にせもの,"imitation, counterfeit",JLPT_1 JLPT
-日夜,にちや,"day and night, always",JLPT_1 JLPT
-荷造り,にづくり,"packing, baling, crating",JLPT_1 JLPT
-担う,になう,"to carry on shoulder, to bear (burden), to shoulder (gun)",JLPT_1 JLPT
-鈍る,にぶる,"to become less capable, to grow dull, to become blunt, to weaken",JLPT_1 JLPT
-にも関わらず,にもかかわらず,"in spite of, nevertheless",JLPT_1 JLPT
-ニュアンス,ニュアンス,nuance,JLPT_1 JLPT
-ニュー,ニュー,new,JLPT_1 JLPT
-入手,にゅうしゅ,"obtaining, coming to hand",JLPT_1 JLPT
-入賞,にゅうしょう,winning a prize or place (in a contest,JLPT_1 JLPT
-入浴,にゅうよく,"bathe, bathing",JLPT_1 JLPT
-尿,にょう,urine,JLPT_1 JLPT
-認識,にんしき,"recognition, cognizance",JLPT_1 JLPT
-妊娠,にんしん,"conception, pregnancy",JLPT_1 JLPT
-任務,にんむ,"duty, mission, task",JLPT_1 JLPT
-任命,にんめい,"appointment, nomination, ordination",JLPT_1 JLPT
-抜かす,ぬかす,"to omit, to leave out",JLPT_1 JLPT
-抜け出す,ぬけだす,"to slip out, to sneak away, to excel",JLPT_1 JLPT
-主,ぬし,"owner, master, god",JLPT_1 JLPT Intermediate_Japanese_Ln.13 Intermediate_Japanese
-沼,ぬま,"swamp, bog, pond",JLPT_1 JLPT
-音色,ねいろ,"tone color, timbre",JLPT_1 JLPT
-値打ち,ねうち,"value, worth, price",JLPT_1 JLPT
-ネガ,ネガ,(photographic) negative,JLPT_1 JLPT
-寝かせる,ねかせる,"to put to bed, to lay down, to ferment",JLPT_1 JLPT
-ねじまわし,ねじまわし,screwdriver,JLPT_1 JLPT
-捩れる,ねじれる,"twist, strain",JLPT_1 JLPT
-妬む,ねたむ,"to be jealous, to be envious",JLPT_1 JLPT
-ねだる,ねだる,"to nag, to demand",JLPT_1 JLPT
-熱意,ねつい,"zeal, enthusiasm",JLPT_1 JLPT
-熱湯,ねっとう,boiling water,JLPT_1 JLPT
-熱量,ねつりょう,calorific value,JLPT_1 JLPT
-粘り,ねばり,"stickiness, viscosity",JLPT_1 JLPT
-粘る,ねばる,"to be sticky, to be adhesive, to persist, to stick to",JLPT_1 JLPT
-値引き,ねびき,"price reduction, discount",JLPT_1 JLPT
-根回し,ねまわし,making necessary arrangements,JLPT_1 JLPT
-眠たい,ねむたい,sleepy,JLPT_1 JLPT
-練る,ねる,"to knead, to work over, to polish up",JLPT_1 JLPT
-念,ねん,"sense, feeling, desire",JLPT_1 JLPT
-年賀,ねんが,"New Year's greetings, New Year's card",JLPT_1 JLPT
-念願,ねんがん,"one's heart's desire, earnest petition",JLPT_1 JLPT
-年号,ねんごう,"name of an era, year number",JLPT_1 JLPT
-燃焼,ねんしょう,"burning, combustion",JLPT_1 JLPT
-年長,ねんちょう,seniority,JLPT_1 JLPT
-燃料,ねんりょう,fuel,JLPT_1 JLPT
-年輪,ねんりん,annual tree ring,JLPT_1 JLPT
-ノイローゼ,ノイローゼ,neurosis (GER: Neurose),JLPT_1 JLPT
-農耕,のうこう,"farming, agriculture",JLPT_1 JLPT
-農場,のうじょう,farm,JLPT_1 JLPT
-農地,のうち,agricultural land,JLPT_1 JLPT
-納入,のうにゅう,"payment, supply",JLPT_1 JLPT
-逃す,のがす,"to let loose, to set free, to let escape",JLPT_1 JLPT
-逃れる,のがれる,to escape,JLPT_1 JLPT
-軒並,のきなみ,row of houses; uniformly,JLPT_1 JLPT
-望ましい,のぞましい,"desirable, hoped for",JLPT_1 JLPT
-乗っ取る,のっとる,"to capture, to occupy, to take over",JLPT_1 JLPT
-のどか,のどか,"tranquil, calm, quiet",JLPT_1 JLPT
-罵る,ののしる,"to speak ill of, to abuse",JLPT_1 JLPT
-延べ,のべ,"futures, credit (buying), stretching, total",JLPT_1 JLPT
-飲み込む,のみこむ,"to gulp down, to swallow deeply, to understand",JLPT_1 JLPT Intermediate_Japanese_Ln.12 Intermediate_Japanese
-乗り込む,のりこむ,"to board, to get into (a car); to march into, to enter",JLPT_1 JLPT
-刃,は,"blade, sword",JLPT_1 JLPT
-～派,～は,"group, party, section (mil)",JLPT_1 JLPT
-バー,バー,bar,JLPT_1 JLPT
-把握,はあく,"grasp, catch, understanding",JLPT_1 JLPT
-パート,パート,part-time job,JLPT_1 JLPT Intermediate_Japanese_Ln.8 Intermediate_Japanese
-廃棄,はいき,"disposal, abandon, discarding",JLPT_1 JLPT
-配給,はいきゅう,"distribution (e.g., films, rice",JLPT_1 JLPT
-ばい菌,ばいきん,"bacteria, germ(s)",JLPT_1 JLPT
-配偶者,はいぐうしゃ,spouse,JLPT_1 JLPT
-拝啓,はいけい,-- a formal greeting used at the beginning of a letter --,Intermediate_Japanese_Ln.4 JLPT_1 JLPT Intermediate_Japanese
-背景,はいけい,"background, scenery, setting",JLPT_1 JLPT
-背後,はいご,"back, rear",JLPT_1 JLPT
-廃止,はいし,"abolition, repeal",JLPT_1 JLPT
-拝借,はいしゃく,(humble) (polite) borrowing,JLPT_1 JLPT
-排除,はいじょ,"exclusion, removal, rejection",JLPT_1 JLPT
-賠償,ばいしょう,"reparations, indemnity, compensation",JLPT_1 JLPT
-排水,はいすい,drainage,JLPT_1 JLPT
-敗戦,はいせん,"defeat, losing a war",JLPT_1 JLPT
-配置,はいち,"arrangement (of resources), disposition",JLPT_1 JLPT
-配布,はいふ,distribution,JLPT_1 JLPT
-配分,はいぶん,"distribution, allotment",JLPT_1 JLPT
-敗北,はいぼく,defeat (as a verb it means 'to be defeated'),JLPT_1 JLPT
-倍率,ばいりつ,"diameter, magnification",JLPT_1 JLPT
-配慮,はいりょ,"consideration, concern, forethought",JLPT_1 JLPT
-配列,はいれつ,"arrangement, array (programming)",JLPT_1 JLPT
-破壊,はかい,destruction,JLPT_1 JLPT
-いたわる,いたわる,"to sympathize with, to console, to care for",JLPT_1 JLPT
-一概に,いちがいに,"unconditionally, necessarily",JLPT_1 JLPT
-著しい,いちじるしい,"remarkable, considerable",JLPT_1 JLPT
-一同,いちどう,"all present, all concerned, all of us",JLPT_1 JLPT
-一部分,いちぶぶん,"a part, a portion",JLPT_1 JLPT
-一別,いちべつ,parting,JLPT_1 JLPT
-一面,いちめん,"one side, the other hand",JLPT_1 JLPT
-一目,いちもく,"a glance, a look, a glimpse",JLPT_1 JLPT
-一様,いちよう,"uniform, similar, equal",JLPT_1 JLPT
-一律,いちりつ,"even, uniform, equal",JLPT_1 JLPT
-一連,いちれん,"a series, a chain, a ream (of paper)",JLPT_1 JLPT
-一括,いっかつ,"all together, batch",JLPT_1 JLPT
-一気,いっき,"at one push, in one gulp",JLPT_1 JLPT
-一挙に,いっきょに,"at a stroke, with a single swoop",JLPT_1 JLPT
-一見,いっけん,"a look, a glimpse, glance; first meeting",JLPT_1 JLPT
-一切,いっさい,"without exception, the whole",JLPT_1 JLPT
-一心,いっしん,"one mind, with rapt attention",JLPT_1 JLPT
-いっそ,いっそ,"rather, sooner, might as well",JLPT_1 JLPT
-一変,いっぺん,complete change,JLPT_1 JLPT
-意図,いと,"intention, aim, design",JLPT_1 JLPT
-営む,いとなむ,"to carry on (e.g., in ceremony), to run a business",JLPT_1 JLPT
-挑む,いどむ,to challenge,JLPT_1 JLPT
-稲光,いなびかり,(flash of) lightning,JLPT_1 JLPT
-祈り,いのり,"prayer, supplication",JLPT_1 JLPT
-いびき,いびき,snoring,JLPT_1 JLPT
-今更,いまさら,"now, again",JLPT_1 JLPT
-未だ,いまだ,"yet, still",JLPT_1 JLPT
-移民,いみん,"emigrant, immigrant",JLPT_1 JLPT
-嫌々,いやいや,"reluctantly, by no means, unwillingly",JLPT_1 JLPT
-卑しい,いやしい,"greedy, vulgar, shabby",JLPT_1 JLPT
-いやに,いやに,"awfully, terribly",JLPT_1 JLPT
-いやらしい,いやらしい,"unpleasant, disgusting, indecent",JLPT_1 JLPT
-意欲,いよく,"will, desire, ambition",JLPT_1 JLPT
-威力,いりょく,"power, might, authority",JLPT_1 JLPT
-衣類,いるい,"clothes, clothing, garments",JLPT_1 JLPT
-異論,いろん,"different opinion, objection",JLPT_1 JLPT
-印鑑,いんかん,"stamp, seal",JLPT_1 JLPT
-陰気,いんき,"gloom, melancholy",JLPT_1 JLPT
-隠居,いんきょ,retirement; retired person,JLPT_1 JLPT
-インターチェンジ,インターチェンジ,interchange,JLPT_1 JLPT
-インターナショナル,インターナショナル,international,JLPT_1 JLPT
-インターフォン,インターフォン,"entry phone, intercom",JLPT_1 JLPT
-インテリ,インテリ,"(abbr.) egghead, intelligentsia",JLPT_1 JLPT
-インフォメーション,インフォメーション,information,JLPT_1 JLPT
-インフレ,インフレ,(abbr.) inflation,JLPT_1 JLPT
-受かる,うかる,to pass (examination),JLPT_1 JLPT
-受け入れ,うけいれ,"receiving, acceptance",JLPT_1 JLPT
-受け入れる,うけいれる,"to accept, to receive",JLPT_1 JLPT
-受け継ぐ,うけつぐ,"to inherit, to succeed",JLPT_1 JLPT
-受け付ける,うけつける,"to be accepted, to receive (an application)",JLPT_1 JLPT
-受け止める,うけとめる,"to catch, to react to, to take",JLPT_1 JLPT
-受身,うけみ,"passive, passive voice",JLPT_1 JLPT
-受持ち,うけもち,"charge (of something), matter in one's charge",JLPT_1 JLPT
-動き,うごき,"movement, activity, trend",JLPT_1 JLPT
-埋める,うずめる,"to bury, to fill",JLPT_1 JLPT
-嘘つき,うそつき,liar,JLPT_1 JLPT
-うたた寝,うたたね,"dozing, napping",JLPT_1 JLPT
-打ち明ける,うちあける,"to confess, to be open",JLPT_1 JLPT
-打ち切る,うちきる,"to stop, to abort, to discontinue, to close",JLPT_1 JLPT
-打ち消し,うちけし,"(gram) negation, denial, negative",JLPT_1 JLPT
-打ち込む,うちこむ,"to devote oneself to, to shoot into",JLPT_1 JLPT
-団扇,うちわ,fan,JLPT_1 JLPT
-内訳,うちわけ,"the items, breakdown, classification",JLPT_1 JLPT
-写し,うつし,"copy, duplicate",JLPT_1 JLPT
-訴え,うったえ,"lawsuit, complaint",JLPT_1 JLPT
-うっとうしい,うっとうしい,"weary, annoying",JLPT_1 JLPT
-うつむく,うつむく,"to look downward, to stoop",JLPT_1 JLPT
-空ろ,うつろ,"blank, hollow, empty",JLPT_1 JLPT
-器,うつわ,"bowl, vessel, container",JLPT_1 JLPT
-腕前,うでまえ,"ability, skill, facility",JLPT_1 JLPT
-雨天,うてん,rainy weather,JLPT_1 JLPT
-促す,うながす,"to urge, to suggest, to demand",JLPT_1 JLPT
-うぬぼれ,うぬぼれ,"pretension, conceit, hubris",JLPT_1 JLPT
-生まれつき,うまれつき,"by nature, by birth, native",JLPT_1 JLPT
-埋め込む,うめこむ,"to embed, implant",JLPT_1 JLPT
-梅干し,うめぼし,dried plum,JLPT_1 JLPT
-裏返し,うらがえし,"inside out, reverse",JLPT_1 JLPT
-売り出し,うりだし,(bargain) sale,JLPT_1 JLPT
-売り出す,うりだす,"to put on sale, to market",JLPT_1 JLPT
-潤う,うるおう,to be moist; to profit by,JLPT_1 JLPT
-浮気,うわき,"affair, to cheat",JLPT_1 JLPT
-上回る,うわまわる,to exceed,JLPT_1 JLPT
-植わる,うわる,to be planted,JLPT_1 JLPT
-運営,うんえい,"management, administration, operation",JLPT_1 JLPT
-うんざり,うんざり,"tedious, boring, being fed up with",JLPT_1 JLPT
-運送,うんそう,"shipping, freight",JLPT_1 JLPT
-運賃,うんちん,"freight rates, shipping expenses, (passenger) fare",JLPT_1 JLPT Intermediate_Japanese_Ln.10 Intermediate_Japanese
-云々,うんぬん,"and so on, and so forth",JLPT_1 JLPT
-運搬,うんぱん,"transport, carriage",JLPT_1 JLPT
-運命,うんめい,fate,JLPT_1 JLPT
-運輸,うんゆ,transportation,JLPT_1 JLPT
-運用,うんよう,"making use of, application, practical use",JLPT_1 JLPT
-エアメール,エアメール,air mail,JLPT_1 JLPT
-～営,～えい,~ run,JLPT_1 JLPT
-英字,えいじ,English letter (character),JLPT_1 JLPT
-映写,えいしゃ,projection,JLPT_1 JLPT
-映像,えいぞう,"reflection, image",JLPT_1 JLPT
-英雄,えいゆう,"hero, great man",JLPT_1 JLPT
-液,えき,"liquid, fluid",JLPT_1 JLPT
-閲覧,えつらん,"inspection, reference, browse",JLPT_1 JLPT
-獲物,えもの,"game, spoils, trophy",JLPT_1 JLPT
-襟,えり,"neck, collar",JLPT_1 JLPT
-エレガント,エレガント,elegant,JLPT_1 JLPT
-円滑,えんかつ,"harmony, smoothness",JLPT_1 JLPT
-縁側,えんがわ,"veranda, porch, balcony, open corridor",JLPT_1 JLPT
-沿岸,えんがん,"coast, shore",JLPT_1 JLPT
-婉曲,えんきょく,"euphemistic, indirect, insinuating",JLPT_1 JLPT
-演出,えんしゅつ,"production (erg. play, direction)",JLPT_1 JLPT
-エンジニア,エンジニア,engineer,JLPT_1 JLPT
-演じる,えんじる,"to perform, to play (a part), to act",JLPT_1 JLPT
-演ずる,えんずる,"to perform, to play (a part), to act",JLPT_1 JLPT
-沿線,えんせん,along railway line,JLPT_1 JLPT
-縁談,えんだん,marriage proposal,JLPT_1 JLPT
-遠方,えんぽう,"long way, distant place",JLPT_1 JLPT
-円満,えんまん,"harmony, peace, smoothness",JLPT_1 JLPT
-追い込む,おいこむ,"to herd, to corner, to drive",JLPT_1 JLPT
-追い出す,おいだす,"to expel, to drive out",JLPT_1 JLPT
-於いて,おいて,"at, in, on",JLPT_1 JLPT
-老いる,おいる,"to age, to grow old",JLPT_1 JLPT
-応急,おうきゅう,emergency,JLPT_1 JLPT
-黄金,おうごん,gold,JLPT_1 JLPT
-往診,おうしん,"doctor's visit, house call",JLPT_1 JLPT
-応募,おうぼ,"subscription, application",JLPT_1 JLPT
-おおい (かん),おおい (かん),hey,JLPT_1 JLPT
-大方,おおかた,"almost all, majority",JLPT_1 JLPT
-大柄,おおがら,"large build, large pattern",JLPT_1 JLPT
-おおげさ,おおげさ,"grandiose, exaggerated",JLPT_1 JLPT
-大筋,おおすじ,"outline, summary",JLPT_1 JLPT
-大空,おおぞら,"heaven, the sky",JLPT_1 JLPT
-オートマチック,オートマチック,automatic,JLPT_1 JLPT
-大幅,おおはば,"full width, large scale, drastic",JLPT JLPT_1 MediaMissing
-おおまかな,おおまかな,"rough, approximate",JLPT_1 JLPT
-大水,おおみず,flood,JLPT_1 JLPT
-公,おおやけ,public,JLPT_1 JLPT
-犯す,おかす,"to perpetrate, to violate",JLPT_1 JLPT
-侵す,おかす,"to invade, to raid, to trespass",JLPT_1 JLPT
-臆病,おくびょう,"cowardice, timidity",JLPT_1 JLPT
-遅らす,おくらす,"to retard, to delay",JLPT_1 JLPT
-厳か,おごそか,"majestic, dignified",JLPT_1 JLPT
-行い,おこない,"conduct, behavior, action",JLPT_1 JLPT
-おごる (ゆうしょくを～),おごる (ゆうしょくを～),to give (someone) a treat,JLPT_1 JLPT
-収まる,おさまる,to settle into; to be obtained,JLPT_1 JLPT
-納まる,おさまる,to settle into; to be obtained,JLPT_1 JLPT
-治まる,おさまる,"to be at peace, to calm down",JLPT_1 JLPT
-お産,おさん,(giving) birth,JLPT_1 JLPT
-押し切る,おしきる,to have one's own way,JLPT_1 JLPT
-押し込む,おしこむ,"to push into, to crowd into",JLPT_1 JLPT
-惜しむ,おしむ,"to be frugal, to value, to regret",JLPT_1 JLPT
-押し寄せる,おしよせる,"to push aside, to advance on",JLPT_1 JLPT
-雄,おす,male (animal),JLPT_1 JLPT
-御世辞,おせじ,"flattery, compliment",JLPT_1 JLPT
-襲う,おそう,to attack,JLPT_1 JLPT
-遅くとも,おそくとも,at the latest,JLPT_1 JLPT
-恐れ,おそれ,"fear, horror",JLPT_1 JLPT
-恐れ入る,おそれいる,"to be filled with awe, to feel small",JLPT_1 JLPT
-おだてる,おだてる,to flatter,JLPT_1 JLPT
-落ち込む,おちこむ,to get depressed,JLPT_1 Genki_Ln.16 JLPT Genki
-落ち着き,おちつき,"calm, composure",JLPT_1 JLPT
-落葉,おちば,fallen leaves,JLPT_1 JLPT
-乙,おつ,2nd in rank,JLPT_1 JLPT
-お使い,おつかい,errand,JLPT_1 JLPT
-おっかない,おっかない,"frightening, scary",JLPT_1 JLPT
-お手上げ,おてあげ,"given in, given up hope",JLPT_1 JLPT
-おどおど,おどおど,"coweringly, hesitantly",JLPT_1 JLPT
-脅す,おどす,"to threaten, to menace",JLPT_1 JLPT
-訪れる,おとずれる,to visit,JLPT_1 JLPT
-お供,おとも,"attendant, companion",JLPT_1 JLPT
-衰える,おとろえる,"to become weak, to decline",JLPT_1 JLPT
-同い年,おないどし,of the same age,JLPT_1 JLPT
-自ずから,おのずから,"naturally, as a matter of course",JLPT_1 JLPT
-怯える,おびえる,to become frightened,JLPT_1 JLPT
-おびただしい,おびただしい,"abundantly, innumerably",JLPT_1 JLPT
-脅かす,おびやかす,"to threaten, to coerce",JLPT_1 JLPT
-帯びる,おびる,"to bear, to carry, to be entrusted",JLPT_1 JLPT
-お袋,おふくろ,mother,JLPT_1 JLPT
-覚え,おぼえ,"memory, sense, experience",JLPT_1 JLPT
-おまけ,おまけ,a discount; something additional,JLPT_1 JLPT
-お宮,おみや,Shinto shrine,JLPT_1 JLPT
-おむつ,おむつ,"diaper, nappy",JLPT_1 JLPT
-思い付き,おもいつき,"plan, idea, suggestion",JLPT_1 JLPT
-趣,おもむき,"flavor, appearance, quaint",JLPT_1 JLPT
-赴く,おもむく,"to go, to proceed",JLPT_1 JLPT
-重んじる,おもんじる,"to respect, to honor, to esteem, to prize",JLPT_1 JLPT
-重んずる,おもんずる,"to honor, to respect, to value",JLPT_1 JLPT
-親父,おやじ,"one's father, old man, one's boss",JLPT_1 JLPT
-及び,および,"and, as well as",JLPT_1 JLPT
-及ぶ,およぶ,"to reach, to extend",JLPT_1 JLPT
-折,おり,"chance, occasion",JLPT_1 JLPT
-檻,おり,"cage, pen, jail cell",JLPT_1 JLPT
-オリエンテーション,オリエンテーション,orientation,JLPT_1 JLPT
-折り返す,おりかえす,"to turn up, to fold back",JLPT_1 JLPT
-織物,おりもの,"textile, fabric",JLPT_1 JLPT
-俺,おれ,I (ego) (boastful first-person pronoun),JLPT_1 JLPT
-愚か,おろか,"foolish, stupid",JLPT_1 JLPT
-おろそか,おろそか,"neglect, negligence, carelessness",JLPT_1 JLPT
-おんぶ,おんぶ,carrying on one's back (erg. Baby),JLPT_1 JLPT
-オンライン,オンライン,on-line,JLPT_1 JLPT
-温和,おんわ,"gentle, mild, moderate",JLPT_1 JLPT
-我,が～,ego,JLPT_1 JLPT
-カーペット,カーペット,carpet,JLPT_1 JLPT
-～界,～かい,"world, circle, kingdom",JLPT_1 JLPT
-～街,～がい,town,JLPT_1 JLPT
-改悪,かいあく,"deterioration, changing for the worse",JLPT_1 JLPT
-海運,かいうん,marine transportation,JLPT_1 JLPT
-外貨,がいか,foreign money,JLPT_1 JLPT
-改革,かいかく,"reform, reformation, innovation",JLPT_1 JLPT
-貝殻,かいがら,shell,JLPT_1 JLPT
-外観,がいかん,"appearance, exterior, facade",JLPT_1 JLPT
-階級,かいきゅう,"class, rank, grade",JLPT_1 JLPT
-海峡,かいきょう,channel,JLPT_1 JLPT
-会見,かいけん,"interview, conference",JLPT_1 JLPT
-介護,かいご,nursing,JLPT_1 JLPT
-開催,かいさい,"holding a meeting, open an exhibition",JLPT_1 JLPT
-回収,かいしゅう,"collection, recovery",JLPT_1 JLPT
-改修,かいしゅう,"repair, improvement",JLPT_1 JLPT
-怪獣,かいじゅう,monster,JLPT_1 JLPT
-解除,かいじょ,"cancellation, release, cancel",JLPT_1 JLPT
-外相,がいしょう,Foreign Minister,JLPT_1 JLPT
-害する,がいする,"to harm, to offend",JLPT_1 JLPT
-概説,がいせつ,"general statement, outline",JLPT_1 JLPT
-回送,かいそう,forwarding,JLPT_1 JLPT
-階層,かいそう,"class, level, stratum, hierarchy",JLPT_1 JLPT
-開拓,かいたく,"cultivation, pioneer",JLPT_1 JLPT
-会談,かいだん,"conversation, interview",JLPT_1 JLPT
-改定,かいてい,reform,JLPT_1 JLPT
-改訂,かいてい,revision,JLPT_1 JLPT
-ガイド,ガイド,guide,JLPT_1 JLPT
-街道,かいどう,highway,JLPT_1 JLPT
-該当,がいとう,"corresponding, answering to, coming under",JLPT_1 JLPT
-街頭,がいとう,in the street,JLPT_1 JLPT
-ガイドブック,ガイドブック,guidebook,JLPT_1 JLPT
-介入,かいにゅう,intervention,JLPT_1 JLPT
-概念,がいねん,"general idea, concept, notion",JLPT_1 JLPT
-開発,かいはつ,"development, exploitation",JLPT_1 JLPT
-海抜,かいばつ,height above sea level,JLPT_1 JLPT
-介抱,かいほう,"nursing, looking after",JLPT_1 JLPT
-解剖,かいぼう,"dissection, autopsy",JLPT_1 JLPT
-外来,がいらい,"(abbr.) imported, outpatient clinic",JLPT_1 JLPT
-回覧,かいらん,circulation,JLPT_1 JLPT
-概略,がいりゃく,"outline, summary, gist",JLPT_1 JLPT
-海流,かいりゅう,ocean current,JLPT_1 JLPT
-改良,かいりょう,"improvement, reform",JLPT_1 JLPT
-回路,かいろ,circuit (electric),JLPT_1 JLPT
-海路,かいろ,sea route,JLPT_1 JLPT
-省みる,かえりみる,to reflect,JLPT_1 JLPT
-顧みる,かえりみる,"to look back, to turn around, to review",JLPT_1 JLPT
-顔付き,かおつき,facial expression,JLPT_1 JLPT
-課外,かがい,extracurricular,JLPT_1 JLPT
-掲げる,かかげる,"to hoist, to fly (a sail), to float (a flag)",JLPT_1 JLPT
-かかと,かかと,shoe heel,JLPT_1 JLPT
-書き取る,かきとる,"to write down, to take dictation",JLPT_1 JLPT
-掻き回す,かきまわす,"to stir up, to churn, to disturb",JLPT_1 JLPT
-かく (はじを),かく (はじを),to humiliate oneself,JLPT_1 JLPT
-～画,～かく,~ strokes,JLPT_1 JLPT
-学芸,がくげい,"arts and sciences, liberal arts",JLPT_1 JLPT
-格差,かくさ,"difference, disparity",JLPT_1 JLPT
-拡散,かくさん,"scattering, diffusion",JLPT_1 JLPT
-学士,がくし,university graduate,JLPT_1 JLPT
-各種,かくしゅ,"every kind, all sorts",JLPT_1 JLPT
-隔週,かくしゅう,every other week,JLPT_1 JLPT
-確信,かくしん,"conviction, confidence",JLPT_1 JLPT
-革新,かくしん,"reform, innovation",JLPT_1 JLPT
-学説,がくせつ,theory,JLPT_1 JLPT
-確定,かくてい,"fixed, decision",JLPT_1 JLPT
-カクテル,カクテル,cocktail,JLPT_1 JLPT
-獲得,かくとく,"acquisition, possession",JLPT_1 JLPT
-楽譜,がくふ,"score (music, sheet music)",JLPT_1 JLPT
-確保,かくほ,"guarantee, insure, secure",JLPT_1 JLPT
-革命,かくめい,revolution,JLPT_1 JLPT
-確立,かくりつ,establishment,JLPT_1 JLPT
-賭,かけ,"betting, gambling, a gamble",JLPT_1 JLPT
-掛～,かけ～,credit,JLPT_1 JLPT
-～掛け,～かけ,"rack, hanger",JLPT_1 JLPT
-崖,がけ,cliff,JLPT_1 JLPT
-駆け足,かけあし,"running fast, double time",JLPT_1 JLPT
-家計,かけい,"household economy, family finances",JLPT_1 JLPT
-駆けっこ,かけっこ,(foot) race,JLPT_1 JLPT
-加工,かこう,"manufacturing, processing, treatment",JLPT_1 JLPT
-化合,かごう,chemical combination,JLPT_1 JLPT
-かさばる,かさばる,to be bulky,JLPT_1 JLPT
-かさむ,かさむ,"to pile up, to increase",JLPT_1 JLPT
-箇条書,かじょうがき,"itemized form, itemization",JLPT_1 JLPT
-頭,かしら,"head, chief",JLPT_1 JLPT
-微か,かすか,"faint, dim, weak",JLPT_1 JLPT
-霞む,かすむ,"to grow hazy, to be misty",JLPT_1 JLPT
-擦る,かする,"to rub, to chafe",JLPT_1 JLPT
-火星,かせい,Mars,JLPT_1 JLPT
-化石,かせき,"fossil, petrifaction, fossilization",JLPT_1 JLPT
-河川,かせん,rivers,JLPT_1 JLPT
-化繊,かせん,synthetic fibers,JLPT_1 JLPT
-過疎,かそ,depopulation,JLPT_1 JLPT
-片～,かた～,single ~,JLPT_1 JLPT
-片言,かたこと,"broken (in reference to speaking style, e.g., Japanese)",JLPT_1 JLPT Intermediate_Japanese_Ln.13 Intermediate_Japanese
-傾ける,かたむける,"to incline, to tilt, to bend",JLPT_1 JLPT
-固める,かためる,"to harden, to freeze, to fortify",JLPT_1 JLPT
-傍ら,かたわら,"beside(s, while, nearby",JLPT_1 JLPT
-花壇,かだん,flower bed,JLPT_1 JLPT
-家畜,かちく,"domestic animals, livestock, cattle",JLPT_1 JLPT
-且つ,かつ,"yet, and",JLPT_1 JLPT
-がっくり,がっくり,heartbroken,JLPT_1 JLPT
-合唱,がっしょう,"chorus, singing in a chorus",JLPT_1 JLPT
-がっしり,がっしり,"firmly, solidly, tough",JLPT_1 JLPT
-合致,がっち,"agreement, concurrence, conforming to",JLPT_1 JLPT
-がっちり,がっちり,"solidly built, tightly",JLPT_1 JLPT
-かつて,かつて,"once, before, formerly",JLPT_1 JLPT
-勝手,かって,"kitchen; one's way, selfishness",JLPT_1 JLPT
-カット,カット,"cut, cutting",JLPT_1 JLPT
-活発,かっぱつ,"vigor, active",JLPT_1 JLPT
-合併,がっぺい,"combination, amalgamation, merger",JLPT_1 JLPT
-カテゴリー,カテゴリー,category,JLPT_1 JLPT
-叶う,かなう,to come true,JLPT_1 JLPT
-叶える,かなえる,"to grant (request, wish)",JLPT_1 JLPT
-金槌,かなづち,(iron) hammer,JLPT_1 JLPT
-かなわない,かなわない,"be beyond one's power, be unable",JLPT_1 JLPT
-加入,かにゅう,"becoming a member, admission",JLPT_1 JLPT
-予て,かねて,"previously, already, lately",JLPT_1 JLPT
-庇う,かばう,"to protect someone, to&nbsp;&nbsp;cover up for someone",JLPT_1 JLPT
-株式,かぶしき,stock,JLPT_1 JLPT
-かぶれる,かぶれる,to react to; to be influenced by,JLPT_1 JLPT
-花粉,かふん,pollen,JLPT_1 JLPT
-貨幣,かへい,"money, currency, coinage",JLPT_1 JLPT
-構える,かまえる,to set up,JLPT_1 JLPT
-過密,かみつ,crowded,JLPT_1 JLPT
-噛み切る,かみきる,"to bite off, to gnaw through",JLPT_1 JLPT
-カムバック,カムバック,comeback,JLPT_1 JLPT
-カメラマン,カメラマン,cameraman,JLPT_1 JLPT
-粥,かゆ,rice porridge,JLPT_1 JLPT
-体付き,からだつき,"body build, figure",JLPT_1 JLPT
-絡む,からむ,"to entangle, to entwine",JLPT_1 JLPT
-かりに,かりに,"temporarily; if, for argument's sake",JLPT_1 JLPT
-カルテ,カルテ,clinical records (GER: Karte),JLPT_1 JLPT
-ガレージ,ガレージ,garage (at house),JLPT_1 JLPT
-過労,かろう,"overwork, strain",JLPT_1 JLPT
-かろうじて,かろうじて,"barely, narrowly",JLPT_1 JLPT
-交す,かわす,to exchange,JLPT_1 JLPT
-代る代る,かわるがわる,alternately,JLPT_1 JLPT
-簡易,かんい,"simplicity, easiness, quasi-",JLPT_1 JLPT
-灌漑,かんがい,irrigation,JLPT_1 JLPT
-眼科,がんか,ophthalmology,JLPT_1 JLPT
-眼球,がんきゅう,eyeball,JLPT_1 JLPT
-玩具,がんぐ,toy,JLPT_1 JLPT
-簡潔,かんけつ,"brevity, concise, simple",JLPT_1 JLPT
-還元,かんげん,"resolution, reduction, return",JLPT_1 JLPT
-看護,かんご,nursing,JLPT_1 JLPT
-漢語,かんご,"Chinese word, Sino-Japanese word",JLPT_1 JLPT
-頑固,がんこ,"stubbornness, obstinacy",JLPT_1 JLPT
-勧告,かんこく,"advice, counsel",JLPT_1 JLPT
-換算,かんさん,"conversion, change, exchange",JLPT_1 JLPT
-監視,かんし,"observation, guarding, surveillance",JLPT_1 JLPT
-慣習,かんしゅう,usual (historical) custom,JLPT_1 JLPT
-観衆,かんしゅう,"spectators, audience",JLPT_1 JLPT
-願書,がんしょ,application form,JLPT_1 JLPT
-干渉,かんしょう,"interference, intervention",JLPT_1 JLPT
-頑丈,がんじょう,"solid, firm, strong",JLPT_1 JLPT
-感触,かんしょく,"sense of touch, feeling, sensation",JLPT_1 JLPT
-肝心,かんじん,"essential, fundamental, crucial",JLPT_1 JLPT
-肝腎,かんじん,"essential, fundamental, crucial",JLPT_1 JLPT
-関税,かんぜい,"customs, duty, tariff",JLPT_1 JLPT
-岩石,がんせき,rock,JLPT_1 JLPT
-感染,かんせん,"infection, contagion",JLPT_1 JLPT
-幹線,かんせん,"main line, trunk line",JLPT_1 JLPT
-簡素,かんそ,"simplicity, plain",JLPT_1 JLPT
-観点,かんてん,point of view,JLPT_1 JLPT
-感度,かんど,"sensitivity, severity (quake)",JLPT_1 JLPT
-カンニング,カンニング,"cunning, cheat",JLPT_1 JLPT
-元年,がんねん,first year (of a specific reign),JLPT_1 JLPT
-幹部,かんぶ,"management, executive",JLPT_1 JLPT
-完ぺき,かんぺき,"perfection, completeness, flawless",JLPT_1 JLPT
-勘弁,かんべん,"pardon, forgiveness, forbearance",JLPT_1 JLPT
-感無量,かんむりょう,"deep feeling, filled with emotion",JLPT_1 JLPT
-勧誘,かんゆう,"invitation, canvassing, inducement",JLPT_1 Intermediate_Japanese_Ln.5 JLPT Intermediate_Japanese
-関与,かんよ,"participation, taking part in",JLPT_1 JLPT
-寛容,かんよう,"forbearance, tolerance, generosity, involvement",JLPT_1 JLPT
-元来,がんらい,"originally, naturally",JLPT_1 JLPT
-観覧,かんらん,viewing,JLPT_1 JLPT
-慣例,かんれい,"custom, precedent, of convention",JLPT_1 JLPT
-還暦,かんれき,60th birthday,JLPT_1 JLPT
-貫禄,かんろく,"presence, dignity",JLPT_1 JLPT
-緩和,かんわ,"relief, mitigation",JLPT_1 JLPT
-議案,ぎあん,legislative bill,JLPT_1 JLPT
-危害,きがい,"injury, harm, danger",JLPT_1 JLPT
-企画,きかく,"planning, project",JLPT_1 Intermediate_Japanese_Ln.14 JLPT Intermediate_Japanese
-規格,きかく,"standard, norm",JLPT_1 JLPT
-着飾る,きかざる,to dress up,JLPT_1 JLPT
-気兼ね,きがね,"hesitance, diffidence, feeling constraint",JLPT_1 JLPT
-気軽,きがる,"cheerful, buoyant, lighthearted",JLPT_1 JLPT
-危機,きき,crisis,JLPT_1 JLPT
-聞き取り,ききとり,listening comprehension,JLPT_1 JLPT
-効き目,ききめ,"effect, virtue, efficacy",JLPT_1 JLPT
-帰京,ききょう,returning to Tokyo,JLPT_1 JLPT
-戯曲,ぎきょく,"play, drama",JLPT_1 JLPT
-基金,ききん,"fund, foundation",JLPT_1 JLPT
-喜劇,きげき,"comedy, funny show",JLPT_1 JLPT
-議決,ぎけつ,"resolution, decision, vote",JLPT_1 JLPT
-棄権,きけん,"abstain from voting, renunciation of a right",JLPT_1 JLPT
-既婚,きこん,married,JLPT_1 JLPT
-気障,きざ,"affectation, conceit, snobbery",JLPT_1 JLPT
-記載,きさい,"mention, entry",JLPT_1 JLPT
-兆,きざし,"sign, omen, indication",JLPT_1 JLPT
-気質,きしつ,"character, trait, temperament",JLPT_1 JLPT
-期日,きじつ,"fixed date, settlement date",JLPT_1 JLPT
-きしむ,きしむ,"to jar, to creak, to grate",JLPT_1 JLPT
-議事堂,ぎじどう,Diet building,JLPT_1 JLPT
-記述,きじゅつ,"describing, descriptor",JLPT_1 JLPT
-気象,きしょう,"weather, climate",JLPT_1 JLPT
-傷付く,きずつく,"to be hurt, to be wounded, to get injured",JLPT_1 JLPT
-傷付ける,きずつける,"to wound, to hurt someone's feelings",JLPT_1 JLPT
-犠牲,ぎせい,sacrifice,JLPT_1 JLPT
-汽船,きせん,steamship,JLPT_1 JLPT
-寄贈,きぞう,"donation, presentation",JLPT_1 JLPT
-偽造,ぎぞう,"forgery, fabrication, counterfeiting",JLPT_1 JLPT
-貴族,きぞく,"noble, aristocrat",JLPT_1 JLPT
-議題,ぎだい,"topic of discussion, agenda",JLPT_1 JLPT
-鍛える,きたえる,"to forge, to train, to discipline",JLPT_1 JLPT
-気立て,きだて,"good-natured, kind-hearted",JLPT_1 JLPT
-来る,きたる,"to come, to approach,",JLPT_1 JLPT
-きちっと,きちっと,"exactly, perfectly",JLPT_1 JLPT
-几帳面,きちょうめん,"methodical, punctual, steady",JLPT_1 JLPT
-きっかり,きっかり,"exactly, precisely",JLPT_1 JLPT
-きっちり,きっちり,"precisely, tightly",JLPT_1 JLPT
-きっぱり,きっぱり,"clearly, plainly, distinctly",JLPT_1 JLPT
-規定,きてい,"regulation, provisions",JLPT_1 JLPT
-起点,きてん,starting point,JLPT_1 JLPT
-軌道,きどう,orbit; track,JLPT_1 JLPT
-技能,ぎのう,"technical skill, ability, capacity",JLPT_1 JLPT
-規範,きはん,"model, standard, example",JLPT_1 JLPT
-気品,きひん,"grace, elegance",JLPT_1 JLPT
-気風,きふう,"character, traits, ethos",JLPT_1 JLPT
-起伏,きふく,undulation,JLPT_1 JLPT
-規模,きぼ,"scale, scope, plan, structure",JLPT_1 JLPT
-気まぐれ,きまぐれ,"whim, caprice, uneven temper",JLPT_1 JLPT
-生真面目,きまじめ,"serious, sincerity",JLPT_1 JLPT
-期末,きまつ,(end of the season or term),JLPT_1 JLPT
-きまりわるい,きまりわるい,"feeling awkward, being ashamed",JLPT_1 JLPT
-記名,きめい,"signature, register",JLPT_1 JLPT
-規約,きやく,"agreement, rules, code",JLPT_1 JLPT
-脚色,きゃくしょく,"dramatization (e.g., film",JLPT_1 JLPT
-逆転,ぎゃくてん,"(sudden) change, reversal, turn-around",JLPT_1 JLPT
-脚本,きゃくほん,scenario,JLPT_1 JLPT
-華奢,きゃしゃ,"delicate, slender",JLPT_1 JLPT
-客観,きゃっかん,objective,JLPT_1 JLPT
-キャッチ,キャッチ,catch,JLPT_1 JLPT
-キャリア,キャリア,"career, career government employee",JLPT_1 JLPT
-救援,きゅうえん,"relief, rescue, reinforcement",JLPT_1 JLPT
-休学,きゅうがく,"temporary absence from school, suspension",JLPT_1 JLPT
-究極,きゅうきょく,"ultimate, final, eventual",JLPT_1 JLPT
-窮屈,きゅうくつ,"narrow, tight, formal",JLPT_1 JLPT
-球根,きゅうこん,(plant) bulb,JLPT_1 JLPT
-救済,きゅうさい,"relief, aid, rescue",JLPT_1 JLPT
-給仕,きゅうじ,waiter,JLPT_1 JLPT
-給食,きゅうしょく,"school lunch, providing a meal",JLPT_1 JLPT
-休戦,きゅうせん,"truce, armistice",JLPT_1 JLPT
-宮殿,きゅうでん,palace,JLPT_1 JLPT
-旧知,きゅうち,"old friend, old friendship",JLPT_1 JLPT
-窮乏,きゅうぼう,poverty,JLPT_1 JLPT
-寄与,きよ,"contribution, service",JLPT_1 JLPT
-強,きょう,strong,JLPT_1 JLPT
-～狂,～きょう,"maniac, fan, freak",JLPT_1 JLPT
-驚異,きょうい,"wonder, miracle",JLPT_1 JLPT
-教科,きょうか,"subject, curriculum",JLPT_1 JLPT
-協会,きょうかい,"association, society, organization",JLPT_1 JLPT
-共学,きょうがく,coeducation,JLPT_1 JLPT
-共感,きょうかん,"sympathy, response",JLPT_1 JLPT
-境遇,きょうぐう,"environment, circumstances",JLPT_1 JLPT
-教訓,きょうくん,"lesson, precept, moral instruction",JLPT_1 JLPT
-強行,きょうこう,"forcing, enforcement",JLPT_1 JLPT
-強硬,きょうこう,"firm, vigorous, stubborn",JLPT_1 JLPT
-教材,きょうざい,teaching materials,JLPT_1 JLPT
-凶作,きょうさく,"bad harvest, poor crop",JLPT_1 JLPT
-業者,ぎょうしゃ,"trader, merchant",JLPT_1 JLPT
-教習,きょうしゅう,"training, instruction",JLPT_1 JLPT
-郷愁,きょうしゅう,"nostalgia, homesickness",JLPT_1 JLPT
-教職,きょうしょく,teaching profession,JLPT_1 JLPT
-興じる,きょうじる,"to amuse oneself, to make merry",JLPT_1 JLPT
-強制,きょうせい,"obligation, compulsion, enforcement",JLPT_1 JLPT
-行政,ぎょうせい,administration,JLPT_1 JLPT
-業績,ぎょうせき,"achievement, work, contribution",JLPT_1 JLPT
-共存,きょうぞん,coexistence,JLPT_1 JLPT
-協定,きょうてい,"arrangement, pact, agreement",JLPT_1 JLPT
-郷土,きょうど,homeland,JLPT_1 JLPT
-脅迫,きょうはく,"threat, coercion",JLPT_1 JLPT
-業務,ぎょうむ,"business, duties, work",JLPT_1 JLPT
-共鳴,きょうめい,"resonance, sympathy",JLPT_1 JLPT
-郷里,きょうり,"birth-place, home town",JLPT_1 JLPT
-強烈,きょうれつ,"strong, intense, severe",JLPT_1 JLPT
-共和,きょうわ,"republicanism, cooperation",JLPT_1 JLPT
-局限,きょくげん,"limit, localize",JLPT_1 JLPT
-極端,きょくたん,"extreme, extremity",JLPT_1 JLPT
-居住,きょじゅう,residence,JLPT_1 JLPT
-拒絶,きょぜつ,"refusal, rejection",JLPT_1 JLPT
-漁船,ぎょせん,fishing boat,JLPT_1 JLPT
-漁村,ぎょそん,fishing village,JLPT_1 JLPT
-拒否,きょひ,"denial, rejection, refusal",JLPT_1 JLPT
-許容,きょよう,"permission, pardon",JLPT_1 JLPT
-清らか,きよらか,"clean, pure, chaste",JLPT_1 JLPT
-きらびやか,きらびやか,"gorgeous, gaudy, dazzling",JLPT_1 JLPT
-～きり,～きり,only,JLPT_1 JLPT
-義理,ぎり,"debt of gratitude, obligation",JLPT_1 JLPT
-切替,きりかえ,"exchange, conversion, switchover",JLPT_1 JLPT
-気流,きりゅう,atmospheric current,JLPT_1 JLPT
-切れ目,きれめ,"break, pause, gap",JLPT_1 JLPT
-疑惑,ぎわく,"doubt, misgivings, suspicion",JLPT_1 JLPT
-極めて,きわめて,"exceedingly, extremely (written expression)",JLPT_1 JLPT Intermediate_Japanese_Ln.13 Intermediate_Japanese
-近眼,きんがん,nearsightedness,JLPT_1 JLPT
-緊急,きんきゅう,"urgent, pressing, emergency",JLPT_1 JLPT
-近郊,きんこう,"suburbs, outskirts",JLPT_1 JLPT
-均衡,きんこう,"equilibrium, balance",JLPT_1 JLPT
-禁じる,きんじる,to prohibit,JLPT_1 JLPT
-勤勉,きんべん,"industry, diligence",JLPT_1 JLPT
-吟味,ぎんみ,"examination, careful investigation",JLPT_1 JLPT
-勤務,きんむ,"service, duty, work",JLPT_1 JLPT
-禁物,きんもつ,"taboo, forbidden thing",JLPT_1 JLPT
-勤労,きんろう,"labor, exertion, diligent service",JLPT_1 JLPT
-クイズ,クイズ,quiz,JLPT_1 JLPT
-食い違う,くいちがう,"to cross each other, to differ",JLPT_1 JLPT
-空間,くうかん,"space, room, airspace",JLPT_1 JLPT
-空腹,くうふく,hunger,JLPT_1 JLPT
-区画,くかく,"division, section, area",JLPT_1 JLPT
-区間,くかん,section,JLPT_1 JLPT
-茎,くき,stalk,JLPT_1 JLPT
-区切り,くぎり,"an end, a stop, punctuation",JLPT_1 JLPT
-くぐる,くぐる,to pass through; to go around,JLPT_1 JLPT
-くじ (～をひく),くじ (～をひく),"lottery, lot",JLPT_1 JLPT
-くじびき,くじびき,"lottery, drawn lot",JLPT_1 JLPT
-くすぐったい,くすぐったい,ticklish,JLPT_1 JLPT
-愚痴,ぐち,"idle complaint, grumble",JLPT_1 JLPT
-口吟む,くちずさむ,to humble,JLPT_1 JLPT
-嘴,くちばし,"beak, bill",JLPT_1 JLPT
-朽ちる,くちる,to rot,JLPT_1 JLPT
-覆す,くつがえす,"to overturn, to upset, to overthrow",JLPT_1 JLPT
-くっきり,くっきり,"distinctly, clearly, boldly",JLPT_1 JLPT
-屈折,くっせつ,"bending, indentation, refraction",JLPT_1 JLPT
-ぐっと,ぐっと,"firmly, fast, more",JLPT_1 JLPT
-首飾り,くびかざり,necklace,JLPT_1 JLPT
-首輪,くびわ,"necklace, choker",JLPT_1 JLPT
-組み込む,くみこむ,"to insert, to include, to cut in (printing)",JLPT_1 JLPT
-組み合わせる,くみあわせる,"to join together, to combine, to join up",JLPT_1 JLPT
-蔵,くら,"warehouse, cellar",JLPT_1 JLPT
-グレー,グレー,"grey, gray",JLPT_1 JLPT
-クレーン,クレーン,crane,JLPT_1 JLPT
-玄人,くろうと,"expert, professional",JLPT_1 JLPT
-黒字,くろじ,balance (figure) in the black,JLPT_1 JLPT
-軍艦,ぐんかん,"warship, battleship",JLPT_1 JLPT Intermediate_Japanese_Ln.8 Intermediate_Japanese
-軍事,ぐんじ,military affairs,JLPT_1 JLPT
-君主,くんしゅ,"ruler, monarch",JLPT_1 JLPT
-群集,ぐんしゅう,"(social) group, crowd, mob",JLPT_1 JLPT
-群衆,ぐんしゅう,"(social) group, crowd, mob",JLPT_1 JLPT
-軍備,ぐんび,"armaments, military preparations",JLPT_1 JLPT
-軍服,ぐんぷく,military or naval uniform,JLPT_1 JLPT
-芸,げい,"art, accomplishment, performance",JLPT_1 JLPT
-経過,けいか,"passage, progress",JLPT_1 JLPT
-軽快,けいかい,"lively, casual, light",JLPT_1 JLPT
-警戒,けいかい,"warning, admonition, vigilance",JLPT_1 JLPT
-敬具,けいぐ,Sincerely (used at the end of letter),Intermediate_Japanese_Ln.4 JLPT_1 JLPT Intermediate_Japanese
-軽減,けいげん,"reduction, lessening",JLPT_1 JLPT
-掲載,けいさい,"appearance (e.g., article in paper)",JLPT_1 JLPT
-傾斜,けいしゃ,"inclination, slope, dip",JLPT_1 JLPT
-形成,けいせい,formation,JLPT_1 JLPT
-形勢,けいせい,"condition, situation, prospects",JLPT_1 JLPT
-軽率,けいそつ,"thoughtless, careless, hasty",JLPT_1 JLPT
-刑罰,けいばつ,"judgment, penalty, punishment",JLPT_1 JLPT
-経費,けいひ,"expenses, cost, outlay",JLPT_1 JLPT
-警部,けいぶ,police inspector,JLPT_1 JLPT
-転換,てんかん,"convert, divert",JLPT_1 JLPT
-転居,てんきょ,"moving, changing residence",JLPT_1 JLPT
-転勤,てんきん,transfer (to another office of a company),JLPT_1 Intermediate_Japanese_Ln.14 JLPT Intermediate_Japanese
-点検,てんけん,"inspection, examination, checking",JLPT_1 JLPT
-電源,でんげん,"source of electricity, power (e.g., button on TV)",JLPT_1 JLPT
-天国,てんごく,"paradise, heaven, Kingdom of Heaven",JLPT_1 JLPT
-天才,てんさい,a genius,JLPT_1 JLPT Intermediate_Japanese_Ln.8 Intermediate_Japanese
-天災,てんさい,"natural calamity, disaster",JLPT_1 JLPT
-展示,てんじ,"exhibition, display",JLPT_1 JLPT
-伝説,でんせつ,"tradition, legend, folklore",JLPT_1 JLPT Intermediate_Japanese_Ln.8 Intermediate_Japanese
-点線,てんせん,dotted line,JLPT_1 JLPT
-転じる,てんじる,"to turn, to shift",JLPT_1 JLPT
-転ずる,てんずる,"to turn, to shift",JLPT_1 JLPT
-天体,てんたい,heavenly body,JLPT_1 JLPT
-伝達,でんたつ,"transmission (e.g., news, communication, delivery)",JLPT_1 JLPT
-天地,てんち,"heaven and earth, the universe",JLPT_1 JLPT
-てんで,てんで,"(not) at all, altogether, entirely",JLPT_1 JLPT
-転任,てんにん,change of post,JLPT_1 JLPT
-展望,てんぼう,"view, outlook, prospect",JLPT_1 JLPT
-伝来,でんらい,"ancestral, hereditary, imported",JLPT_1 JLPT
-転落,てんらく,"fall, degradation",JLPT_1 JLPT
-問い合わせる,といあわせる,"to inquire, to seek information",JLPT_1 JLPT
-当～,とう～,"Our ~ (e.g., Hotel, plane, etc.)",JLPT_1 JLPT
-胴,どう,"trunk, body, frame",JLPT_1 JLPT
-同意,どうい,"agreement, consent; same meaning",JLPT_1 JLPT
-動員,どういん,mobilization,JLPT_1 JLPT
-同感,どうかん,"agreement, same opinion, same feeling",JLPT_1 JLPT
-陶器,とうき,"pottery, ceramics",JLPT_1 JLPT
-討議,とうぎ,"debate, discussion",JLPT_1 JLPT
-動機,どうき,"motive, incentive",JLPT_1 JLPT
-等級,とうきゅう,"grade, class",JLPT_1 JLPT
-同級,どうきゅう,"the same grade, same class",JLPT_1 JLPT
-同居,どうきょ,living together,JLPT_1 JLPT
-登校,とうこう,attendance (at school),JLPT_1 JLPT
-統合,とうごう,"integration, unification, synthesis",JLPT_1 JLPT
-動向,どうこう,"trend, tendency, movement, attitude",JLPT_1 JLPT
-投資,とうし,investment,JLPT_1 JLPT
-同情,どうじょう,"sympathy, compassion, sympathize",JLPT_1 JLPT
-道場,どうじょう,"(arch) dojo, hall used for martial arts training, mandala",JLPT_1 JLPT
-統制,とうせい,"regulation, control",JLPT_1 JLPT
-当選,とうせん,"being elected, winning the prize",JLPT_1 JLPT
-逃走,とうそう,"flight, desertion, escape",JLPT_1 JLPT
-統率,とうそつ,"command, generalship, leadership",JLPT_1 JLPT
-到達,とうたつ,"reaching, attaining, arrival",JLPT_1 JLPT
-統治,とうち,"rule, reign, governing",JLPT_1 JLPT
-仕切る,しきる,"to partition, to divide, to mark off",JLPT_1 JLPT
-資金,しきん,"funds, capital",JLPT_1 JLPT
-軸,じく,"axis, stem, shaft",JLPT_1 JLPT
-しくじる,しくじる,"to fail, to fall through, to blunder",JLPT_1 JLPT
-仕組,しくみ,"structure, mechanism",JLPT_1 JLPT
-死刑,しけい,death penalty,JLPT_1 JLPT
-湿気る,しける,"to be damp, to be moist",JLPT_1 JLPT
-施行,しこう,"enforcement, operation",JLPT_1 JLPT
-思考,しこう,thought,JLPT_1 JLPT
-志向,しこう,"intention, aim",JLPT_1 JLPT
-嗜好,しこう,"taste, liking, preference",JLPT_1 JLPT
-事項,じこう,"matter(s), item(s), facts",JLPT_1 JLPT Intermediate_Japanese_Ln.15 Intermediate_Japanese
-時刻表,じこくひょう,"timetable, (train) schedule",JLPT_1 JLPT Intermediate_Japanese_Ln.10 Intermediate_Japanese
-地獄,じごく,hell,JLPT_1 JLPT
-時差,じさ,time difference,JLPT_1 JLPT
-自在,じざい,"freely, at will",JLPT_1 JLPT
-視察,しさつ,"inspection, observation",JLPT_1 JLPT
-資産,しさん,"property, fortune, assets",JLPT_1 JLPT
-支持,しじ,support,JLPT_1 JLPT
-自主,じしゅ,"independence, autonomy",JLPT_1 JLPT
-自首,じしゅ,"surrender, give oneself up",JLPT_1 JLPT
-刺繍,ししゅう,embroidery,JLPT_1 JLPT
-市場,しじょう,(the) market (as a concept),JLPT_1 JLPT
-辞職,じしょく,resignation,JLPT_1 JLPT
-雫,しずく,drop (of water),JLPT_1 JLPT
-システム,システム,system,JLPT_1 JLPT
-沈める,しずめる,"to sink, to submerge",JLPT_1 JLPT
-施設,しせつ,"establishment, facility",JLPT_1 JLPT
-事前,じぜん,"prior, beforehand, in advance",JLPT_1 JLPT
-子息,しそく,(hon.) son,JLPT_1 JLPT
-持続,じぞく,"continuation, endurance",JLPT_1 JLPT
-自尊心,じそんしん,"self-respect, conceit",JLPT_1 JLPT
-慕う,したう,to yearn to adore,JLPT_1 JLPT
-下心,したごころ,"secret intention, motive",JLPT_1 JLPT
-下地,したじ,"groundwork, foundation",JLPT_1 JLPT
-親しむ,したしむ,"to be intimate with, to befriend",JLPT_1 JLPT
-下調べ,したしらべ,preliminary investigation,JLPT_1 JLPT
-愛想,あいそう,sociability,JLPT JLPT_1
-間柄,あいだがら,relationship,JLPT JLPT_1
-合間,あいま,interval,JLPT JLPT_1
-敢えて,あえて,"dare (to do), venture (to do), challenge (to do)",JLPT JLPT_1
-仰ぐ,あおぐ,"to look up (to), to respect; to ask for",JLPT JLPT_1
-垢,あか,"dirt, filth",JLPT JLPT_1
-赤字,あかじ,"deficit, go in the red",JLPT JLPT_1
-明かす,あかす,to reveal; to stay up,JLPT JLPT_1
-赤らむ,あからむ,"to become red, to blush",JLPT JLPT_1
-上がり,あがり,"ascent; income; completion, stop",JLPT JLPT_1
-諦め,あきらめ,"resignation, reconciliation, consolation",JLPT JLPT_1
-アクセル,アクセル,(abbr.) accelerator,JLPT JLPT_1
-あくどい,あくどい,gaudy vicious,JLPT JLPT_1
-顎,あご,chin,JLPT JLPT_1
-憧れ,あこがれ,"yearning, longing, aspiration",Intermediate_Japanese Intermediate_Japanese_Ln.8 JLPT JLPT_1
-麻,あさ,hemp,JLPT JLPT_1
-あざ,あざ,"birthmark, bruise",JLPT JLPT_1
-浅ましい,あさましい,"shameful, mean, despicable",JLPT JLPT_1
-欺く,あざむく,to deceive,JLPT JLPT_1
-鮮やか,あざやか,"vivid, clear",JLPT JLPT_1
-嘲笑う,あざわらう,"to sneer at, to ridicule",JLPT JLPT_1
-悪しからず,あしからず,"don't take me wrong, but..., I'm sorry",JLPT JLPT_1
-味わい,あじわい,"flavor, relish",JLPT JLPT_1
-焦る,あせる,"to be in a hurry, to be impatient",JLPT JLPT_1
-あせる (こえが～),あせる (こえが～),"to fade, to discolor",JLPT JLPT_1
-値,あたい,"value, price, worth",JLPT JLPT_1
-値する,あたいする,"to be worth, to deserve",JLPT JLPT_1
-悪化,あっか,"deterioration, worsen",JLPT JLPT_1
-扱い,あつかい,"treatment, service",JLPT JLPT_1
-呆気ない,あっけない,"not enough, too quick (short, long, etc.)",JLPT JLPT_1
-あっさり,あっさり,"easily, readily, quickly",JLPT JLPT_1
-斡旋,あっせん,"kind offices, mediation",JLPT JLPT_1
-圧倒,あっとう,"overwhelm, overpower",JLPT JLPT_1
-圧迫,あっぱく,"pressure, coercion, oppression",JLPT JLPT_1
-あつらえる,あつらえる,"to give an order, to place an order",JLPT JLPT_1
-圧力,あつりょく,"stress, pressure",JLPT JLPT_1
-当て,あて,expectations; depend,JLPT JLPT_1
-～宛,～あて,"for…(e.g., In a letter)",JLPT JLPT_1
-当て字,あてじ,"phonetic-equivalent character, substitute character",JLPT JLPT_1
-跡継ぎ,あとつぎ,"heir, successor",JLPT JLPT_1
-後回し,あとまわし,"putting off, postponing",JLPT JLPT_1
-油絵,あぶらえ,oil painting,JLPT JLPT_1
-アプローチ,アプローチ,approach (in golf),JLPT JLPT_1
-あべこべ,あべこべ,"contrary, opposite, inverse",JLPT JLPT_1
-甘える,あまえる,"to behave like a spoiled child, to fawn on",JLPT JLPT_1
-雨具,あまぐ,rain gear,JLPT JLPT_1
-甘口,あまくち,sweet flavor,JLPT JLPT_1
-アマチュア,アマチュア,amateur,JLPT JLPT_1
-網,あみ,net,JLPT JLPT_1
-操る,あやつる,"to manipulate, to operate, to pull strings",JLPT JLPT_1
-危ぶむ,あやぶむ,"to fear, to have misgivings, to be doubtful",JLPT_1 JLPT
-あやふや,あやふや,"uncertain, vague, ambiguous",JLPT_1 JLPT
-過ち,あやまち,"fault, error, indiscretion",JLPT_1 JLPT
-誤る,あやまる,to make a mistake,JLPT_1 JLPT
-歩み,あゆみ,"step, progress, history",JLPT_1 JLPT
-歩む,あゆむ,to walk,JLPT_1 JLPT
-予め,あらかじめ,"in advance, previously",JLPT_1 JLPT
-荒らす,あらす,to damage; to invade,JLPT_1 JLPT
-争い,あらそい,"dispute, quarrel, conflict",JLPT_1 JLPT
-改まる,あらたまる,to be renewed; to be formal,JLPT_1 JLPT
-荒っぽい,あらっぽい,"rough, rude",JLPT_1 JLPT
-アラブ,アラブ,Arab,JLPT_1 JLPT
-霰,あられ,"hail (e.g., falling ice balls)",JLPT_1 JLPT
-有り様,ありさま,"state, condition",JLPT_1 JLPT
-ありのまま,ありのまま,"the truth, as it is, frankly",JLPT_1 JLPT
-ありふれる,ありふれる,"common, ordinary, routine",JLPT_1 JLPT
-アルカリ,アルカリ,alkali,JLPT_1 JLPT
-アルミ,アルミ,"aluminum (Al, aluminum)",JLPT_1 JLPT
-アワー,アワー,hour,JLPT_1 JLPT
-合わす,あわす,"to join together, to face, to unite",JLPT_1 JLPT
-～合せ,～あわせ,in all,JLPT_1 JLPT
-アンコール,アンコール,encore,JLPT_1 JLPT
-暗殺,あんさつ,assassination,JLPT_1 JLPT
-暗算,あんざん,mental arithmetic,JLPT_1 JLPT
-暗示,あんじ,"hint, suggestion",JLPT_1 JLPT
-案じる,あんじる,"to be anxious, to ponder",JLPT_1 JLPT
-安静,あんせい,rest,JLPT_1 JLPT
-案の定,あんのじょう,"sure enough, as usual",JLPT_1 JLPT
-いい加減,いいかげん,"random, irresponsible",JLPT_1 JLPT
-言い訳,いいわけ,"excuse, explanation",JLPT_1 JLPT
-イェス,イェス,yes; Jesus,JLPT_1 JLPT
-家出,いえで,running away from home,JLPT_1 JLPT
-生かす,いかす,to keep something alive; to make use of,JLPT_1 JLPT
-いかに,いかに,"how, in what way",JLPT_1 JLPT
-いかにも,いかにも,truly (same as 実に (じつに)),JLPT_1 JLPT Intermediate_Japanese_Ln.13 Intermediate_Japanese
-異議,いぎ,"objection, dissent, protest",JLPT_1 JLPT
-生き甲斐,いきがい,"something one lives for, very important",JLPT_1 JLPT
-行き違い,いきちがい,"misunderstanding, disagreement",JLPT_1 JLPT
-意気込む,いきごむ,to be enthusiastic about,JLPT_1 JLPT
-育成,いくせい,"rearing, training, cultivation",JLPT_1 JLPT
-幾多,いくた,"many, numerous",JLPT_1 JLPT
-"(花を〜) 生ける, 活ける",(はなを～) いける,to arrange (flowers),JLPT JLPT_1 MediaMissing
-異見,いけん,"different opinion, objection",JLPT_1 JLPT
-意向,いこう,"intention, idea, inclination",JLPT_1 JLPT
-移行,いこう,switching over to,JLPT_1 JLPT
-いざ,いざ,"now, come (now), crucial moment",JLPT_1 JLPT
-移住,いじゅう,"migration, immigration",JLPT_1 JLPT
-衣装,いしょう,"clothing, costume, outfit",JLPT_1 JLPT
-いじる,いじる,"to touch, to tamper with",JLPT_1 JLPT
-異性,いせい,the opposite sex,JLPT_1 JLPT
-遺跡,いせき,historic ruins,JLPT_1 JLPT
-依存,いぞん,"dependence, dependent, reliance",JLPT_1 JLPT
-委託,いたく,"consign (goods (for sale) to a firm), entrust",JLPT_1 JLPT
-いたって,いたって,"very much, exceedingly, extremely",JLPT_1 JLPT
-出世,しゅっせ,"promotion, successful career, eminence",JLPT_1 JLPT
-出題,しゅつだい,proposing a question,JLPT_1 JLPT
-出動,しゅつどう,"mobilization, action",JLPT_1 JLPT
-出費,しゅっぴ,"expenses, disbursements",JLPT_1 JLPT
-出品,しゅっぴん,"exhibit, display",JLPT_1 JLPT
-主導,しゅどう,main leadership,JLPT_1 JLPT
-主任,しゅにん,"person in charge, responsible official",JLPT_1 JLPT Intermediate_Japanese_Ln.8 Intermediate_Japanese
-首脳,しゅのう,"head, leader",JLPT_1 JLPT
-守備,しゅび,defense,JLPT_1 JLPT
-手法,しゅほう,technique,JLPT_1 JLPT
-樹木,じゅもく,"trees and shrubs, arbor",JLPT_1 JLPT
-樹立,じゅりつ,"establish, create",JLPT_1 JLPT
-準急,じゅんきゅう,"local express (train, slower than an express)",JLPT_1 JLPT
-準じる,じゅんじる,"to follow, to conform, to apply to",JLPT_1 JLPT
-～署,～しょ,department,JLPT_1 JLPT
-～症,～しょう,disease,JLPT_1 JLPT
-～証,～しょう,"proof, certificate",JLPT_1 JLPT
-～嬢,～じょう,young woman,JLPT_1 JLPT
-上位,じょうい,"superior, higher order",JLPT_1 JLPT
-上演,じょうえん,art performance,JLPT_1 JLPT
-城下,じょうか,land near the castle,JLPT_1 JLPT
-消去,しょうきょ,"elimination, erasing",JLPT_1 JLPT
-上空,じょうくう,"sky, high-altitude sky, upper air",JLPT_1 JLPT
-衝撃,しょうげき,"shock, crash, impact, ballistic",JLPT_1 JLPT
-証言,しょうげん,"evidence, testimony",JLPT_1 JLPT
-証拠,しょうこ,"evidence, proof",JLPT_1 JLPT
-照合,しょうごう,"check, verification",JLPT_1 JLPT
-詳細,しょうさい,"detail, particulars",JLPT_1 JLPT
-上昇,じょうしょう,"rising, ascending, climbing",JLPT_1 JLPT
-昇進,しょうしん,promotion,JLPT_1 JLPT
-称する,しょうする,"to take the name of, to call oneself",JLPT_1 JLPT
-情勢,じょうせい,"state of things, condition, situation",JLPT_1 JLPT
-消息,しょうそく,"news, letter, circumstances",JLPT_1 JLPT
-承諾,しょうだく,"consent, agreement",JLPT_1 JLPT
-情緒,じょうちょ,"emotion, feeling",JLPT_1 JLPT
-情緒,じょうしょ,"emotion, feeling",JLPT_1 JLPT
-象徴,しょうちょう,symbol,JLPT_1 JLPT
-小児科,しょうにか,pediatrics,JLPT_1 JLPT
-使用人,しようにん,"employee, servant",JLPT_1 JLPT
-情熱,じょうねつ,"passion, enthusiasm, zeal",JLPT_1 JLPT
-譲歩,じょうほ,"concession, conciliation, compromise",JLPT_1 JLPT
-条約,じょうやく,"treaty, pact",JLPT_1 JLPT Intermediate_Japanese_Ln.8 Intermediate_Japanese
-勝利,しょうり,"victory, triumph, win",JLPT_1 JLPT
-上陸,じょうりく,"landing, disembarkation",JLPT_1 JLPT
-蒸溜,じょうりゅう,distillation,JLPT_1 JLPT
-奨励,しょうれい,"encouragement, promotion",JLPT_1 JLPT
-ショー,ショー,show,JLPT_1 JLPT
-除外,じょがい,"exception, exclusion",JLPT_1 JLPT
-職員,しょくいん,"staff member, personnel",JLPT_1 JLPT
-植民地,しょくみんち,colony,JLPT_1 JLPT
-職務,しょくむ,professional duties,JLPT_1 JLPT
-諸君,しょくん,"Gentlemen!, Ladies!",JLPT_1 JLPT
-助言,じょげん,"advice, suggestion",JLPT_1 JLPT Intermediate_Japanese Intermediate_Japanese_Ln.11
-徐行,じょこう,going slowly,JLPT_1 JLPT
-所在,しょざい,whereabouts,JLPT_1 JLPT
-所持,しょじ,"possession, owning",JLPT_1 JLPT
-所属,しょぞく,"attached to, belong to",JLPT_1 JLPT
-処置,しょち,treatment,JLPT_1 JLPT
-しょっちゅう,しょっちゅう,"always, constantly",JLPT_1 JLPT
-所定,しょてい,"fixed, prescribed",JLPT_1 JLPT
-所得,しょとく,income,JLPT_1 JLPT
-処罰,しょばつ,punishment,JLPT_1 JLPT
-初版,しょはん,first edition,JLPT_1 JLPT
-書評,しょひょう,book review,JLPT_1 JLPT
-処分,しょぶん,"disposal, dealing, punishment",JLPT_1 JLPT
-庶民,しょみん,"masses, common people",JLPT_1 JLPT
-庶務,しょむ,general affairs,JLPT_1 JLPT
-所有,しょゆう,"one's possessions, ownership",JLPT_1 JLPT
-調べ,しらべ,"investigation, inspection",JLPT_1 JLPT
-自立,じりつ,"independence, self-reliance",JLPT_1 JLPT
-記す,しるす,"to note, to write down",JLPT_1 JLPT
-指令,しれい,"orders, instructions, directive",JLPT_1 JLPT
-～心,～しん,mind of ~,JLPT_1 JLPT
-陣,じん,"battle formation, camp, encampment",JLPT_1 JLPT
-進化,しんか,"evolution, progress",JLPT_1 JLPT
-人格,じんかく,"personality, character",JLPT_1 JLPT
-審議,しんぎ,deliberation,JLPT_1 JLPT
-新婚,しんこん,newly-wed,JLPT_1 JLPT
-審査,しんさ,"judging, inspection, examination",JLPT_1 JLPT
-人材,じんざい,man of talent,JLPT_1 JLPT
-紳士,しんし,gentleman,JLPT_1 JLPT
-真実,しんじつ,"truth, reality",JLPT_1 JLPT
-信者,しんじゃ,"believer, devotee",JLPT_1 JLPT
-真珠,しんじゅ,pearl,JLPT_1 JLPT
-進出,しんしゅつ,advancement,JLPT_1 Intermediate_Japanese_Ln.14 JLPT Intermediate_Japanese
-心情,しんじょう,mentality,JLPT_1 JLPT
-新人,しんじん,"new face, newcomer",JLPT_1 JLPT
-神聖,しんせい,"holiness, sacredness, dignity",JLPT_1 JLPT
-親善,しんぜん,friendship,JLPT_1 JLPT
-真相,しんそう,"truth, real situation",JLPT_1 JLPT
-迅速,じんそく,"quick, fast, prompt",JLPT_1 JLPT
-人体,じんたい,human body,JLPT_1 JLPT
-新築,しんちく,"new building, new construction",JLPT_1 JLPT
-心中,しんじゅう,double suicide,JLPT_1 JLPT
-進呈,しんてい,presentation,JLPT_1 JLPT
-進展,しんてん,"progress, development",JLPT_1 JLPT
-神殿,しんでん,"temple, sacred place",JLPT_1 JLPT
-進度,しんど,progress,JLPT_1 JLPT
-振動,しんどう,"oscillation, vibration",JLPT_1 JLPT
-新入生,しんにゅうせい,"new student, first-year student, freshman",JLPT_1 Intermediate_Japanese_Ln.5 JLPT Intermediate_Japanese
-信任,しんにん,"trust, confidence, credence",JLPT_1 JLPT
-神秘,しんぴ,mystery,JLPT_1 JLPT
-辛抱,しんぼう,"patience, endurance",JLPT_1 JLPT
-人民,じんみん,"people, public",JLPT_1 JLPT
-侵略,しんりゃく,"aggression, invasion, raid",JLPT_1 JLPT
-診療,しんりょう,medical examination and treatment,JLPT_1 JLPT
-粋,すい,essence,JLPT_1 JLPT
-水源,すいげん,source of river,JLPT_1 JLPT
-推進,すいしん,"propulsion, driving force",JLPT_1 JLPT
-吹奏,すいそう,playing wind instruments,JLPT_1 JLPT
-推測,すいそく,"guess, conjecture",JLPT_1 JLPT
-水田,すいでん,(water-filled) paddy field,JLPT_1 JLPT
-推理,すいり,"reasoning, inference, mystery or detective genre",JLPT_1 JLPT
-数詞,すうし,numeral,JLPT_1 JLPT
-崇拝,すうはい,"worship, adoration",JLPT_1 JLPT
-据え付ける,すえつける,"to install, to equip, to mount",JLPT_1 JLPT
-据える,すえる,"to set, to lay, to place",JLPT_1 JLPT
-すがすがしい,すがすがしい,"fresh, refreshing",JLPT_1 JLPT
-救い,すくい,"help, aid, relief",JLPT_1 JLPT
-すくう (みずを～),すくう (みずを～),to scoop,JLPT_1 JLPT
-健やか,すこやか,"vigorous, healthy, sound",JLPT_1 JLPT
-濯ぐ,すすぐ,"to rinse, to wash out",JLPT_1 JLPT
-進み,すすみ,progress,JLPT_1 JLPT
-裾,すそ,"(trouser) cuff, (skirt) hem, cut edge of a hairdo",JLPT_1 JLPT
-スタジオ,スタジオ,studio,JLPT_1 JLPT
-スチーム,スチーム,steam,JLPT_1 JLPT
-ストライキ,ストライキ,strike,JLPT_1 JLPT
-スト,スト,(abbr.) strike,JLPT_1 JLPT
-ストロー,ストロー,straw,JLPT_1 JLPT
-ストロボ,ストロボ,"stroboscope (literally: strobo, strobe lamp, stroboscopic lamp)",JLPT_1 JLPT
-すばしこい,すばしこい,"nimble, smart, quick",JLPT_1 JLPT
-素早い,すばやい,"fast, quick",JLPT_1 JLPT
-ずばり,ずばり,"decisively, unreservedly, frankly",JLPT_1 JLPT
-スプリング,スプリング,spring,JLPT_1 JLPT
-スペース,スペース,space,JLPT_1 JLPT
-ずぶぬれ,ずぶぬれ,"soaked, dripping wet",JLPT_1 JLPT
-スポーツカー,スポーツカー,sports car,JLPT_1 JLPT
-澄ます,すます,"to clear, to make clear, to listen for",JLPT_1 JLPT
-清ます,すます,"to clear, to make clear, to listen for",JLPT_1 JLPT
-済ます,すます,to finish; to settle; to do without,JLPT_1 JLPT
-すみやか,すみやか,speedy,JLPT_1 JLPT
-スラックス,スラックス,slacks,JLPT_1 JLPT
-ずらっと,ずらっと,"in a line, in a row",JLPT_1 JLPT
-ずるずる,ずるずる,"dragging on, sound of sniffling",JLPT_1 JLPT
-ずれ,ずれ,"difference, gap",JLPT_1 JLPT
-すれちがい,すれちがい,chance encounter,JLPT_1 JLPT
-擦れる,すれる,"to rub, to chafe",JLPT_1 JLPT
-すんなり,すんなり,"pass with no objection, slim, slender",JLPT_1 JLPT
-生育,せいいく,"growth, development, breeding",JLPT_1 JLPT
-成育,せいいく,"growth, raising",JLPT_1 JLPT
-成果,せいか,"results, fruits",JLPT_1 JLPT
-正解,せいかい,"correct, right answer, solution",JLPT_1 JLPT
-正義,せいぎ,"justice, right, righteousness",JLPT_1 JLPT
-生計,せいけい,"livelihood, living",JLPT_1 JLPT
-政権,せいけん,"(political) administration, political power",JLPT_1 JLPT
-星座,せいざ,constellation,JLPT_1 JLPT
-制裁,せいさい,"restraint, sanctions, punishment",JLPT_1 JLPT
-政策,せいさく,"political measures, policy",JLPT_1 JLPT
-生死,せいし,life and death,JLPT_1 JLPT
-静止,せいし,"stillness, repose, standing still",JLPT_1 JLPT
-誠実,せいじつ,"sincere, honest, faithful",JLPT_1 JLPT
-成熟,せいじゅく,"maturity, ripeness",JLPT_1 JLPT
-青春,せいしゅん,"youth, springtime of life, adolescent",JLPT_1 JLPT
-清純,せいじゅん,"purity, innocence",JLPT_1 JLPT
-聖書,せいしょ,Bible,JLPT_1 JLPT
-正常,せいじょう,"normalcy, normality, normal",JLPT_1 JLPT
-制する,せいする,"to control, to command",JLPT_1 JLPT
-整然,せいぜん,"orderly, regular, well-organized",JLPT_1 JLPT
-盛装,せいそう,"be dressed up, wear rich clothes",JLPT_1 JLPT
-盛大,せいだい,"grand, prosperous, magnificent",JLPT_1 JLPT
-清濁,せいだく,"good and evil, purity and impurity",JLPT_1 JLPT
-制定,せいてい,"enactment, establishment, creation",JLPT_1 JLPT
-静的,せいてき,static,JLPT_1 JLPT
-製鉄,せいてつ,iron manufacture,JLPT_1 JLPT
-晴天,せいてん,fine weather,JLPT_1 JLPT
-正当,せいとう,"just, due, proper",JLPT_1 JLPT
-制服,せいふく,uniform,JLPT_1 JLPT
-征服,せいふく,"conquest, subjugation, overcoming",JLPT_1 JLPT
-製法,せいほう,"manufacturing method, recipe, formula",JLPT_1 JLPT
-精密,せいみつ,"precise, exact, detailed, minute",JLPT_1 JLPT
-税務署,ぜいむしょ,tax office,JLPT_1 JLPT
-制約,せいやく,"limitation, constraints",JLPT_1 JLPT
-勢力,せいりょく,"influence, power, might, strength",JLPT_1 JLPT
-整列,せいれつ,"stand in a row, form a line",JLPT_1 JLPT
-セール,セール,sale,JLPT_1 JLPT
-急かす,せかす,"to hurry, to urge on",JLPT_1 JLPT
-伜,せがれ,"son, my son",JLPT_1 JLPT
-責務,せきむ,"duty, obligation",JLPT_1 JLPT
-セクション,セクション,section,JLPT_1 JLPT
-世辞,せじ,"flattery, compliment",JLPT_1 JLPT
-世帯,せたい,household,JLPT_1 JLPT
-是正,ぜせい,"correction, revision",JLPT_1 JLPT
-世代,せだい,generation,JLPT_1 JLPT
-切開,せっかい,"opening up, cutting through",JLPT_1 JLPT
-セックス,セックス,sex,JLPT_1 JLPT
-切実,せつじつ,"compelling, serious, severe, acute",JLPT_1 JLPT
-接触,せっしょく,"touch, contact",JLPT_1 JLPT
-接続詞,せつぞくし,conjunction,JLPT_1 JLPT
-設置,せっち,"establishment, institution",JLPT_1 JLPT
-折衷,せっちゅう,"compromise, cross, blending, eclecticism",JLPT_1 JLPT
-設定,せってい,"establishment, creation",JLPT_1 JLPT
-説得,せっとく,persuasion,JLPT_1 JLPT
-切ない,せつない,"painful, trying, sad",JLPT_1 JLPT
-絶版,ぜっぱん,out of print,JLPT_1 JLPT
-設立,せつりつ,"establishment, foundation, institution",JLPT_1 JLPT
-攻め,せめ,"attack, offense",JLPT_1 JLPT
-ゼリー,ゼリー,jelly,JLPT_1 JLPT
-セレモニー,セレモニー,ceremony,JLPT_1 JLPT
-世論,せろん,public opinion,JLPT_1 JLPT
-先,せん,"priority, precedence, previous",JLPT_1 JLPT
-繊維,せんい,"fiber, fiber, textile",JLPT_1 JLPT
-全快,ぜんかい,complete recovery of health,JLPT_1 JLPT
-宣教,せんきょう,religious mission,JLPT_1 JLPT
-宣言,せんげん,"declaration, proclamation, announcement",JLPT_1 JLPT
-戦災,せんさい,war damage,JLPT_1 JLPT
-専修,せんしゅう,specialization,JLPT_1 JLPT
-戦術,せんじゅつ,tactics,JLPT_1 JLPT
-センス,センス,"sense (for music, style, tact, etc.)",JLPT_1 JLPT
-潜水,せんすい,diving,JLPT_1 JLPT
-全盛,ぜんせい,height of prosperity,JLPT_1 JLPT
-先代,せんだい,"family predecessor, previous age, previous generation",JLPT_1 JLPT
-先だって,せんだって,"recently, the other day",JLPT_1 JLPT
-先着,せんちゃく,first arrival,JLPT_1 JLPT
-前提,ぜんてい,"preamble, premise, prerequisite",JLPT_1 JLPT
-先天的,せんてんてき,"inherent, congenital, hereditary",JLPT_1 JLPT
-前途,ぜんと,"future prospects, outlook, the journey ahead",JLPT_1 JLPT
-戦闘,せんとう,"battle, fight, combat",JLPT_1 JLPT
-潜入,せんにゅう,"infiltration, sneaking in",JLPT_1 JLPT
-船舶,せんぱく,ship,JLPT_1 JLPT
-全滅,ぜんめつ,annihilation,JLPT_1 JLPT
-専用,せんよう,"exclusive use, personal use",JLPT_1 JLPT
-占領,せんりょう,"occupation, possession, have a room to oneself",JLPT_1 JLPT
-善良,ぜんりょう,"goodness, excellence, virtue",JLPT_1 JLPT
-戦力,せんりょく,war potential,JLPT_1 JLPT
-前例,ぜんれい,precedent,JLPT_1 JLPT
-相応,そうおう,"suitability, fitness",JLPT_1 JLPT
-総会,そうかい,general meeting,JLPT_1 JLPT
-創刊,そうかん,"launching (e.g., newspaper, first issue)",JLPT_1 JLPT
-雑木,ぞうき,"various kinds of small trees, assorted trees",JLPT_1 JLPT
-早急,そうきゅう,urgent,JLPT_1 JLPT
-早急,さっきゅう,urgent,JLPT_1 JLPT
-増強,ぞうきょう,"reinforce, increase",JLPT_1 JLPT
-送金,そうきん,"remittance, sending money",JLPT_1 JLPT
-走行,そうこう,"running a wheeled vehicle (e.g., car, traveling)",JLPT_1 JLPT
-総合,そうごう,"synthesis, generalization",JLPT_1 JLPT
-捜索,そうさく,"search (esp. for someone or something missing, investigation)",JLPT_1 JLPT
-蔵相,ぞうしょう,Minister of Finance,JLPT_1 JLPT
-装飾,そうしょく,ornament,JLPT_1 JLPT
-増進,ぞうしん,"promoting, increase, advance",JLPT_1 JLPT
-相対,そうたい,relative,JLPT_1 JLPT
-壮大,そうだい,"magnificent, grand, majestic",JLPT_1 JLPT
-騒動,そうどう,"strife, riot, rebellion",JLPT_1 JLPT
-遭難,そうなん,"disaster, shipwreck, accident",JLPT_1 JLPT
-相場,そうば,"market price, speculation, estimation",JLPT_1 JLPT
-装備,そうび,equipment,JLPT_1 JLPT
-創立,そうりつ,"establishment, founding",JLPT_1 JLPT
-添える,そえる,"to add to, to attach, to accompany",JLPT_1 JLPT
-ソース,ソース,source,JLPT_1 JLPT
-即座に,そくざに,"immediately, right away",JLPT_1 JLPT
-促進,そくしん,"promotion, acceleration, encouragement",JLPT_1 JLPT
-即する,そくする,"to conform to, to agree with, to be adapted to,",JLPT_1 JLPT
-束縛,そくばく,"restraint, restriction, confinement",JLPT_1 JLPT
-側面,そくめん,"side, sidelight, lateral",JLPT_1 JLPT
-損う,そこなう,"to harm, to hurt",JLPT_1 JLPT
-そこら,そこら,"everywhere, somewhere",JLPT_1 JLPT
-素材,そざい,"raw materials, subject matter",JLPT_1 JLPT
-阻止,そし,"obstruction, check, hindrance",JLPT_1 JLPT
-訴訟,そしょう,"litigation, lawsuit",JLPT_1 JLPT
-育ち,そだち,"breeding, growth",JLPT_1 JLPT
-措置,そち,"measure, step",JLPT_1 JLPT
-ソックス,ソックス,socks,JLPT_1 JLPT
-素っ気無い,そっけない,"cold, short, curt, blunt",JLPT_1 JLPT
-外方,そっぽ,look (or turn) the other way,JLPT_1 JLPT
-備え付ける,そなえつける,"to provide, to equip, to install",JLPT_1 JLPT
-備わる,そなわる,to be furnished with,JLPT_1 JLPT
-具わる,そなわる,to be furnished with,JLPT_1 JLPT
-聳える,そびえる,"to rise, to tower, to soar",JLPT_1 JLPT
-素朴,そぼく,"simplicity, artlessness, naivety",JLPT_1 JLPT
-背く,そむく,"to run counter to, to go against",JLPT_1 JLPT
-染まる,そまる,to be dyed,JLPT_1 JLPT
-染める,そめる,"to dye, to color",JLPT_1 JLPT
-そらす,そらす,"to bend, to warp",JLPT_1 JLPT
-そり (～にのる),そり (～にのる),"sleigh, sled",JLPT_1 JLPT
-反る,そる,"to warp, to be warped, to curve",JLPT_1 JLPT
-それゆえ,それゆえ,"therefore, for that reason, so",JLPT_1 JLPT
-ソロ,ソロ,solo,JLPT_1 JLPT
-揃い,そろい,"set, suit, uniform",JLPT_1 JLPT
-ぞんざい,ぞんざい,"rude, careless, slovenly",JLPT_1 JLPT
-損失,そんしつ,loss,JLPT_1 JLPT
-存続,そんぞく,"duration, continuance",JLPT_1 JLPT
-ダース,ダース,dozen,JLPT_1 JLPT
-対応,たいおう,dealing with,JLPT_1 JLPT
-大家,たいか,"rich family, distinguished family",JLPT_1 JLPT
-退化,たいか,"degeneration, retrogression",JLPT_1 JLPT
-大概,たいがい,"in general, mainly",JLPT_1 JLPT
-体格,たいかく,"physique, constitution",JLPT_1 JLPT
-大金,たいきん,large amount of money,JLPT_1 JLPT
-待遇,たいぐう,"treatment, reception",JLPT_1 JLPT
-対決,たいけつ,"confrontation, showdown",JLPT_1 JLPT
-体験,たいけん,personal experience,JLPT_1 JLPT Intermediate_Japanese_Ln.13 Intermediate_Japanese
-対抗,たいこう,"opposition, antagonism",JLPT_1 JLPT
-退治,たいじ,extermination,JLPT_1 JLPT
-大衆,たいしゅう,general public,JLPT_1 JLPT
-対処,たいしょ,"deal with, cope",JLPT_1 JLPT
-退職,たいしょく,retirement (from office),JLPT_1 JLPT
-題する,だいする,to title,JLPT_1 JLPT
-態勢,たいせい,"attitude, conditions, tendency",JLPT_1 JLPT
-対談,たいだん,"talk, dialogue",JLPT_1 JLPT
-大胆,だいたん,"bold, daring, audacious",JLPT_1 JLPT
-対等,たいとう,equivalent,JLPT_1 JLPT
-台無し,だいなし,"mess, spoiled, (come to) nothing",JLPT_1 JLPT
-滞納,たいのう,"non-payment, default",JLPT_1 JLPT
-対比,たいひ,"contrast, comparison",JLPT_1 JLPT
-タイピスト,タイピスト,typist,JLPT_1 JLPT
-大部,たいぶ,"most (e.g., most part, greater, fairly, a good deal, much)",JLPT_1 JLPT
-大便,だいべん,feces,JLPT_1 JLPT
-代弁,だいべん,speak for another,JLPT_1 JLPT
-待望,たいぼう,"long-expected, waiting",JLPT_1 JLPT
-台本,だいほん,"libretto, scenario",JLPT_1 JLPT
-タイマー,タイマー,timer,JLPT_1 JLPT
-怠慢,たいまん,"negligence, carelessness",JLPT_1 JLPT
-タイミング,タイミング,timing,JLPT_1 JLPT
-タイム,タイム,time,JLPT_1 JLPT
-タイムリー,タイムリー,"timely, run-batted-in (baseball), RBI",JLPT_1 JLPT
-対面,たいめん,"interview, meeting",JLPT_1 JLPT
-代用,だいよう,substitution,JLPT_1 JLPT
-体力,たいりょく,physical strength,JLPT_1 JLPT
-タイル,タイル,tile,JLPT_1 JLPT
-対話,たいわ,"conversation, dialogue",JLPT_1 JLPT
-耐える,たえる,"to endure, to put up with",JLPT_1 JLPT
-堪える,たえる,"to endure, to put up with",JLPT_1 JLPT
-絶える,たえる,"to die out, to become extinct",JLPT_1 JLPT
-断える,たえる,"to cease, to become extinct",JLPT_1 JLPT
-打開,だかい,"solution, breakthrough",JLPT_1 JLPT
-焚火,たきび,(open) fire,JLPT_1 JLPT
-妥協,だきょう,"compromise, giving in",JLPT_1 JLPT
-たくましい,たくましい,"burly, strong, sturdy",JLPT_1 JLPT
-巧み,たくみ,"skill, cleverness",JLPT_1 JLPT
-丈,たけ,"length, height",JLPT_1 JLPT
-打撃,だげき,"blow, damage; batting (baseball)",JLPT_1 JLPT
-妥結,だけつ,agreement,JLPT_1 JLPT
-駄作,ださく,poor work,JLPT_1 JLPT
-足し算,たしざん,addition,JLPT_1 JLPT
-多数決,たすうけつ,majority rule,JLPT_1 JLPT
-助け,たすけ,assistance,JLPT_1 JLPT
-携わる,たずさわる,"to engage, to involve",JLPT_1 JLPT
-漂う,ただよう,"to drift about, to float, to hang in air",JLPT_1 JLPT
-立ち去る,たちさる,"to leave, to depart",JLPT_1 JLPT
-立ち寄る,たちよる,"to stop by, to drop in for a short visit",JLPT_1 JLPT
-抱っこ,だっこ,(child's) hug,JLPT_1 JLPT
-達者,たっしゃ,"skillful, in good health",JLPT_1 JLPT
-脱出,だっしゅつ,escape,JLPT_1 JLPT
-脱する,だっする,"to escape from, to get out",JLPT_1 JLPT
-達成,たっせい,achievement,JLPT_1 JLPT
-脱退,だったい,"secession, withdrawal",JLPT_1 JLPT
-だったら,だったら,if it's the case,JLPT_1 JLPT
-立て替える,たてかえる,"to pay in advance, to pay for another",JLPT_1 JLPT
-建前,たてまえ,position; stance one takes in public; principle,JLPT_1 JLPT Intermediate_Japanese_Ln.15 Intermediate_Japanese
-奉る,たてまつる,"to offer, to do respectfully",JLPT_1 JLPT
-だと,だと,if it's the case,JLPT_1 JLPT
-他動詞,たどうし,transitive verb (direct object),JLPT_1 JLPT
-辿り着く,たどりつく,"to reach, to make it somehow",JLPT_1 JLPT
-辿る,たどる,"to follow (road, to pursue (course), to follow up",JLPT_1 JLPT
-束ねる,たばねる,"to tie up in a bundle, to control",JLPT_1 JLPT
-だぶだぶ,だぶだぶ,"loose, baggy",JLPT_1 JLPT
-他方,たほう,"another side, on the other hand",JLPT_1 JLPT
-多忙,たぼう,busy,JLPT_1 JLPT
-給う,たまう,"to receive, to grant",JLPT_1 JLPT
-魂,たましい,"soul, spirit",JLPT_1 JLPT
-溜まり,たまり,"collected things, gathering place, arrears",JLPT_1 JLPT
-賜る,たまわる,"to grant, to bestow",JLPT_1 JLPT
-保つ,たもつ,"to keep, to preserve, to sustain",JLPT_1 JLPT
-たやすい,たやすい,"easy, simple, light",JLPT_1 JLPT
-多様,たよう,"diversity, variety",JLPT_1 JLPT
-だるい,だるい,"sluggish, feel heavy (tired), languid",JLPT_1 JLPT Intermediate_Japanese_Ln.12 Intermediate_Japanese
-弛み,たるみ,"slack, slackening",JLPT_1 JLPT
-弛む,たるむ,"to slacken, to loosen, to relax",JLPT_1 JLPT
-垂れる,たれる,"to hang, to droop; to drip",JLPT_1 JLPT
-タレント,タレント,"talent, star, personality",JLPT_1 JLPT
-タワー,タワー,tower,JLPT_1 JLPT
-単一,たんいつ,"single, simple, sole",JLPT_1 JLPT
-短歌,たんか,31-syllable Japanese poem,JLPT_1 JLPT
-担架,たんか,"stretcher, litter",JLPT_1 JLPT
-短気,たんき,quick temper,JLPT_1 JLPT
-団結,だんけつ,"unity, union, solidarity",JLPT_1 JLPT
-探検,たんけん,"exploration, expedition",JLPT_1 JLPT
-断言,だんげん,"assertion, declaration, affirmation",JLPT_1 JLPT
-短縮,たんしゅく,"shortening, abbreviation, reduction",JLPT_1 JLPT
-断然,だんぜん,"firmly, absolutely, definitely",JLPT_1 JLPT
-炭素,たんそ,carbon (C),JLPT_1 JLPT
-短大,たんだい,junior college,JLPT_1 JLPT
-単調,たんちょう,"monotony, monotone, dullness",JLPT_1 JLPT
-単独,たんどく,"sole, single",JLPT_1 JLPT
-旦那,だんな,"master (of house), husband (informal)",JLPT_1 JLPT
-短波,たんぱ,short wave,JLPT_1 JLPT
-蛋白質,たんぱくしつ,protein,JLPT_1 JLPT
-ダンプ,ダンプ,dump truck,JLPT_1 JLPT
-断面,だんめん,cross section,JLPT_1 JLPT
-弾力,だんりょく,"elasticity, flexibility",JLPT_1 JLPT
-治安,ちあん,"public order, security",JLPT_1 JLPT
-チームワーク,チームワーク,teamwork,JLPT_1 JLPT
-チェンジ,チェンジ,change,JLPT_1 JLPT
-違える,ちがえる,to change,JLPT_1 JLPT
-畜産,ちくさん,animal husbandry,JLPT_1 JLPT
-畜生,ちくしょう,"beast, brute, damn",JLPT_1 JLPT
-蓄積,ちくせき,"accumulation, accumulate, store",JLPT_1 JLPT
-地形,ちけい,"landform, geographical features, topography",JLPT_1 JLPT
-知性,ちせい,intelligence,JLPT_1 JLPT
-乳,ちち,"milk, breast, loop",JLPT_1 JLPT
-縮まる,ちぢまる,"to be shortened, to be contracted, to shrink",JLPT_1 JLPT
-秩序,ちつじょ,"order, regularity",JLPT_1 JLPT Intermediate_Japanese_Ln.10 Intermediate_Japanese
-窒息,ちっそく,suffocation,JLPT_1 JLPT
-知的,ちてき,intellectual,JLPT_1 JLPT
-着手,ちゃくしゅ,"embarkation, launch",JLPT_1 JLPT
-着色,ちゃくしょく,"coloring, coloring",JLPT_1 JLPT
-着席,ちゃくせき,"sit down, seat",JLPT_1 JLPT
-着目,ちゃくもく,attention,JLPT_1 JLPT
-着陸,ちゃくりく,"landing, touch down",JLPT_1 JLPT
-着工,ちゃっこう,start of (construction) work,JLPT_1 JLPT
-茶の間,ちゃのま,living room (Japanese style),JLPT_1 JLPT
-茶の湯,ちゃのゆ,tea ceremony,JLPT_1 JLPT
-ちやほや,ちやほや,"pamper, make a fuss of, spoil",JLPT_1 JLPT
-チャンネル,チャンネル,a channel,JLPT_1 JLPT
-宙返り,ちゅうがえり,"somersault, looping-the-loop",JLPT_1 JLPT
-中継,ちゅうけい,"relay, hook-up",JLPT_1 JLPT
-忠告,ちゅうこく,"advice, warning",JLPT_1 JLPT
-中傷,ちゅうしょう,"slander, libel, defamation",JLPT_1 JLPT
-中枢,ちゅうすう,"center, mainstay, nucleus",JLPT_1 JLPT
-抽選,ちゅうせん,"lottery, raffle, drawing (of lots)",JLPT_1 JLPT
-中断,ちゅうだん,"interruption, suspension, break",JLPT_1 JLPT
-中毒,ちゅうどく,poisoning,JLPT_1 JLPT
-中腹,ちゅうふく,"mountain side, halfway up",JLPT_1 JLPT
-中立,ちゅうりつ,neutrality,JLPT_1 JLPT
-中和,ちゅうわ,"neutralize, counteract",JLPT_1 JLPT
-～著,～ちょ,written by ~,JLPT_1 JLPT
-腸,ちょう,"bowels, intestines",JLPT_1 JLPT
-蝶,ちょう,butterfly,JLPT_1 JLPT
-超,ちょう,"super-, ultra-, hyper-",JLPT_1 JLPT
-調印,ちょういん,"signature, sign, sealing",JLPT_1 JLPT
-聴覚,ちょうかく,the sense of hearing,JLPT_1 JLPT
-長官,ちょうかん,"chief, (government) secretary",JLPT_1 JLPT
-聴講,ちょうこう,"lecture attendance, auditing",JLPT_1 JLPT
-徴収,ちょうしゅう,"collection, levy",JLPT_1 JLPT
-聴診器,ちょうしんき,stethoscope,JLPT_1 JLPT
-調停,ちょうてい,"arbitration, conciliation, mediation",JLPT_1 JLPT
-重複,ちょうふく,"duplication, repetition, overlapping, redundancy, restoration",JLPT_1 JLPT
-長編,ちょうへん,"long (e.g., novel, film)",JLPT_1 JLPT
-重宝,ちょうほう,"convenient, useful",JLPT_1 JLPT
-調理,ちょうり,cooking,JLPT_1 JLPT
-調和,ちょうわ,harmony,JLPT_1 JLPT
-ちょくちょく,ちょくちょく,"often, frequently, now and then, occasionally",JLPT_1 JLPT
-直面,ちょくめん,confrontation,JLPT_1 JLPT
-著書,ちょしょ,"literary work, book",JLPT_1 JLPT
-貯蓄,ちょちく,savings,JLPT_1 JLPT
-直感,ちょっかん,"intuition, instinct",JLPT_1 JLPT
-著名,ちょめい,"well-known, noted, celebrated",JLPT_1 JLPT
-ちらっと,ちらっと,"at a glance, by accident",JLPT_1 JLPT
-塵,ちり,"dust, dirt",JLPT_1 JLPT
-塵取り,ちりとり,dustpan,JLPT_1 JLPT
-賃金,ちんぎん,wages,JLPT_1 JLPT
-沈殿,ちんでん,"precipitation, deposition, settlement",JLPT_1 JLPT
-沈没,ちんぼつ,"sinking, foundering",JLPT_1 JLPT
-沈黙,ちんもく,"silence, reticence",JLPT_1 JLPT
-陳列,ちんれつ,"exhibition, display, show",JLPT_1 JLPT
-追及,ついきゅう,"investigation, inquiry",JLPT_1 JLPT
-追跡,ついせき,pursuit,JLPT_1 JLPT
-追放,ついほう,"exile, banishment",JLPT_1 JLPT
-費やす,ついやす,"to spend, to devote, to waste",JLPT_1 JLPT
-墜落,ついらく,"falling, crashing",JLPT_1 JLPT
-痛感,つうかん,"feeling keenly, fully realizing",JLPT_1 JLPT
-通常,つうじょう,"common, normal, usual",JLPT_1 JLPT
-痛切,つうせつ,"keen, deep",JLPT_1 JLPT
-杖,つえ,cane,JLPT_1 JLPT
-使い道,つかいみち,use,JLPT_1 JLPT
-仕える,つかえる,"to serve, to work for",JLPT_1 JLPT
-司る,つかさどる,"to rule, to govern, to administer",JLPT_1 JLPT
-つかの間,つかのま,"moment, brief time,",JLPT_1 JLPT
-月並,つきなみ,"conventional, trite, common",JLPT_1 JLPT
-継目,つぎめ,"joint, seam",JLPT_1 JLPT
-尽きる,つきる,"to be used up, to be run out",JLPT_1 JLPT
-尽くす,つくす,"to exhaust, to run out; to devote, to serve",JLPT_1 JLPT
-つくづく,つくづく,"completely, really",JLPT_1 JLPT
-作り,つくり,"make up, structure, physique",JLPT_1 JLPT
-造り,つくり,"make up, structure, physique",JLPT_1 JLPT
-繕う,つくろう,"to mend, to repair",JLPT_1 JLPT
-付け加える,つけくわえる,to add one thing to another,JLPT_1 JLPT
-告げる,つげる,to inform,JLPT_1 JLPT
-つじつま (はなしの～),つじつま (はなしの～),"coherence, consistency",JLPT_1 JLPT
-筒,つつ,"pipe, tube",JLPT_1 JLPT
-突く,つつく,"to thrust, to strike, to attack; to poke, to nudge, to pick at",JLPT_1 JLPT
-突っ突く,つっつく,to prompt someone,JLPT_1 JLPT
-謹む,つつしむ,"to be careful, to be chaste or discreet",JLPT_1 JLPT
-突っ張る,つっぱる,"to support, to become stiff; to thrust (ones opponent), to stick to (ones opinion), to insist on",JLPT_1 JLPT
-務まる,つとまる,"be equal, be fit",JLPT_1 JLPT
-勤め先,つとめさき,place of work,JLPT_1 JLPT
-努めて,つとめて,"make an effort!, work hard!",JLPT_1 JLPT
-津波,つなみ,"tsunami, tidal wave",JLPT_1 JLPT
-つねる,つねる,to pinch,JLPT_1 JLPT
-角,つの,horn,JLPT_1 JLPT
-募る,つのる,"to invite, to solicit help, participation, etc",JLPT_1 JLPT
-唾,つば,"saliva, spit, sputum",JLPT_1 JLPT
-呟く,つぶやく,"to mutter, to murmur",JLPT_1 JLPT
-つぶら,つぶら,"round, rotund",JLPT_1 JLPT
-つぶる (めを～),つぶる (めを～),to close the eyes,JLPT_1 JLPT
-壷,つぼ,"jar, pot, vase",JLPT_1 JLPT
-蕾,つぼみ,"bud, flower bud",JLPT_1 JLPT
-連なる,つらなる,"to extend, to stretch out, to stand in a row",JLPT_1 JLPT
-貫く,つらぬく,to go through,JLPT_1 JLPT
-連ねる,つらねる,"to link, to join, to put together",JLPT_1 JLPT
-釣り鐘,つりがね,temple bell (for striking),JLPT_1 JLPT
-吊り革,つりかわ,strap,JLPT_1 JLPT
-手当,てあて,"allowance, compensation; treatment",JLPT_1 JLPT
-定義,ていぎ,definition,JLPT_1 JLPT
-提供,ていきょう,"offer, program sponsoring",JLPT_1 JLPT
-提携,ていけい,"cooperation, tie-up, joint business",JLPT_1 JLPT
-体裁,ていさい,"decency, style, form, appearance",JLPT_1 JLPT
-提示,ていじ,"presentation, exhibit, suggest, citation",JLPT_1 JLPT
-ティシュペーパー,ティシュペーパー,tissue,JLPT_1 JLPT
-定食,ていしょく,"fixed-price lunch, set meal, dinner",JLPT_1 JLPT Intermediate_Japanese_Ln.13 Intermediate_Japanese
-訂正,ていせい,"correction, revision",JLPT_1 JLPT
-停滞,ていたい,"stagnation, tie-up, congestion, retention",JLPT_1 JLPT
-邸宅,ていたく,"mansion, residence",JLPT_1 JLPT
-定年,ていねん,retirement age,JLPT_1 JLPT
-堤防,ていぼう,"bank, weir",JLPT_1 JLPT
-手遅れ,ておくれ,being (too); belated treatment,JLPT_1 JLPT
-でかい,でかい,huge,JLPT_1 JLPT
-手掛かり,てがかり,"hint, clue, key",JLPT_1 JLPT
-手掛ける,てがける,"to handle, to manage, to work with",JLPT_1 JLPT
-手数,てかず,"trouble, labor, handling",JLPT_1 JLPT
-手軽,てがる,"easy, simple, cheap",JLPT_1 JLPT
-適応,てきおう,"adaptation, accommodation, conformity",JLPT_1 JLPT
-適宜,てきぎ,suitability,JLPT_1 JLPT
-適性,てきせい,aptitude,JLPT_1 JLPT
-できもの,できもの,"boil, rash",JLPT_1 JLPT
-手際,てぎわ,"performance, skill, tact",JLPT_1 JLPT
-出くわす,でくわす,"to happen to meet, to come across",JLPT_1 JLPT
-手順,てじゅん,"process, procedure, protocol",JLPT_1 JLPT Intermediate_Japanese_Ln.12 Intermediate_Japanese
-手錠,てじょう,"handcuffs, manacles",JLPT_1 JLPT
-手数,てすう,"trouble, labor, handling",JLPT_1 JLPT
-デコレーション,デコレーション,decoration,JLPT_1 JLPT
-手近,てぢか,"near, handy, familiar",JLPT_1 JLPT
-てっきり,てっきり,"surely, certainly, beyond doubt",JLPT_1 JLPT
-鉄鋼,てっこう,iron and steel,JLPT_1 JLPT
-デッサン,デッサン,rough sketch (FRE: dessin),JLPT_1 JLPT
-徹する,てっする,"to devote oneself, to believe in",JLPT_1 JLPT
-てっぺん,てっぺん,"top, summit, apex",JLPT_1 JLPT
-鉄棒,てつぼう,"iron rod, crowbar, horizontal bar (gymnastics)",JLPT_1 JLPT
-出直し,でなおし,"adjustment, touch up",JLPT_1 JLPT
-掌,てのひら,the palm,JLPT_1 JLPT
-手配,てはい,"arrangement, search (by police)",JLPT_1 JLPT
-手筈,てはず,"arrangement, plan, program",JLPT_1 JLPT
-手引,てびき,"guidance, guide, introduction",JLPT_1 JLPT
-手本,てほん,"model, pattern",JLPT_1 JLPT
-手回し,てまわし,"preparations, arrangements",JLPT_1 JLPT
-手元,てもと,"(money) on hand or at home, one's purse; usual skill",JLPT_1 JLPT
-デモンストレーション,デモンストレーション,demonstration,JLPT_1 JLPT
-照り返す,てりかえす,"to reflect, to throw back light",JLPT_1 JLPT
-テレックス,テレックス,"telex, teletypewriter exchange",JLPT_1 JLPT
-手分け,てわけ,division of labor,JLPT_1 JLPT
-天,てん,"heaven, sky",JLPT_1 JLPT
-田園,でんえん,"country, rural districts",JLPT_1 JLPT
-天下,てんか,"the world, whole country",JLPT_1 JLPT
-転回,てんかい,"revolution, rotation",JLPT_1 JLPT
-連休,れんきゅう,consecutive holidays,JLPT_1 JLPT
-レンジ,レンジ,"range, stove",JLPT_1 JLPT
-連日,れんじつ,every day,JLPT_1 JLPT
-連帯,れんたい,solidarity,JLPT_1 JLPT
-レンタカー,レンタカー,rented car,JLPT_1 JLPT
-連中,れんちゅう,"colleagues, company, a lot",JLPT_1 JLPT
-レントゲン,レントゲン,X-ray (lit: Roentgen),JLPT_1 JLPT
-連邦,れんぽう,"commonwealth, federation of states",JLPT_1 JLPT
-連盟,れんめい,"league, union, alliance",JLPT_1 JLPT
-老衰,ろうすい,"senility, senile decay",JLPT_1 JLPT
-朗読,ろうどく,"reading aloud, recitation",JLPT_1 JLPT
-浪費,ろうひ,"waste, extravagance",JLPT_1 JLPT
-労力,ろうりょく,"labor, effort, trouble",JLPT_1 JLPT
-ロープウエイ,ロープウエイ,"ropeway, aerial tram",JLPT_1 JLPT
-ロープ,ロープ,rope,JLPT_1 JLPT
-ろくな,ろくな,"satisfactory, decent",JLPT_1 JLPT
-露骨,ろこつ,"blunt, outspoken; conspicuous; broad, suggestive",JLPT_1 JLPT
-ロマンチック,ロマンチック,romantic,JLPT_1 JLPT
-論議,ろんぎ,discussion,JLPT_1 JLPT
-論理,ろんり,logic,JLPT_1 JLPT
-惑星,わくせい,planet,JLPT_1 JLPT
-技,わざ,"art, technique",JLPT_1 JLPT
-わざわざ,わざわざ,"take the trouble (to do), doing something especially rather than incidentally",JLPT_1 JLPT Intermediate_Japanese_Ln.9 Intermediate_Japanese
-煩わしい,わずらわしい,"burdensome, troublesome, complicated",JLPT_1 JLPT Intermediate_Japanese_Ln.15 Intermediate_Japanese
-渡り鳥,わたりどり,"migratory bird, bird of passage",JLPT_1 JLPT
-ワット,ワット,watt,JLPT_1 JLPT
-詫び,わび,apology,JLPT_1 JLPT
-和文,わぶん,"Japanese text, sentence in Japanese",JLPT_1 JLPT
-藁,わら,straw,JLPT_1 JLPT
-～割,～わり,~ percent,JLPT_1 JLPT
-割当,わりあて,"allotment, allocation, quota",JLPT_1 JLPT
-割込む,わりこむ,"to cut in, to disturb",JLPT_1 JLPT
-悪者,わるもの,"bad fellow, rascal",JLPT_1 JLPT
-我,われ,"me, oneself, self, ego",JLPT_1 JLPT
-捗る,はかどる,"to make progress, to move right ahead (with the work), to advance",JLPT_1 JLPT
-はかない,はかない,"short-lived, momentary, ephemeral",JLPT_1 JLPT
-ばかばかしい,ばかばかしい,stupid,JLPT_1 JLPT
-破棄,はき,"revocation, annulment, breaking (e.g., treaty)",JLPT_1 JLPT
-剥ぐ,はぐ,"to tear off, to peel off, to rip off",JLPT_1 JLPT
-迫害,はくがい,persecution,JLPT_1 JLPT
-薄弱,はくじゃく,"feebleness, weakness, weak",JLPT_1 JLPT
-白状,はくじょう,confession,JLPT_1 JLPT
-漠然,ばくぜん,"obscure, vague, equivocal",JLPT_1 JLPT
-爆弾,ばくだん,bomb,JLPT_1 JLPT
-爆破,ばくは,"blast, explosion, blow up",JLPT_1 JLPT
-暴露,ばくろ,"disclosure, exposure, revelation",JLPT_1 JLPT
-励ます,はげます,"to encourage, to cheer, to raise (the voice)",JLPT_1 JLPT Intermediate_Japanese_Ln.13 Intermediate_Japanese
-励む,はげむ,"to be zealous, to make an effort",JLPT_1 JLPT
-剥げる,はげる,"to come off, to be worn off, to fade, to discolor",JLPT_1 JLPT
-化ける,ばける,"to disguise, to take the form of",JLPT_1 JLPT
-派遣,はけん,"dispatch, send",JLPT_1 JLPT
-恥,はじ,"shame, embarrassment",JLPT_1 JLPT
-弾く,はじく,"to play (piano, guitar)",JLPT_1 JLPT
-パジャマ,パジャマ,pajamas,JLPT_1 JLPT
-恥じらう,はじらう,"to feel shy, to be bashful, to blush",JLPT_1 JLPT
-恥じる,はじる,to feel ashamed,JLPT_1 JLPT
-橋渡し,はしわたし,"bridge building', mediation",JLPT_1 JLPT
-弾む,はずむ,"to bounce, to be encouraged, to splurge on",JLPT_1 JLPT
-破損,はそん,damage,JLPT_1 JLPT
-叩く,はたく,"to strike, to clap, to dust, to beat",JLPT_1 JLPT
-裸足,はだし,barefoot,JLPT_1 JLPT
-果たす,はたす,"to accomplish, to fulfill, to carry out, to achieve",JLPT_1 JLPT
-蜂蜜,はちみつ,honey,JLPT_1 JLPT
-パチンコ,パチンコ,pachinko (Japanese pinball),JLPT_1 JLPT
-罰,ばつ,"punishment, penalty",JLPT_1 JLPT
-発育,はついく,"(physical) growth, development",JLPT_1 JLPT
-発芽,はつが,germination,JLPT_1 JLPT
-発掘,はっくつ,"excavation, exhumation; discovery (e.g., new talent)",JLPT_1 JLPT
-発言,はつげん,"utterance, speech, proposal",JLPT_1 JLPT
-バッジ,バッジ,badge,JLPT_1 JLPT
-発生,はっせい,"outbreak, spring forth, occurrence",JLPT_1 JLPT
-仕立てる,したてる,"to tailor, to make, to prepare",JLPT_1 JLPT
-下取り,したどり,"trade in, part exchange",JLPT_1 JLPT
-下火,したび,"burning low, waning, declining",JLPT_1 JLPT
-実,じつ,"fruit, good result",JLPT_1 JLPT
-実家,じっか,(one's parents') home,JLPT_1 JLPT
-失格,しっかく,"disqualification, elimination, incapacity (legal)",JLPT_1 JLPT
-質疑,しつぎ,question,JLPT_1 JLPT
-失脚,しっきゃく,"losing one's standing, being overthrown, falling",JLPT_1 JLPT
-実業家,じつぎょうか,"industrialist, businessman",JLPT_1 JLPT
-シック,シック,chic,JLPT_1 JLPT
-じっくり,じっくり,"deliberately, carefully",JLPT_1 JLPT
-躾,しつけ,"discipline, training",JLPT_1 JLPT
-躾ける,しつける,"to discipline, to teach manners",JLPT_1 JLPT
-実践,じっせん,"practice, put into practice",JLPT_1 JLPT
-質素,しっそ,"simplicity, modesty, frugality",JLPT_1 JLPT
-実態,じったい,"truth, fact",JLPT_1 JLPT
-失調,しっちょう,"lack of harmony, imbalance",JLPT_1 JLPT
-嫉妬,しっと,jealousy,JLPT_1 JLPT
-実費,じっぴ,"actual expense, cost price",JLPT_1 JLPT
-指摘,してき,"pointing out, identification",JLPT_1 JLPT
-自転,じてん,"rotation, spin",JLPT_1 JLPT
-助動詞,じょどうし,auxiliary verb,JLPT_1 JLPT
-淑やか,しとやか,graceful,JLPT_1 JLPT
-萎びる,しなびる,"to shrivel, to fade",JLPT_1 JLPT
-シナリオ,シナリオ,scenario,JLPT_1 JLPT
-しなやか,しなやか,"supple, flexible, elastic",JLPT_1 JLPT
-屎尿,しにょう,human waste,JLPT_1 JLPT
-地主,じぬし,landlord,JLPT_1 JLPT
-凌ぐ,しのぐ,"to outdo, to surpass; to endure",JLPT_1 JLPT
-芝,しば,lawn,JLPT_1 JLPT
-始発,しはつ,first train,JLPT_1 JLPT
-耳鼻科,じびか,otolaryngology,JLPT_1 JLPT
-私物,しぶつ,"private property, personal effects",JLPT_1 JLPT
-しぶとい,しぶとい,"tenacious, stubborn",JLPT_1 JLPT
-司法,しほう,administration of justice,JLPT_1 JLPT
-始末,しまつ,disposal; cleaning up afterwards,JLPT_1 JLPT
-染みる,しみる,to soak; pierce,JLPT_1 JLPT
-使命,しめい,"mission, errand, message",JLPT_1 JLPT
-地元,じもと,local,JLPT_1 JLPT
-視野,しや,"field of vision, outlook",JLPT_1 JLPT
-弱,じゃく,"delicate, supple",JLPT_1 JLPT
-社交,しゃこう,social life,JLPT_1 JLPT
-ジャズ,ジャズ,jazz,JLPT_1 JLPT
-謝絶,しゃぜつ,refusal,JLPT_1 JLPT
-社宅,しゃたく,company owned house,JLPT_1 JLPT
-若干,じゃっかん,"some, few, number of",JLPT_1 JLPT
-三味線,しゃみせん,three-stringed Japanese guitar,JLPT_1 JLPT
-斜面,しゃめん,"slope, slanting surface, bevel",JLPT_1 JLPT
-砂利,じゃり,"gravel, ballast, pebbles",JLPT_1 JLPT
-洒落る,しゃれる,"to joke, to play on words; stylish",JLPT_1 JLPT
-ジャンパー,ジャンパー,"jacket, jumper",JLPT_1 JLPT
-ジャンプ,ジャンプ,jump,JLPT_1 JLPT
-ジャンボ,ジャンボ,jumbo,JLPT_1 JLPT
-ジャンル,ジャンル,genre,JLPT_1 JLPT
-主,しゅ,"owner, master, god",JLPT_1 JLPT
-種,しゅ,seed; variety,JLPT_1 JLPT
-私有,しゆう,private ownership,JLPT_1 JLPT
-～宗,～しゅう,sect,JLPT_1 JLPT
-収益,しゅうえき,"earnings, proceeds, returns",JLPT_1 JLPT
-修学,しゅうがく,learning,JLPT_1 JLPT
-周期,しゅうき,"cycle, period",JLPT_1 JLPT
-衆議院,しゅうぎいん,"Lower House, House of Representatives",JLPT_1 JLPT
-就業,しゅうぎょう,"employment, starting work",JLPT_1 JLPT
-従業員,じゅうぎょういん,"employee, worker",JLPT_1 JLPT
-集計,しゅうけい,"totalization, aggregate",JLPT_1 JLPT
-襲撃,しゅうげき,"attack, charge, raid",JLPT_1 JLPT
-収支,しゅうし,income and expenditure,JLPT_1 JLPT
-終始,しゅうし,from beginning to end; consistent(ly),JLPT_1 JLPT
-修士,しゅうし,Masters degree program,JLPT_1 JLPT
-従事,じゅうじ,"engaging, pursuing, following",JLPT_1 JLPT
-終日,しゅうじつ,all day,JLPT_1 JLPT
-充実,じゅうじつ,"fullness, perfection",JLPT_1 JLPT
-収集,しゅうしゅう,"gathering up, collection",JLPT_1 JLPT
-十字路,じゅうじろ,crossroads,JLPT_1 JLPT
-執着,しゅうじゃく,"attachment, adhesion, tenacity",JLPT_1 JLPT
-執着,しゅうちゃく,"attachment, adhesion, tenacity",JLPT_1 JLPT
-柔軟,じゅうなん,flexible,JLPT_1 JLPT
-重複,じゅうふく,"duplication, repetition, overlapping",JLPT_1 JLPT
-収容,しゅうよう,accommodation; seating; custody,JLPT_1 JLPT
-従来,じゅうらい,"up to now, so far, traditional",JLPT_1 JLPT
-守衛,しゅえい,"security guard, doorkeeper",JLPT_1 JLPT
-主演,しゅえん,"starring, playing the leading part",JLPT_1 JLPT
-主観,しゅかん,"subjectivity, subject, ego",JLPT_1 JLPT
-修行,しゅぎょう,"pursuit of knowledge, training, ascetic practice",JLPT_1 JLPT
-塾,じゅく,after-school (cram) school,JLPT Intermediate_Japanese JLPT_1 Intermediate_Japanese_Ln.5 Genki_Ln.22 Genki
-祝賀,しゅくが,"celebration, congratulations",JLPT_1 JLPT
-宿命,しゅくめい,"fate, destiny, predestination",JLPT_1 JLPT
-手芸,しゅげい,handicrafts,JLPT_1 JLPT
-主権,しゅけん,sovereignty,JLPT_1 JLPT
-主催,しゅさい,"organization, sponsorship, to host",JLPT_1 JLPT
-取材,しゅざい,"coverage, collecting data",JLPT_1 JLPT
-趣旨,しゅし,"object, meaning",JLPT_1 JLPT
-種々,しゅじゅ,variety,JLPT_1 JLPT
-主食,しゅしょく,staple food,JLPT_1 JLPT
-主人公,しゅじんこう,protagonist,JLPT_1 JLPT
-主体,しゅたい,"subject, main constituent",JLPT_1 JLPT
-主題,しゅだい,"subject, theme, motif",JLPT_1 JLPT
-出演,しゅつえん,"leading performer, stage appearance",JLPT_1 JLPT
-出血,しゅっけつ,bleeding,JLPT_1 JLPT
-出現,しゅつげん,"appearance, arrival",JLPT_1 JLPT
-出産,しゅっさん,childbirth,JLPT_1 Intermediate_Japanese_Ln.14 JLPT Intermediate_Japanese
-出社,しゅっしゃ,come to work,JLPT_1 JLPT
-出生,しゅっしょう,birth,JLPT_1 JLPT
-出生,しゅっせい,birth,JLPT_1 JLPT
-微量,びりょう,"minuscule amount, extremely small quantity",JLPT_1 JLPT
-昼飯,ひるめし,lunch (mid-day meal),JLPT_1 JLPT
-比例,ひれい,proportion,JLPT_1 JLPT
-疲労,ひろう,"fatigue, weariness",JLPT_1 JLPT
-敏感,びんかん,"sensibility, susceptibility, sensitive (to)",JLPT_1 JLPT
-貧困,ひんこん,"poverty, lack",JLPT_1 JLPT
-品質,ひんしつ,quality,JLPT_1 JLPT
-貧弱,ひんじゃく,"poor, meager, insubstantial",JLPT_1 JLPT
-品種,ひんしゅ,"breed, type, variety",JLPT_1 JLPT
-ヒント,ヒント,hint,JLPT_1 JLPT
-頻繁,ひんぱん,frequency,JLPT_1 JLPT
-貧乏,びんぼう,"poverty, destitute, poor",JLPT_1 JLPT
-ファイト,ファイト,fight,JLPT_1 JLPT
-ファイル,ファイル,file; portfolio,JLPT_1 Genki_Ln.16 JLPT Genki
-ファン,ファン,fan,JLPT_1 JLPT
-不意,ふい,"sudden, abrupt, unexpected",JLPT_1 JLPT
-フィルタ,フィルタ,filter,JLPT_1 JLPT
-封,ふう,seal,JLPT_1 JLPT
-封鎖,ふうさ,"blockade, freezing (funds)",JLPT_1 JLPT
-風車,ふうしゃ,windmill,JLPT_1 JLPT
-風習,ふうしゅう,custom,JLPT_1 JLPT
-風俗,ふうぞく,"manners, customs; sex industry",JLPT_1 JLPT
-ブーツ,ブーツ,boots,JLPT_1 JLPT
-風土,ふうど,"natural features, climate",JLPT_1 JLPT
-ブーム,ブーム,boom,JLPT_1 JLPT
-フォーム,フォーム,foam; form,JLPT_1 JLPT
-部下,ぶか,one's subordinate,JLPT Intermediate_Japanese JLPT_1 Intermediate_Japanese_Ln.9 Genki_Ln.22 Genki
-不可欠,ふかけつ,"indispensable, essential",JLPT_1 JLPT
-ぶかぶか,ぶかぶか,"too big, baggy",JLPT_1 JLPT
-不吉,ふきつ,"ominous, sinister, bad luck, ill omen",JLPT_1 JLPT
-不況,ふきょう,"recession, depression, slump",JLPT_1 JLPT
-布巾,ふきん,dish cloth,JLPT_1 JLPT
-複合,ふくごう,"composite, complex",JLPT_1 JLPT
-福祉,ふくし,"welfare, well-being",JLPT_1 JLPT
-覆面,ふくめん,"mask, veil, disguise",JLPT_1 JLPT
-膨れる,ふくれる,"to swell (out), to be inflated, to bulge",JLPT_1 JLPT
-不景気,ふけいき,"business recession, hard times, depression",JLPT_1 JLPT
-耽る,ふける,"to indulge in, to give oneself up to, to be absorbed in",JLPT_1 JLPT
-老ける,ふける,to age,JLPT_1 JLPT
-富豪,ふごう,"wealthy person, millionaire",JLPT_1 JLPT
-布告,ふこく,"edict, ordinance, proclamation",JLPT_1 JLPT
-ブザー,ブザー,buzzer,JLPT_1 JLPT
-負債,ふさい,"debt, liabilities",JLPT_1 JLPT
-不在,ふざい,absence,JLPT_1 JLPT
-ふさわしい,ふさわしい,appropriate,JLPT_1 JLPT
-不順,ふじゅん,"irregularity, unseasonableness",JLPT_1 JLPT
-負傷,ふしょう,"injury, wound",JLPT_1 JLPT
-侮辱,ぶじょく,"insult, contempt, slight",JLPT_1 JLPT
-不審,ふしん,"suspicious, doubt, infidelity",JLPT_1 JLPT
-不振,ふしん,"dullness, slump, stagnation",JLPT_1 JLPT
-武装,ぶそう,"arms, armament, armed",JLPT_1 JLPT
-札,ふだ,"token, label; ticket, card; charm, talisman",JLPT_1 JLPT
-負担,ふたん,burden; load,JLPT_1 Intermediate_Japanese_Ln.14 JLPT Intermediate_Japanese
-不調,ふちょう,"bad condition, disorder, slump",JLPT_1 JLPT
-復活,ふっかつ,"revival (e.g., musical), restoration",JLPT_1 JLPT
-物議,ぶつぎ,public discussion (criticism),JLPT_1 JLPT
-復旧,ふっきゅう,"restoration, restitution, rehabilitation",JLPT_1 JLPT
-復興,ふっこう,"revival, renaissance, reconstruction",JLPT_1 JLPT
-物資,ぶっし,"goods, materials",JLPT_1 JLPT
-仏像,ぶつぞう,Buddhist image (statue),JLPT_1 JLPT
-物体,ぶったい,object,JLPT_1 JLPT
-沸騰,ふっとう,"boiling, seething",JLPT_1 JLPT
-不当,ふとう,"injustice, impropriety, unfair",JLPT_1 JLPT
-不動産,ふどうさん,real estate,JLPT_1 JLPT
-無難,ぶなん,"safety, security",JLPT_1 JLPT
-赴任,ふにん,(proceeding to) new appointment,JLPT_1 JLPT
-腐敗,ふはい,"decay, depravity",JLPT_1 JLPT
-不評,ふひょう,"bad reputation, disgrace, unpopularity",JLPT_1 JLPT
-不服,ふふく,"dissatisfaction, discontent, disapproval",JLPT_1 JLPT
-普遍,ふへん,"universality, ubiquity, omnipresence",JLPT_1 JLPT
-踏まえる,ふまえる,"to be based on, to have origin in",JLPT_1 JLPT
-踏み込む,ふみこむ,"to step into (someone else's territory, to break into, to raid",JLPT_1 JLPT
-不明,ふめい,"unknown, ambiguous",JLPT_1 JLPT
-部門,ぶもん,"class, group, category, department, field, branch",JLPT_1 JLPT
-扶養,ふよう,"support, maintenance",JLPT_1 JLPT
-ふらふら,ふらふら,"unsteady on one's feet, totter, dizzy",JLPT_1 JLPT
-ぶらぶら,ぶらぶら,"dangle heavily, sway to and fro, stroll idly",JLPT_1 JLPT
-振り返る,ふりかえる,"to turn head, to turn around, to look back",JLPT_1 JLPT
-振り出し,ふりだし,"outset, starting point, drawing or issuing (draft)",JLPT_1 JLPT
-不良,ふりょう,"badness, delinquent, failure",JLPT_1 JLPT
-浮力,ふりょく,buoyancy,JLPT_1 JLPT
-武力,ぶりょく,"armed might, military power, the sword, force",JLPT_1 JLPT
-ブル,ブル,bull,JLPT_1 JLPT
-震わせる,ふるわせる,"to be shaking, to be trembling",JLPT_1 JLPT
-無礼,ぶれい,"impolite, rude",JLPT_1 JLPT
-付録,ふろく,"appendix, supplement",JLPT_1 JLPT
-フロント,フロント,front,JLPT_1 JLPT
-憤慨,ふんがい,"indignation, resentment",JLPT_1 JLPT
-文化財,ぶんかざい,"cultural assets, cultural property",JLPT_1 JLPT
-分業,ぶんぎょう,"division of labor, specialization, assembly-line production",JLPT_1 JLPT
-文語,ぶんご,"written language, literary language",JLPT_1 JLPT
-分散,ぶんさん,"dispersion, decentralization, variance (statistics)",JLPT_1 JLPT
-分子,ぶんし,"numerator, molecule",JLPT_1 JLPT
-紛失,ふんしつ,losing something,JLPT_1 JLPT
-噴出,ふんしゅつ,"spewing, gushing, spouting",JLPT_1 JLPT
-文書,ぶんしょ,"document, writing",JLPT_1 JLPT
-紛争,ふんそう,"dispute, trouble, strife",JLPT_1 JLPT
-ふんだん,ふんだん,"plentiful, abundant, lavish",JLPT_1 JLPT
-分担,ぶんたん,"apportionment, sharing",JLPT_1 JLPT
-奮闘,ふんとう,"hard struggle, strenuous effort",JLPT_1 JLPT
-分配,ぶんぱい,"division, sharing",JLPT_1 JLPT
-分母,ぶんぼ,denominator,JLPT_1 JLPT
-粉末,ふんまつ,fine powder,JLPT_1 JLPT
-分離,ぶんり,"separation, detachment, segregation",JLPT_1 JLPT
-分裂,ぶんれつ,"split, division, break up",JLPT_1 JLPT
-ペア,ペア,"pair, pear",JLPT_1 JLPT
-兵器,へいき,"arms, weapons, ordinance",JLPT_1 JLPT
-閉口,へいこう,shut mouth,JLPT_1 JLPT
-閉鎖,へいさ,"closing, closure, shutdown",JLPT_1 JLPT
-兵士,へいし,soldier,JLPT_1 JLPT
-平常,へいじょう,"normal, usual",JLPT_1 JLPT
-平方,へいほう,"square (e.g., meter, square)",JLPT_1 JLPT
-並列,へいれつ,"arrangement, parallel, abreast",JLPT_1 JLPT
-ベース,ベース,"base, bass",JLPT_1 JLPT
-辟易,へきえき,"wince, shrink back, succumbing to, being frightened",JLPT_1 JLPT
-ぺこぺこ,ぺこぺこ,"fawn, be very hungry",JLPT_1 JLPT
-ベスト,ベスト,best; vest,JLPT_1 JLPT
-ベストセラー,ベストセラー,best-seller,JLPT_1 JLPT
-隔たる,へだたる,to be distant,JLPT_1 JLPT
-縁,へり,edge,JLPT_1 JLPT
-へりくだる,へりくだる,to deprecate oneself and praise the listener,JLPT_1 JLPT
-弁解,べんかい,"explanation, justification, excuse",JLPT_1 JLPT
-変革,へんかく,"change, reform(the) Reformation",JLPT_1 JLPT
-返還,へんかん,"return, restoration",JLPT_1 JLPT
-便宜,べんぎ,"convenience, accommodation",JLPT_1 JLPT
-偏見,へんけん,"prejudice, narrow view",JLPT_1 JLPT
-弁護,べんご,"defense, pleading, advocacy",JLPT_1 JLPT
-返済,へんさい,repayment,JLPT_1 JLPT
-弁償,べんしょう,"compensation, reparation, reimbursement",JLPT_1 JLPT
-変遷,へんせん,"change, transition, vicissitudes",JLPT_1 JLPT
-返答,へんとう,reply,JLPT_1 JLPT
-変動,へんどう,"change, fluctuation",JLPT_1 JLPT
-弁論,べんろん,"discussion, debate, argument",JLPT_1 JLPT
-穂,ほ,"ear (of plant), head (of plant)",JLPT_1 JLPT
-保育,ほいく,"nursing, nurturing, rearing",JLPT_1 JLPT
-ボイコット,ボイコット,boycott,JLPT_1 JLPT
-ポイント,ポイント,point,JLPT_1 JLPT
-法案,ほうあん,bill (law),JLPT_1 JLPT
-防衛,ぼうえい,"defense, protection, self-defense",JLPT_1 JLPT
-防火,ぼうか,"fire prevention, fire fighting, fire proof",JLPT_1 JLPT
-崩壊,ほうかい,"collapse, decay (physics), crumbling",JLPT_1 JLPT
-妨害,ぼうがい,"disturbance, obstruction, interference",JLPT_1 JLPT
-法学,ほうがく,"law, jurisprudence",JLPT_1 JLPT
-封建,ほうけん,feudalistic,JLPT_1 JLPT
-豊作,ほうさく,"abundant harvest, bumper crop",JLPT_1 JLPT
-方策,ほうさく,"plan, policy",JLPT_1 JLPT
-奉仕,ほうし,"attendance, service",JLPT_1 JLPT
-方式,ほうしき,"form, method, system",JLPT_1 JLPT
-放射,ほうしゃ,"radiation, emission",JLPT_1 JLPT
-放射能,ほうしゃのう,radioactivity,JLPT_1 JLPT
-報酬,ほうしゅう,"remuneration, recompense, reward",JLPT_1 JLPT
-放出,ほうしゅつ,"release, emit",JLPT_1 JLPT
-報じる,ほうじる,"to inform, to report",JLPT_1 JLPT
-報ずる,ほうずる,"to inform, to report",JLPT_1 JLPT
-紡績,ぼうせき,spinning,JLPT_1 JLPT
-呆然,ぼうぜん,"dumbfounded, overcome with surprise",JLPT_1 JLPT
-放置,ほうち,"leave as is, leave alone, neglect",JLPT_1 JLPT
-膨張,ぼうちょう,"expansion, swelling, increase",JLPT_1 JLPT
-法廷,ほうてい,courtroom,JLPT_1 JLPT
-報道,ほうどう,"coverage, report",JLPT_1 JLPT
-冒頭,ぼうとう,"beginning, start, outset",JLPT_1 JLPT
-暴動,ぼうどう,"insurrection, riot, uprising",JLPT_1 JLPT
-褒美,ほうび,"reward, prize",JLPT_1 JLPT
-暴風,ぼうふう,"storm, windstorm, gale",JLPT_1 JLPT
-葬る,ほうむる,"to bury, to entomb",JLPT_1 JLPT
-放り込む,ほうりこむ,to throw into,JLPT_1 JLPT
-放り出す,ほうりだす,"to throw out, to give up, to abandon",JLPT_1 JLPT
-暴力,ぼうりょく,violence,JLPT_1 JLPT
-飽和,ほうわ,saturation,JLPT_1 JLPT
-ホース,ホース,hose,JLPT_1 JLPT
-ポーズ,ポーズ,pause,JLPT_1 JLPT
-ホール,ホール,hall; hole,JLPT_1 JLPT
-保温,ほおん,"retaining warmth, keeping heat in, heat insulation",JLPT_1 JLPT
-捕獲,ほかく,"capture, seizure",JLPT_1 JLPT
-保管,ほかん,"custody, safekeeping, storage",JLPT_1 JLPT
-補給,ほきゅう,"supply, supplying, replenishment",JLPT_1 JLPT
-補強,ほきょう,reinforcement,JLPT_1 JLPT
-募金,ぼきん,"fund-raising, collection of funds",JLPT_1 JLPT
-牧師,ぼくし,"pastor, minister, clergyman",JLPT_1 JLPT
-捕鯨,ほげい,whaling,JLPT_1 JLPT
-惚ける,ぼける,"to grow senile, to fade",JLPT_1 JLPT
-保険,ほけん,"insurance, guarantee",JLPT_1 JLPT
-母校,ぼこう,alma mater,JLPT_1 JLPT
-母国,ぼこく,one's home country (same as 自分の国 (じぶんのくに)),JLPT_1 JLPT Intermediate_Japanese_Ln.15 Intermediate_Japanese
-誇る,ほこる,"to boast of, to be proud of",JLPT_1 JLPT
-綻びる,ほころびる,"to come apart at the seams, to smile broadly",JLPT_1 JLPT
-干し～,ほし～,dried ~,JLPT_1 JLPT
-ポジション,ポジション,position,JLPT_1 JLPT
-干し物,ほしもの,dried washing (clothes,JLPT_1 JLPT
-保守,ほしゅ,"conservative, maintaining",JLPT_1 JLPT
-補充,ほじゅう,"supplementation, replenishment, replenishing",JLPT_1 JLPT
-補助,ほじょ,"assistance, support, auxiliary",JLPT_1 JLPT
-舗装,ほそう,"pavement, road surface",JLPT_1 JLPT
-補足,ほそく,"supplement, complement",JLPT_1 JLPT
-墓地,ぼち,"cemetery, graveyard",JLPT_1 JLPT
-発作,ほっさ,"fit, attack",JLPT_1 JLPT
-没収,ぼっしゅう,forfeited,JLPT_1 JLPT
-発足,ほっそく,"starting, inauguration",JLPT_1 JLPT
-ポット,ポット,pot,JLPT_1 JLPT
-ほっぺた,ほっぺた,cheek,JLPT_1 JLPT
-ぼつぼつ,ぼつぼつ,"gradually, here and there, spots",JLPT_1 JLPT
-没落,ぼつらく,"ruin, fall, collapse",JLPT_1 JLPT
-解ける,ほどける,"to come untied, to come apart",JLPT_1 JLPT
-施す,ほどこす,"to give, to conduct, to perform",JLPT_1 JLPT
-ほとり,ほとり,vicinity of lake; river,JLPT_1 JLPT
-ぼやく,ぼやく,"to grumble, to complain",JLPT_1 JLPT
-ぼやける,ぼやける,"to become dim, to become blurred",JLPT_1 JLPT
-保養,ほよう,"health preservation, recuperation, recreation",JLPT_1 JLPT
-捕虜,ほりょ,prisoner of war,JLPT_1 JLPT
-ボルト,ボルト,volt; bolt,JLPT_1 JLPT
-滅びる,ほろびる,"to be ruined, to perish, to be destroyed",JLPT_1 JLPT
-滅ぼす,ほろぼす,"to destroy, to overthrow, to ruin",JLPT_1 JLPT
-本格,ほんかく,"propriety, full-scale",JLPT_1 JLPT
-本館,ほんかん,main building,JLPT_1 JLPT
-本気,ほんき,"seriousness, truth, sanctity",JLPT_1 JLPT
-本国,ほんごく,one's own country,JLPT_1 JLPT
-本質,ほんしつ,"essence, true nature, reality",JLPT_1 JLPT
-本体,ほんたい,"substance, body, trunk",JLPT_1 JLPT
-本音,ほんね,"(one's) real intention, motive",JLPT_1 JLPT Intermediate_Japanese_Ln.15 Intermediate_Japanese
-本能,ほんのう,instinct,JLPT_1 JLPT
-本場,ほんば,"home, best place, genuine",JLPT_1 JLPT
-ポンプ,ポンプ,pump,JLPT_1 JLPT
-本文,ほんぶん,"text (of document), body (of letter)",JLPT_1 JLPT
-本名,ほんみょう,real name,JLPT_1 JLPT
-マーク,マーク,mark,JLPT_1 JLPT
-マイ～,マイ～,"my ~, one's own ~",JLPT_1 JLPT
-マイクロフォン,マイクロフォン,microphone,JLPT_1 JLPT
-埋蔵,まいぞう,"buried property, treasure trove",JLPT_1 JLPT
-舞う,まう,"to dance, to flutter about, to revolve",JLPT_1 JLPT
-真上,まうえ,"just above, right overhead",JLPT_1 JLPT
-前売,まえうり,"advance sale, booking",JLPT_1 JLPT
-前置き,まえおき,"preface, introduction",JLPT_1 JLPT
-任す,まかす,"to entrust, to leave to a person",JLPT_1 JLPT
-負かす,まかす,to defeat,JLPT_1 JLPT
-賄う,まかなう,"to give board to, to provide meals, to pay",JLPT_1 JLPT
-紛らわしい,まぎらわしい,"confusing, misleading, ambiguous",JLPT_1 JLPT
-紛れる,まぎれる,"to be diverted, to slip into",JLPT_1 JLPT
-真心,まごころ,"sincerity, devotion",JLPT_1 JLPT
-まごつく,まごつく,"to be confused, to be flustered",JLPT_1 JLPT
-誠,まこと,"truth, faith, fidelity",JLPT_1 JLPT
-誠に,まことに,"indeed, really (very polite), absolutely",JLPT_1 JLPT Genki_Ln.20 Genki
-まさしく,まさしく,"surely, no doubt, evidently",JLPT_1 JLPT
-勝る,まさる,"to excel, to surpass, to out-rival",JLPT_1 JLPT
-～増し,～まし,~increase,JLPT_1 JLPT
-交える,まじえる,"to mix, to converse with, to cross (swords)",JLPT_1 JLPT
-真下,ました,"right under, directly below",JLPT_1 JLPT
-まして,まして,"still more, still less (with neg. verb), to say nothing of",JLPT_1 JLPT
-交わる,まじわる,"to cross, to intersect, to mingle with,",JLPT_1 JLPT
-麻酔,ますい,anesthesia,JLPT_1 JLPT
-またがる (うまを～),またがる (うまを～),to straddle,JLPT_1 JLPT
-待ち合わせ,まちあわせ,appointment,JLPT_1 JLPT
-待ち遠しい,まちどおしい,looking forward to,JLPT_1 JLPT
-待ち望む,まちのぞむ,"to look anxiously for, to wait eagerly for",JLPT_1 JLPT
-まちまち,まちまち,"various, different",JLPT_1 JLPT
-末期,まっき,"deathbed, hour of death",JLPT_1 JLPT
-真っ二つ,まっぷたつ,in two equal parts,JLPT_1 JLPT
-まと,まと,"mark, target",JLPT_1 JLPT
-纏まり,まとまり,"conclusion, settlement, consistency",JLPT_1 JLPT
-纏め,まとめ,"settlement, conclusion",JLPT_1 JLPT
-免れる,まぬがれる,"to escape from, to be exempted",JLPT_1 JLPT
-招き,まねき,invitation,JLPT_1 JLPT
-瞬き,まばたき,"wink, twinkling (of stars), flicker (of light)",JLPT_1 JLPT
-麻痺,まひ,"paralysis, palsy, numbness",JLPT_1 JLPT
-～まみれ,～まみれ,"covered with (by, in) ~",JLPT_1 JLPT
-眉,まゆ,eyebrow,JLPT_1 JLPT
-鞠,まり,ball,JLPT_1 JLPT
-丸ごと,まるごと,"in its entirety, whole, wholly",JLPT_1 JLPT
-まるっきり,まるっきり,"completely, perfectly, just as if",JLPT_1 JLPT
-丸々,まるまる,completely,JLPT_1 JLPT
-丸める,まるめる,"to make round, to round off, to roll up",JLPT_1 JLPT
-満月,まんげつ,full moon,JLPT_1 JLPT
-満場,まんじょう,"unanimous, whole audience",JLPT_1 JLPT
-真ん前,まんまえ,"right in front, under the nose",JLPT_1 JLPT
-真ん丸い,まんまるい,perfectly circular,JLPT_1 JLPT
-真ん円い,まんまるい,perfectly round,JLPT_1 JLPT
-～味,～み,~ cast (sense of taste),JLPT_1 JLPT
-見合い,みあい,formal marriage interview,JLPT_1 JLPT
-見合わせる,みあわせる,to exchange glances; to postpone,JLPT_1 JLPT
-見落とす,みおとす,"to overlook, to fail to notice",JLPT_1 JLPT
-未開,みかい,"savage land, backward region, uncivilized",JLPT_1 JLPT
-味覚,みかく,"taste, palate, sense of taste",JLPT_1 JLPT
-幹,みき,(tree) trunk,JLPT_1 JLPT
-見苦しい,みぐるしい,"unsightly, ugly",JLPT_1 JLPT
-見込み,みこみ,"prospects, expectation, hope",JLPT_1 JLPT
-未婚,みこん,unmarried,JLPT_1 JLPT
-未熟,みじゅく,"inexperience, unskilled, immature",JLPT_1 JLPT
-微塵,みじん,"particle, atom",JLPT_1 JLPT
-水気,みずけ,"moisture, dampness",JLPT_1 JLPT
-ミスプリント,ミスプリント,misprint,JLPT_1 JLPT
-みすぼらしい,みすぼらしい,"shabby, seedy",JLPT_1 JLPT
-ミセス,ミセス,Mrs.,JLPT_1 JLPT
-見せびらかす,みせびらかす,"to show off, to flaunt",JLPT_1 JLPT
-見せ物,みせもの,"show, exhibition",JLPT_1 JLPT
-溝,みぞ,"ditch, drain, gutter, gap",JLPT_1 JLPT
-満たす,みたす,"to satisfy, to ingratiate, to fill, to fulfill",JLPT_1 JLPT
-乱す,みだす,"to throw out of order, to disarrange, to disturb",JLPT_1 JLPT
-乱れる,みだれる,"to get confused, to be disordered, to be disturbed",JLPT_1 JLPT
-未知,みち,not yet known,JLPT_1 JLPT
-身近,みぢか,"near oneself, close to one, familiar",JLPT_1 JLPT
-導く,みちびく,"to be guided, to be shown",JLPT_1 JLPT
-密集,みっしゅう,"crowd, close formation, dense",JLPT_1 JLPT
-密接,みっせつ,"connected, close, intimate",JLPT_1 JLPT
-密度,みつど,density,JLPT_1 JLPT
-見積もり,みつもり,"estimation, quotation",JLPT_1 JLPT
-未定,みてい,"not yet fixed, undecided, pending",JLPT_1 JLPT
-見通し,みとおし,"perspective, unobstructed view, prospect",JLPT_1 JLPT
-見なす,みなす,"to consider as, to regard",JLPT_1 JLPT
-源,みなもと,"source, origin",JLPT_1 JLPT
-見習う,みならう,to follow another's example,JLPT_1 JLPT
-身なり,みなり,personal appearance,JLPT_1 JLPT
-峰,みね,"peak, ridge",JLPT_1 JLPT
-身の上,みのうえ,"one's future, one's welfare, one's personal history",JLPT_1 JLPT
-見逃す,みのがす,"to miss, to overlook, to leave at large",JLPT_1 JLPT
-身の回り,みのまわり,"one's personal appearance, personal belongings",JLPT_1 JLPT
-見計らう,みはからう,to choose at one's own discretion,JLPT_1 JLPT
-見晴らし,みはらし,view,JLPT_1 JLPT
-身振り,みぶり,gesture,JLPT_1 JLPT Intermediate_Japanese Intermediate_Japanese_Ln.11
-脈,みゃく,pulse,JLPT_1 JLPT
-ミュージック,ミュージック,music,JLPT_1 JLPT
-未練,みれん,"lingering affection, attachment, regret(s)",JLPT_1 JLPT
-見渡す,みわたす,"to look out over, to survey (scene), to take an extensive view of",JLPT_1 JLPT
-民宿,みんしゅく,private house providing lodging and meals to tourists,JLPT_1 JLPT Intermediate_Japanese_Ln.10 Intermediate_Japanese
-民族,みんぞく,"people, race",JLPT_1 JLPT
-民俗,みんぞく,folk customs,JLPT_1 JLPT
-無意味,むいみ,"nonsense, no meaning",JLPT_1 JLPT
-ムード,ムード,mood,JLPT_1 JLPT
-無口,むくち,reticence,JLPT_1 JLPT
-婿,むこ,son-in-law,JLPT_1 JLPT
-無効,むこう,"invalid, no effect, unavailable",JLPT_1 JLPT
-無言,むごん,silence,JLPT_1 JLPT
-無邪気,むじゃき,"innocence, simple-mindedness",JLPT_1 JLPT
-むしる,むしる,"to pluck, to pick, to tear",JLPT_1 JLPT
-結び,むすび,"ending, conclusion, union",JLPT_1 JLPT
-結び付き,むすびつき,"connection, relation",JLPT_1 JLPT
-結び付く,むすびつく,"to be connected or related, to join together",JLPT_1 JLPT
-結び付ける,むすびつける,"to combine, to join, to tie on, to attach with a knot",JLPT_1 JLPT
-無線,むせん,"wireless, radio",JLPT_1 JLPT
-無駄遣い,むだづかい,"waste money on, squander money on",JLPT_1 JLPT Genki_Ln.22 Genki
-無断,むだん,"without permission, without notice",JLPT_1 JLPT
-無知,むち,ignorance,JLPT_1 JLPT
-無茶,むちゃ,"absurd, unreasonable",JLPT_1 JLPT Intermediate_Japanese_Ln.12 Intermediate_Japanese
-無茶苦茶,むちゃくちゃ,"confused, jumbled, mixed up, unreasonable",JLPT_1 JLPT
-空しい,むなしい,"vacant, futile, vain",JLPT_1 JLPT
-無念,むねん,"chagrin, regret",JLPT_1 JLPT
-無能,むのう,"inefficiency, incompetence",JLPT_1 JLPT
-無闇に,むやみに,"unreasonably, absurdly, at random",JLPT_1 JLPT
-無用,むよう,"useless, needlessness, unnecessariness",JLPT_1 JLPT
-斑,むら,"unevenness, inconsistency, irregularity",JLPT_1 JLPT
-群がる,むらがる,"to swarm, to gather",JLPT_1 JLPT
-無論,むろん,"of course, naturally",JLPT_1 JLPT
-名産,めいさん,noted product,JLPT_1 JLPT
-名称,めいしょう,name,JLPT_1 JLPT
-命中,めいちゅう,a hit,JLPT_1 JLPT
-明白,めいはく,"obvious, clear",JLPT_1 JLPT
-名簿,めいぼ,register of names,JLPT_1 JLPT
-名誉,めいよ,"honor, credit, prestige",JLPT_1 JLPT
-明瞭,めいりょう,clarity,JLPT_1 JLPT
-明朗,めいろう,"bright, clear, cheerful",JLPT_1 JLPT
-メーカー,メーカー,manufacturer,JLPT_1 JLPT
-目方,めかた,weight,JLPT_1 JLPT
-恵み,めぐみ,blessing,JLPT_1 JLPT
-恵む,めぐむ,"to bless, to show mercy to",JLPT_1 JLPT
-目覚しい,めざましい,"brilliant, remarkable",JLPT_1 JLPT
-目覚める,めざめる,to wake up,JLPT_1 JLPT
-召す,めす,"to call, to send for, to put on",JLPT_1 JLPT
-雌,めす,female (animal),JLPT_1 JLPT
-目付き,めつき,"look, expression of the eyes, eyes",JLPT_1 JLPT
-滅亡,めつぼう,"downfall, collapse, destruction",JLPT_1 JLPT
-メディア,メディア,media,JLPT_1 JLPT
-目途,めど,"goal, outlook",JLPT_1 JLPT
-目盛,めもり,"scale, gradations",JLPT_1 JLPT
-メロディー,メロディー,melody,JLPT_1 JLPT
-面会,めんかい,interview,JLPT_1 JLPT
-免除,めんじょ,"exemption, exoneration, discharge",JLPT_1 JLPT
-面する,めんする,"to face on, to look out on to",JLPT_1 JLPT
-面目,めんぼく,"face, honor, reputation",JLPT_1 JLPT
-面目,めんもく,"face, honor, reputation",JLPT_1 JLPT
-～網,～もう,~ network,JLPT_1 JLPT
-設ける,もうける,"to create, to establish",JLPT_1 JLPT
-申し入れる,もうしいれる,"to propose, to suggest",JLPT_1 JLPT
-申込,もうしこみ,"application, request, proposal",JLPT_1 JLPT
-申出,もうしで,"request, claim, report",JLPT_1 JLPT
-申し出る,もうしでる,"to report to, to tell, to suggest",JLPT_1 JLPT
-申し分,もうしぶん,"objection, shortcomings",JLPT_1 JLPT
-盲点,もうてん,blind spot,JLPT_1 JLPT
-猛烈,もうれつ,"violent, vehement, rage",JLPT_1 JLPT
-モーテル,モーテル,motel,JLPT_1 JLPT
-もがく,もがく,"to struggle, to wriggle, to be impatient",JLPT_1 JLPT
-目録,もくろく,"catalogue, catalog, list",JLPT_1 JLPT
-目論見,もくろみ,"a plan, a scheme, intention",JLPT_1 JLPT
-模型,もけい,"model, dummy, marquette",JLPT_1 JLPT
-模索,もさく,groping (for),JLPT_1 JLPT
-もしかして,もしかして,"perhaps, possibly",JLPT_1 JLPT
-もしくは,もしくは,"or, otherwise",JLPT_1 JLPT
-もたらす,もたらす,"to bring, to take, to bring about",JLPT_1 JLPT
-持ち切り,もちきり,"hot topic, talk of the town",JLPT_1 JLPT
-目下,もっか,"at present, now",JLPT_1 JLPT
-専ら,もっぱら,"wholly, solely, entirely",JLPT_1 JLPT
-もてなす,もてなす,"to entertain, to make welcome",JLPT_1 JLPT
-もてる,もてる,"to be well liked, to be popular",JLPT_1 JLPT
-モニター,モニター,(computer) monitor,JLPT_1 JLPT
-物好き,ものずき,(idle) curiosity,JLPT_1 JLPT
-物足りない,ものたりない,"unsatisfied, unsatisfactory",JLPT_1 JLPT
-もはや,もはや,"already, now",JLPT_1 JLPT
-模範,もはん,"model, example",JLPT_1 JLPT
-模倣,もほう,"imitation, copying",JLPT_1 JLPT
-もめる,もめる,"to disagree, to dispute",JLPT_1 JLPT
-股,もも,"thigh, femur",JLPT_1 JLPT
-腿,もも,"thigh, femur",JLPT_1 JLPT
-催す,もよおす,"to hold (a meeting), to give (a dinner)",JLPT_1 JLPT
-漏らす,もらす,"to let leak, to reveal",JLPT_1 JLPT
-盛り上がる,もりあがる,"to rouse, to swell, to rise",JLPT_1 JLPT
-漏る,もる,"to leak, to run out",JLPT_1 JLPT
-漏れる,もれる,"to leak out, to escape, to filter out",JLPT_1 JLPT
-脆い,もろい,"brittle, fragile, tender-hearted",JLPT_1 JLPT
-もろに,もろに,"completely, altogether, bodily",JLPT_1 JLPT
-矢,や,arrow,JLPT_1 JLPT
-野外,やがい,"fields, outskirts, open air, suburbs",JLPT_1 JLPT
-～薬,～やく,medicine,JLPT_1 JLPT
-夜具,やぐ,bedding,JLPT_1 JLPT
-役職,やくしょく,"post, managerial position, official position",JLPT_1 JLPT
-役場,やくば,town hall,JLPT_1 JLPT
-やけに,やけに,"sure, very",JLPT_1 JLPT
-屋敷,やしき,mansion,JLPT_1 JLPT
-養う,やしなう,"to rear, to maintain, to cultivate",JLPT_1 JLPT
-野心,やしん,"ambition, aspiration",JLPT_1 JLPT
-安っぽい,やすっぽい,"cheap-looking, tawdry",JLPT_1 JLPT
-休める,やすめる,"to rest, to suspend, to give relief",JLPT_1 JLPT
-野生,やせい,wild,JLPT_1 JLPT
-奴,やつ,"(vulg.) fellow, guy, chap",JLPT_1 JLPT
-闇,やみ,"darkness, shady, illegal",JLPT_1 JLPT
-病む,やむ,"to fall ill, to be ill",JLPT_1 JLPT
-ややこしい,ややこしい,"puzzling, tangled, complicated, complex",JLPT_1 JLPT
-やりとおす,やりとおす,"to carry through, to achieve, to complete",JLPT_1 JLPT
-やりとげる,やりとげる,to accomplish,JLPT_1 JLPT
-和らげる,やわらげる,"to soften, to moderate, to relieve",JLPT_1 JLPT
-ヤング,ヤング,young,JLPT_1 JLPT
-～油,～ゆ,~ oil,JLPT_1 JLPT
-優位,ゆうい,"predominance, ascendancy, superiority",JLPT_1 JLPT
-憂鬱,ゆううつ,"depression, melancholy",JLPT_1 JLPT
-有益,ゆうえき,"beneficial, profitable",JLPT_1 JLPT
-優越,ゆうえつ,"supremacy, predominance, being superior to",JLPT_1 JLPT
-勇敢,ゆうかん,"bravery, heroism, gallantry",JLPT_1 JLPT
-夕暮れ,ゆうぐれ,"evening, (evening) twilight",JLPT_1 JLPT
-融資,ゆうし,"financing, loan",JLPT_1 JLPT
-有する,ゆうする,"to own, to be endowed with",JLPT_1 JLPT
-優勢,ゆうせい,"superiority, superior power, predominance",JLPT_1 JLPT
-優先,ゆうせん,"preference, priority",JLPT_1 JLPT
-誘導,ゆうどう,"guidance, leading, inducement",JLPT_1 JLPT
-融通,ゆうずう,"adaptability, versatility, finance",JLPT_1 JLPT
-優美,ゆうび,"grace, refinement, elegance",JLPT_1 JLPT
-有望,ゆうぼう,"good prospects, full of hope, promising",JLPT_1 JLPT
-遊牧,ゆうぼく,nomadism,JLPT_1 JLPT
-夕焼け,ゆうやけ,sunset,JLPT_1 JLPT
-有力,ゆうりょく,"influence, prominence; potent",JLPT_1 JLPT
-幽霊,ゆうれい,"ghost, specter, phantom",JLPT_1 JLPT
-誘惑,ゆうわく,"temptation, allurement, lure",JLPT_1 JLPT
-故,ゆえ,"reason, cause, circumstances",JLPT_1 JLPT
-歪む,ゆがむ,"to warp, to be crooked, to be distorted",JLPT_1 JLPT
-揺さぶる,ゆさぶる,"to shake, to jolt, to rock, to swing",JLPT_1 JLPT
-濯ぐ,ゆすぐ,"to rinse, to wash out",JLPT_1 JLPT
-ゆとり,ゆとり,"reserve, affluence, time (to spare)",JLPT_1 JLPT
-ユニーク,ユニーク,unique,JLPT_1 JLPT
-ユニフォーム,ユニフォーム,uniform,JLPT_1 JLPT
-指差す,ゆびさす,to point at,JLPT_1 JLPT
-弓,ゆみ,bow,JLPT_1 JLPT
-揺らぐ,ゆらぐ,"to swing, to sway, to shake",JLPT_1 JLPT
-緩む,ゆるむ,"to become loose, to slacken",JLPT_1 JLPT
-緩める,ゆるめる,"to loosen, to slow down",JLPT_1 JLPT
-緩やか,ゆるやか,lenient,JLPT_1 JLPT
-要因,よういん,"primary factor, main cause",JLPT_1 JLPT
-溶液,ようえき,solution,JLPT_1 JLPT
-用件,ようけん,business,JLPT_1 JLPT
-養護,ようご,"protection, nursing, protective care",JLPT_1 JLPT
-用紙,ようし,a form,JLPT_1 JLPT Intermediate_Japanese Intermediate_Japanese_Ln.3
-様式,ようしき,"style, form, pattern",JLPT_1 JLPT
-要する,ようする,"to demand, to require, to take",JLPT_1 JLPT
-要請,ようせい,"claim, demand, request, application",JLPT_1 JLPT
-様相,ようそう,aspect,JLPT_1 JLPT
-用品,ようひん,"articles, supplies, parts",JLPT_1 JLPT
-洋風,ようふう,western style,JLPT_1 JLPT
-用法,ようほう,"directions, rules of use",JLPT_1 JLPT
-要望,ようぼう,"demand for, request",JLPT_1 JLPT
-余暇,よか,"leisure, leisure time, spare time",JLPT_1 JLPT
-予感,よかん,"presentiment, premonition",JLPT_1 JLPT
-余興,よきょう,"side show, entertainment",JLPT_1 JLPT
-預金,よきん,"deposit, bank account",JLPT_1 JLPT
-欲,よく,"greed, wants",JLPT_1 JLPT
-抑圧,よくあつ,"restraint, oppression, suppression",JLPT_1 JLPT
-浴室,よくしつ,"bathroom, bath",JLPT_1 JLPT
-抑制,よくせい,"control, restraint, suppression",JLPT_1 JLPT
-欲深い,よくふかい,greedy,JLPT_1 JLPT
-欲望,よくぼう,"desire, appetite",JLPT_1 JLPT Intermediate_Japanese_Ln.13 Intermediate_Japanese
-避ける,よける,"to avoid (physical contact with; to ward off, to avert",JLPT_1 JLPT
-予言,よげん,"prediction, promise, prognostication",JLPT_1 JLPT
-横綱,よこづな,sumo grand champion,JLPT_1 JLPT
-汚れ,よごれ,"dirt, filth",JLPT_1 JLPT
-よし (かん),よし (かん),all right!,JLPT_1 JLPT
-良し,よし,all right!,JLPT_1 JLPT
-善し悪し,よしあし,"good or bad, merits or demerits, quality",JLPT_1 JLPT
-余所見,よそみ,"looking away, looking aside",JLPT_1 JLPT
-余地,よち,"place, room, margin",JLPT_1 JLPT
-よって (よりどころ),よって (よりどころ),"therefore, consequently",JLPT_1 JLPT
-与党,よとう,"government party, (ruling) party in power, government",JLPT_1 JLPT
-呼び止める,よびとめる,to flag down,JLPT_1 Intermediate_Japanese_Ln.6 JLPT Intermediate_Japanese
-夜更し,よふかし,"staying up late, keeping late hours",JLPT_1 JLPT
-夜更け,よふけ,late at night,JLPT_1 JLPT
-余程,よほど,"very, much, to a large extent, quite",JLPT_1 JLPT
-読み上げる,よみあげる,"to read out loud (and clearly), to call a roll",JLPT_1 JLPT
-～寄り,～より,"near to ~ (e.g., North by East)",JLPT_1 JLPT
-寄り掛かる,よりかかる,"to lean against, to recline on, to lean on, to rely on",JLPT_1 JLPT
-世論,よろん,public opinion,JLPT_1 JLPT
-弱る,よわる,"to weaken, to be troubled, to be emaciated",JLPT_1 JLPT
-来場,らいじょう,attendance,JLPT_1 JLPT
-ライス,ライス,rice,JLPT_1 JLPT
-酪農,らくのう,dairy farming,JLPT_1 JLPT
-落下,らっか,"fall, drop, come down",JLPT_1 JLPT
-楽観,らっかん,optimism,JLPT_1 JLPT
-ランプ,ランプ,lamp; ramp,JLPT_1 JLPT
-濫用,らんよう,"abuse, misuse, using to excess",JLPT_1 JLPT
-リード,リード,lead; reed,JLPT_1 JLPT
-理屈,りくつ,"theory, reason",JLPT_1 JLPT
-利子,りし,interest (bank),JLPT_1 JLPT
-利潤,りじゅん,"profit, returns",JLPT_1 JLPT
-理性,りせい,"reason, sense",JLPT_1 JLPT
-利息,りそく,interest (bank),JLPT_1 JLPT
-立体,りったい,solid body,JLPT_1 JLPT
-立方,りっぽう,cube,JLPT_1 JLPT
-立法,りっぽう,"legislation, lawmaking",JLPT_1 JLPT
-利点,りてん,"advantage, point in favor",JLPT_1 JLPT
-略奪,りゃくだつ,"pillage, looting, robbery",JLPT_1 JLPT
-略語,りゃくご,"abbreviation, acronym",JLPT_1 JLPT
-流通,りゅうつう,"circulation of money or goods, distribution",JLPT_1 JLPT
-領域,りょういき,"area, territory, region",JLPT_1 JLPT
-了解,りょうかい,"comprehension, consent, understanding",JLPT_1 JLPT
-領海,りょうかい,territorial waters,JLPT_1 JLPT
-両極,りょうきょく,"both extremities, north and south poles",JLPT_1 JLPT
-良好,りょうこう,"favorable, satisfactory",JLPT_1 JLPT
-良識,りょうしき,good sense,JLPT_1 JLPT
-良質,りょうしつ,"good quality, superior quality",JLPT_1 JLPT
-了承,りょうしょう,"acknowledgment, understanding",JLPT_1 JLPT
-良心,りょうしん,conscience,JLPT_1 JLPT
-領地,りょうち,territory,JLPT_1 JLPT
-領土,りょうど,"territory, possession",JLPT_1 JLPT
-両立,りょうりつ,"compatibility, coexistence, standing together",JLPT_1 JLPT
-旅客,りょかく,passenger,JLPT_1 JLPT
-旅券,りょけん,passport,JLPT_1 JLPT
-履歴,りれき,"personal history, background, log",JLPT_1 JLPT
-理論,りろん,theory,JLPT_1 JLPT
-林業,りんぎょう,forestry,JLPT_1 JLPT
-類,るい,"kind, class, family",JLPT_1 JLPT
-類推,るいすい,analogy,JLPT_1 JLPT
-類似,るいじ,analogous,JLPT_1 JLPT
-ルーズ,ルーズ,loose,JLPT_1 JLPT
-冷酷,れいこく,"cruelty, coldheartedness, ruthless",JLPT_1 JLPT
-冷蔵,れいぞう,refrigeration,JLPT_1 JLPT
-冷淡,れいたん,"coolness, indifference",JLPT_1 JLPT
-レース,レース,race; lace,JLPT_1 JLPT
-レギュラー,レギュラー,regular,JLPT_1 JLPT
-レッスン,レッスン,lesson,JLPT_1 JLPT
-レディー,レディー,lady,JLPT_1 JLPT
-レバー,レバー,lever; liver,JLPT_1 JLPT
-恋愛,れんあい,"love, romance",JLPT_1 JLPT
-バッテリー,バッテリー,battery,JLPT_1 JLPT
-バット,バット,"bat, vat",JLPT_1 JLPT
-発病,はつびょう,"attack, to become sick",JLPT_1 JLPT
-初耳,はつみみ,something heard for the first time,JLPT_1 JLPT
-果て,はて,"the end, the extremity, the limit(s)",JLPT_1 JLPT
-果てる,はてる,"to end, to be finished, to be exhausted",JLPT_1 JLPT
-ばてる,ばてる,"to be exhausted, to be worn out",JLPT_1 JLPT
-パトカー,パトカー,patrol car,JLPT_1 JLPT
-甚だ,はなはだ,"very, greatly, exceedingly",JLPT_1 JLPT
-華々しい,はなばなしい,"brilliant, magnificent, spectacular",JLPT_1 JLPT
-花びら,はなびら,(flower) petal,JLPT_1 JLPT
-華やか,はなやか,"brilliant, gorgeous, florid",JLPT_1 JLPT
-阻む,はばむ,"to keep someone from doing, to stop, to oppose",JLPT_1 JLPT
-浜,はま,"beach, seashore",JLPT_1 JLPT
-浜辺,はまべ,"beach, foreshore",JLPT_1 JLPT
-はまる,はまる,"to get into, to go into, to fit, to be fit for, to suit",JLPT_1 JLPT
-早める,はやめる,"to hasten, to quicken, to accelerate",JLPT_1 JLPT
-腹立ち,はらだち,anger,JLPT_1 JLPT
-原っぱ,はらっぱ,"open field, empty lot, plain",JLPT_1 JLPT
-はらはら,はらはら,feel nervous,JLPT_1 JLPT
-ばらまく,ばらまく,"to disseminate, to scatter",JLPT_1 JLPT
-張り紙,はりがみ,"notice, poster",JLPT_1 JLPT
-遥か,はるか,"far, far-away, distant",JLPT_1 JLPT
-破裂,はれつ,"explosion, rupture, break off",JLPT_1 JLPT
-腫れる,はれる,"to swell (from inflammation, to become swollen)",JLPT_1 JLPT
-繁栄,はんえい,"prospering, prosperity, flourishing",JLPT_1 JLPT
-版画,はんが,art print,JLPT_1 JLPT
-ハンガー,ハンガー,(coat) hanger,JLPT_1 JLPT
-反感,はんかん,"antipathy, revolt, animosity",JLPT_1 JLPT
-反響,はんきょう,"echo, reverberation, repercussion",JLPT_1 JLPT
-パンク,パンク,"puncture, bursting; punk",JLPT_1 JLPT
-反撃,はんげき,"counterattack, counteroffensive, counterblow",JLPT_1 JLPT
-判決,はんけつ,"judicial decision, judgment, sentence, decree",JLPT_1 JLPT
-反射,はんしゃ,"reflection, reverberation",JLPT_1 JLPT
-繁盛,はんじょう,"prosperity, flourishing, thriving",JLPT_1 JLPT
-繁殖,はんしょく,"breed, multiply, propagation",JLPT_1 JLPT
-反する,はんする,"to be inconsistent with, to oppose, to contradict",JLPT_1 JLPT
-判定,はんてい,"judgment, decision, award, verdict",JLPT_1 JLPT
-万人,ばんにん,"all people, everybody, 10000 people",JLPT_1 JLPT
-晩年,ばんねん,(one's) last years,JLPT_1 JLPT
-反応,はんのう,"reaction, response",JLPT_1 JLPT
-万能,ばんのう,"all-purpose, almighty, omnipotent",JLPT_1 JLPT
-半端,はんぱ,"fragment, fraction, incompleteness",JLPT_1 JLPT
-反発,はんぱつ,"repelling, rebound, oppose",JLPT_1 JLPT
-反乱,はんらん,"rebellion, revolt, uprising",JLPT_1 JLPT
-氾濫,はんらん,"overflowing, flood",JLPT_1 JLPT
-美,び,beauty,JLPT_1 JLPT
-ひいては,ひいては,"not only…but also, in addition to, consequently",JLPT_1 JLPT
-ビールス,ビールス,virus,JLPT_1 JLPT
-控室,ひかえしつ,waiting room,JLPT_1 JLPT
-控える,ひかえる,to hold back; to make notes,JLPT_1 JLPT
-悲観,ひかん,"pessimism, disappointment",JLPT_1 JLPT
-引き上げる,ひきあげる,"to withdraw, to leave, to pull out",JLPT_1 JLPT
-率いる,ひきいる,"to lead, to spearhead (a group), to command (troops)",JLPT_1 JLPT
-引き起こす,ひきおこす,to cause,JLPT_1 JLPT
-引下げる,ひきさげる,"to pull down, to lower, to reduce, to withdraw",JLPT_1 JLPT
-引きずる,ひきずる,"to drag along, to pull, to prolong",JLPT_1 JLPT
-引取る,ひきとる,to take back; to adopt; to leave,JLPT_1 JLPT
-否決,ひけつ,"rejection, negation, voting down",JLPT_1 JLPT
-日頃,ひごろ,"normally, habitually",JLPT_1 JLPT
-久しい,ひさしい,"long, long-continued, old (story)",JLPT_1 JLPT
-悲惨,ひさん,"tragedy, disaster; misery, wretched, pitiful",JLPT_1 JLPT
-ビジネス,ビジネス,business,JLPT JLPT_1 Genki_Ln.2 Genki_Ln.1 Genki
-比重,ひじゅう,specific gravity,JLPT_1 JLPT
-美術,びじゅつ,"art, fine arts",JLPT_1 JLPT
-秘書,ひしょ,(private) secretary,JLPT_1 JLPT
-微笑,びしょう,smile,JLPT_1 JLPT
-歪む,ひずむ,"to warp, to be distorted",JLPT_1 JLPT
-密か,ひそか,"secret, private, surreptitious",JLPT_1 JLPT
-浸す,ひたす,"to soak, to dip, to drench",JLPT_1 JLPT
-ひたすら,ひたすら,"nothing but, earnestly, intently",JLPT_1 JLPT
-左利き,ひだりきき,"left-handedness, sake drinker, left-hander",JLPT_1 JLPT
-引っ掻く,ひっかく,to scratch,JLPT_1 JLPT
-必修,ひっしゅう,required (subject),JLPT_1 JLPT
-びっしょり,びっしょり,"wet through, drenched",JLPT_1 JLPT
-必然,ひつぜん,"inevitable, necessary",JLPT_1 JLPT
-匹敵,ひってき,"comparing with, rival, equal",JLPT_1 JLPT
-一息,ひといき,"a breath, a pause, an effort",JLPT_1 JLPT
-人影,ひとかげ,"man's shadow, soul",JLPT_1 JLPT
-人柄,ひとがら,"personality, character",JLPT_1 JLPT
-人気,ひとけ,sign of life,JLPT_1 JLPT
-一頃,ひところ,"once, some time ago",JLPT_1 JLPT
-人質,ひとじち,hostage,JLPT_1 JLPT
-一筋,ひとすじ,"a line, earnestly, blindly, straightforwardly",JLPT_1 JLPT
-人目,ひとめ,"glimpse, public gaze",JLPT_1 JLPT
-日取り,ひどり,"fixed date, appointed day",JLPT_1 JLPT
-雛,ひな,"young bird, chick, doll",JLPT_1 JLPT
-雛祭,ひなまつり,Girls' (dolls') Festival,JLPT_1 JLPT
-日向,ひなた,"sunny place, in the sun",JLPT_1 JLPT
-非難,ひなん,"blame, attack, criticism",JLPT_1 JLPT
-避難,ひなん,"taking refuge, finding shelter",JLPT_1 JLPT
-日の丸,ひのまる,the Japanese flag,JLPT_1 JLPT
-火花,ひばな,spark,JLPT_1 JLPT
-ひび (かべの～),ひび (かべの～),"crack, fissure, flaw",JLPT_1 JLPT
-悲鳴,ひめい,"shriek, scream",JLPT_1 JLPT
-冷やかす,ひやかす,"to banter, to make fun of, to jeer at, to cool, to refrigerate",JLPT_1 JLPT
-日焼け,ひやけ,sunburn,JLPT_1 JLPT
-標語,ひょうご,"motto, slogan, catchword",JLPT_1 JLPT
-描写,びょうしゃ,"depiction, description, portrayal",JLPT_1 JLPT
-ひょっと,ひょっと,"possibly, accidentally",JLPT_1 JLPT
-びら,びら,"handout, leaflet",JLPT_1 JLPT
-平たい,ひらたい,"flat, even, level",JLPT_1 JLPT
-びり,びり,"last on the list, at the bottom",JLPT_1 JLPT
-比率,ひりつ,"ratio, proportion, percentage",JLPT_1 JLPT
+expression,reading,meaning,tags,guid
+現像,げんぞう,developing (film),JLPT_1 JLPT,v9bha+<cj}
+原則,げんそく,"principle, general rule",JLPT_1 JLPT,dVC[`t${#`
+見地,けんち,point of view,JLPT_1 JLPT,wk)a!>hpi:
+現地,げんち,"actual place, local",JLPT_1 JLPT,G$>SwAUY5:
+限定,げんてい,"limit, restriction",JLPT_1 JLPT,o%F/8(![P3
+原点,げんてん,"origin (coordinates, starting point)",JLPT_1 JLPT,bXdt~Sz`DP
+原典,げんてん,"original, source",JLPT_1 JLPT,EB`MVeV|+3
+原爆,げんばく,atomic bomb,JLPT_1 JLPT,qVu!~xa[nC
+原文,げんぶん,"the text, original",JLPT_1 JLPT,w>egRzs&//
+厳密,げんみつ,"strict, close",JLPT_1 JLPT,k<}V}HBo:Y
+賢明,けんめい,"wisdom, intelligence, prudence",JLPT_1 JLPT,rF6VPIq@Kt
+倹約,けんやく,"thrift, economy, frugality",JLPT_1 JLPT,G)qGN7wCPF
+原油,げんゆ,crude oil,JLPT_1 JLPT,mqzQ4phBV%
+兼用,けんよう,"multi-use, combined use",JLPT_1 JLPT,Q[mY;6;Blm
+権力,けんりょく,"(political) power, authority, influence",JLPT_1 JLPT,zLBVbQJht)
+言論,げんろん,"discussion, speech",JLPT_1 JLPT,j=]X!_Sn:<
+故～,こ～,"deceased, late",JLPT_1 JLPT,l<k2Hl<qF:
+語彙,ごい,"vocabulary, glossary",JLPT_1 JLPT,dg-x#L-S>s
+恋する,こいする,"to fall in love with, to love",JLPT_1 JLPT,x>yH@(e$>B
+甲,こう,1st in rank; shell,JLPT_1 JLPT,gr(P$T&hE)
+～光,～こう,light,JLPT_1 JLPT,dR[Ye:I0gD
+好意,こうい,"good will, favor, courtesy",JLPT_1 JLPT,f{|~G`MfSc
+行為,こうい,"act, deed, conduct",JLPT_1 JLPT,"x,?`vew_Y^"
+合意,ごうい,"agreement, consent, mutual understanding",JLPT_1 JLPT,u5DPHkD^67
+工学,こうがく,engineering,JLPT_1 JLPT,nLBSX>%S~{
+抗議,こうぎ,"protest, objection",JLPT_1 JLPT,N%yl^:99*x
+合議,ごうぎ,"consultation, conference",JLPT_1 JLPT,g]f7CW]TnO
+皇居,こうきょ,Imperial Palace,JLPT_1 JLPT,s3?rVk?BGD
+好況,こうきょう,"prosperous conditions, healthy economy",JLPT_1 JLPT,w5c/V*0:/6
+鉱業,こうぎょう,mining industry,JLPT_1 JLPT,w)+*p6qI~s
+興業,こうぎょう,starting a business; industry,JLPT_1 JLPT,qy~me*:#E{
+高原,こうげん,"tableland, plateau",JLPT_1 JLPT,GF2Ak`BNv1
+交互,こうご,"mutual, reciprocal, alternate",JLPT_1 JLPT,i<WWSGhMtl
+煌々と,こうこうと,brightly,JLPT_1 JLPT,wYY;?*yl=I
+考古学,こうこがく,archeology,JLPT_1 JLPT,CYD1fRQ8EC
+工作,こうさく,"handicraft, maneuvering",JLPT_1 JLPT,wzz*)FRo9<
+耕作,こうさく,"cultivation, farming",JLPT_1 JLPT,hB|/|8Uy}2
+鉱山,こうざん,mine,JLPT_1 JLPT,"KT!enF:=,%"
+講習,こうしゅう,"short course, training",JLPT_1 JLPT,g(z7%o&?^
+口述,こうじゅつ,verbal statement,JLPT_1 JLPT,C~8oU(cK0?
+控除,こうじょ,"subsidy, deduction",JLPT_1 JLPT,s2uW?Na1t%
+交渉,こうしょう,negotiation,JLPT_1 JLPT Intermediate_Japanese_Ln.8 Intermediate_Japanese,uv@U[?I@AF
+高尚,こうしょう,"high, noble, refined",JLPT_1 JLPT,Ndw<}.:V2o
+向上,こうじょう,"rise, improvement, progress",JLPT_1 JLPT,Qcz@t2UD0)
+行進,こうしん,"march, parade",JLPT_1 JLPT,A=w}ZE@917
+香辛料,こうしんりょう,spices,JLPT_1 JLPT,ce!{r.1}~3
+降水,こうすい,"rainfall, precipitation",JLPT_1 JLPT,"pb1#Y263n,"
+洪水,こうずい,flood,JLPT_1 JLPT,wakC-uKaq}
+合成,ごうせい,"synthetic, mixed",JLPT_1 JLPT,c^4E@A0[92
+公然,こうぜん,openly,JLPT_1 JLPT,M(>QOkIhfA
+抗争,こうそう,"dispute, resistance",JLPT_1 JLPT,Ayw{S[ULVi
+構想,こうそう,"plan, plot, idea, conception",JLPT_1 JLPT,HJ3]TaFI5x
+後退,こうたい,"retreat, backspace",JLPT_1 JLPT,Hg(g(Ch73j
+光沢,こうたく,"luster, glossy finish (of photographs)",JLPT_1 JLPT,sz+BIfx<J$
+公団,こうだん,public corporation,JLPT_1 JLPT,C&5}~^z)ts
+好調,こうちょう,"satisfactory, in good shape",JLPT_1 JLPT,fn+k2uN^.*
+口頭,こうとう,oral,JLPT_1 JLPT,mWZ1nL&l+A
+講読,こうどく,reading,JLPT_1 JLPT,"cbt]L<,==)"
+購読,こうどく,subscription,JLPT_1 JLPT,BPBnR~`=Cm
+購入,こうにゅう,"purchase, buy",JLPT_1 JLPT,mN.]${Ep@o
+公認,こうにん,"official recognition, authorization",JLPT_1 JLPT,f=;(Z+KSn*
+光熱費,こうねつひ,cost of fuel and light,JLPT_1 JLPT,CBInEbAiwn
+購買,こうばい,"purchase, buy",JLPT_1 JLPT,m|%voYE^yW
+好評,こうひょう,"popularity, favorable reputation",JLPT_1 JLPT,PN?X>r5#3$
+交付,こうふ,"delivering, furnishing (with copies)",JLPT_1 JLPT,iWHq@iV7/S
+公募,こうぼ,"public appeal, public contribution",JLPT_1 JLPT,zuO/%#|pw9
+巧妙,こうみょう,"ingenious, skillful, clever",JLPT_1 JLPT,K0cz7g4lOn
+公用,こうよう,"government business, public use, public expense",JLPT_1 JLPT,E{n/tl9=Ih
+小売,こうり,retail,JLPT_1 JLPT,c_Z6-bZ>!E
+効率,こうりつ,efficiency,JLPT_1 JLPT,zkc6-]4~)6
+公立,こうりつ,public institution,JLPT_1 JLPT,FUSldz(S$f
+護衛,ごえい,"guard, convoy, escort",JLPT_1 JLPT,Bs7a.5p1{r
+コーナー,コーナー,corner,JLPT_1 JLPT,n/T(.dj~.j
+小柄,こがら,"small, diminutive",JLPT_1 JLPT,p|m2.?zBm2
+小切手,こぎって,"cheque, check",JLPT_1 JLPT,vh>Pgi:y!n
+国産,こくさん,domestic products,JLPT_1 JLPT,NVGuI`wyWr
+国定,こくてい,"state-sponsored, national",JLPT_1 JLPT,K:.NA{MA#
+告白,こくはく,"confession, acknowledgment",JLPT_1 JLPT,D/-Yon@zj7
+国防,こくぼう,national defense,JLPT_1 JLPT,gB_-ioo>5E
+国有,こくゆう,national ownership,JLPT_1 JLPT,qhprC(Et1a
+極楽,ごくらく,paradise,JLPT_1 JLPT,MY-u/w:|X`
+国連,こくれん,"U.N., United Nations",JLPT_1 JLPT,PWdSCAXCS{
+焦げ茶,こげちゃ,dark brown,JLPT_1 JLPT,z#D(l+D|+d
+語源,ごげん,"word root, word derivation, etymology",JLPT_1 JLPT,"wW7;mB,H-n"
+心地,ここち,"feeling, sensation, mood",JLPT_1 JLPT,HRZ-ZZ((63
+心得,こころえ,"knowledge, information",JLPT_1 JLPT,r]B:&#9/Oj
+心掛け,こころがけ,"readiness, intention, aim",JLPT_1 JLPT,v|gKw*kSA<
+心掛ける,こころがける,"to bear in mind, to aim to do",JLPT_1 JLPT,xF|-#cu_O[
+志,こころざし,"will, intention, motive",JLPT_1 JLPT,J^EH*N|S>D
+志す,こころざす,"to plan, to intend, to aspire to",JLPT_1 JLPT,zc/071N?*?
+心強い,こころづよい,"heartening, reassuring",JLPT_1 JLPT,K>pZg]2z_[
+心細い,こころぼそい,"helpless, hopeless, discouraging",JLPT_1 JLPT,ve[sU52iIO
+試み,こころみ,"trial, experiment",JLPT_1 JLPT,LnQ-7#~J-i
+試みる,こころみる,"to try, to test",JLPT_1 JLPT,qG!ugw]O{9
+快い,こころよい,"pleasant, agreeable",JLPT_1 JLPT,eXTY5f2Ubn
+誤差,ごさ,error,JLPT_1 JLPT,bE*}iimu/k
+ございます (かん),ございます (かん),"to be (polite, to exist)",JLPT_1 JLPT,g2<)LlaRj=
+孤児,こじ,orphan,JLPT_1 JLPT,Nru>c@<pc2
+こじれる,こじれる,"to get complicated, to grow worse",JLPT_1 JLPT,jQE(/ITykr
+こす (みずを～),こす (みずを～),"to strain, to filter",JLPT_1 JLPT,P2WNAwMh[2
+梢,こずえ,treetop,JLPT_1 JLPT,"P{..MI,|Mb"
+個性,こせい,"individuality, personality, idiosyncrasy",JLPT_1 JLPT,EsL6l#sj?m
+戸籍,こせき,"census, family register",JLPT_1 Intermediate_Japanese_Ln.14 JLPT Intermediate_Japanese,JOc{[NV4x8
+古代,こだい,ancient times,JLPT_1 JLPT,s_N1oO.lmA
+こたつ,こたつ,"table with heater, (originally) charcoal brazier in a floor well",JLPT_1 JLPT,O}EMl{I]K-
+こだわる,こだわる,"to fuss over, to be particular about",JLPT_1 JLPT,Dw-&[Gy8N`
+誇張,こちょう,exaggeration,JLPT_1 JLPT,c]NsRC|}O%
+こつ (をつかむ),こつ (をつかむ),"secret, trick, hang",JLPT_1 JLPT,qPHur}V8b$
+滑稽,こっけい,"funny, humorous, comical",JLPT_1 JLPT,v>_m`mFbvz
+国交,こっこう,diplomatic relations,JLPT_1 JLPT,d-(zI.D]7}
+骨董品,こっとうひん,curio,JLPT_1 JLPT,Dr0mqScf_b
+固定,こてい,"fixation, fixing (e.g., salary, capital)",JLPT_1 JLPT,g$6E|N|S:$
+事柄,ことがら,"matter, thing, affair, circumstance",JLPT_1 JLPT,F=ad!I0A}O
+孤独,こどく,"isolation, loneliness, solitude",JLPT_1 JLPT,"cT&=x,mI2c"
+ことごとく,ことごとく,"altogether, entirely",JLPT_1 JLPT,dR[Sxf+^Ps
+言付け,ことづけ,to leave a message,JLPT_1 JLPT,kU+Y{Q}2@W
+殊に,ことに,"especially, above all",JLPT_1 JLPT,en/8|n9S0h
+粉々,こなごな,in very small pieces,JLPT_1 JLPT,Kmg$=%neFc
+好ましい,このましい,"nice, likable, desirable",JLPT_1 JLPT,x#LKH<P4pQ
+碁盤,ごばん,Go board,JLPT_1 JLPT,zlA@Kkn)Y
+個別,こべつ,particular case,JLPT_1 JLPT,IS>`l#g_rF
+ごまかす,ごまかす,"to deceive, to falsify, to misrepresent",JLPT_1 JLPT,p$tB:Q(vZY
+細やか,こまやか,"meager, modest",JLPT_1 JLPT,w6sGv9Z]7>
+コマーシャル,コマーシャル,a commercial,JLPT_1 JLPT,pmxm=&|P?L
+込める,こめる,"to include, to put into",JLPT_1 JLPT,FCbb2pT+SZ
+コメント,コメント,comment,JLPT_1 JLPT,cplDpvT[1o
+籠もる,こもる,"to seclude oneself, to be confined in",JLPT_1 JLPT,KBSxgcpn$F
+固有,こゆう,"characteristic, tradition, peculiar",JLPT_1 JLPT,yXV:}D_ozd
+暦,こよみ,"calendar, almanac",JLPT_1 JLPT,jx:{}3HoK:
+凝らす,こらす,"to concentrate, to devote, to peer into",JLPT_1 JLPT,oJEMYEm^we
+ごらんなさい (かん),ごらんなさい (かん),"look, (please) try to do",JLPT_1 JLPT,N1BBvCZ=AZ
+孤立,こりつ,"isolation, helplessness",JLPT_1 JLPT,xYDSYkNe4i
+懲りる,こりる,"to learn by experience, to be disgusted with",JLPT_1 JLPT,vbJg<?=y%j
+凝る,こる,"to stiffen, to harden",JLPT_1 JLPT,p)T=z%i7F[
+根気,こんき,"patience; perseverance, energy",JLPT_1 JLPT,GDCM!r*##2
+根拠,こんきょ,"basis, foundation",JLPT_1 JLPT,Grg-T-@C<M
+混血,こんけつ,"mixed race, mixed parentage",JLPT_1 JLPT,saDmLPZfe~
+コンタクト (レンズ),コンタクト (レンズ),contact; contact lens,JLPT_1 JLPT,DU{l0`Yee%
+昆虫,こんちゅう,"insect, bug",JLPT_1 JLPT,P^F+-mx?ec
+根底,こんてい,"root, basis, foundation",JLPT_1 JLPT,g6v%#_YbHK
+混同,こんどう,"confusion, mixing, merger",JLPT_1 JLPT,"M?|],Xch]L"
+コントラスト,コントラスト,contrast,JLPT_1 JLPT,m2RkdF5Kfg
+コントロール,コントロール,control,JLPT_1 JLPT,hZ|i&d%@k8
+コンパス,コンパス,compass,JLPT_1 JLPT,L6kv/h{mWx
+根本,こんぽん,"foundation, root, base",JLPT_1 JLPT,I>Va~AQW*%
+財,ざい,"fortune, riches",JLPT_1 JLPT,Lg^]^#Fui$
+再会,さいかい,"meeting again, reunion",JLPT_1 JLPT,nK{EZH)j58
+災害,さいがい,"calamity, disaster, misfortune",JLPT_1 JLPT,s/:E%{jbbX
+細菌,さいきん,"bacillus, bacterium, germ",JLPT_1 JLPT,I!s+/_djx3
+細工,さいく,"work, craftsmanship, trick",JLPT_1 JLPT,ouX.|>$33M
+採掘,さいくつ,mining,JLPT_1 JLPT,Qb&n#ag5.U
+サイクル,サイクル,cycle,JLPT_1 JLPT,CwR.:*^K)]
+採決,さいけつ,"vote, roll call",JLPT_1 JLPT,dGyNtnPzfu
+再建,さいけん,(temple or shrine) rebuilding,JLPT_1 JLPT,oY^(hGDwBB
+再現,さいげん,"reproduction, return, revival",JLPT_1 JLPT,j$Iu*3{(HU
+財源,ざいげん,"source of funds, resources, finances",JLPT_1 JLPT,gD`:Vm3DD=
+在庫,ざいこ,"stockpile, stock",JLPT_1 JLPT,I`6&P}MLhB
+採算,さいさん,profit,JLPT_1 JLPT,z3sqnTBL(n
+サイズ,サイズ,size,JLPT_1 JLPT,J0]k_!eDR<
+再生,さいせい,"playback, regeneration, resuscitation",JLPT_1 JLPT,hGl1Th{bx@
+財政,ざいせい,"economy, financial affairs",JLPT_1 JLPT,PbUztxpH:]
+最善,さいぜん,the very best,JLPT_1 JLPT,M-1H]L<~pq
+採択,さいたく,"adoption, selection, choice",JLPT_1 JLPT,e+cLZEXhDr
+栽培,さいばい,cultivation,JLPT_1 JLPT,uC68c<~cH)
+再発,さいはつ,"return, relapse, reoccurrence",JLPT_1 JLPT,CS^Rshk:|8
+細胞,さいぼう,cell,JLPT_1 JLPT,CzyHns{dm!
+採用,さいよう,"use, adopt",JLPT_1 JLPT,"vMLF5(iO,d"
+遮る,さえぎる,"to interrupt, to intercept, to obstruct",JLPT_1 JLPT,QMaal]q?M$
+さえずる,さえずる,"to sing, to chirp, to twitter",JLPT_1 JLPT,r@Q>;L$}V-
+冴える,さえる,"to be clear, to be bright, to be skillful",JLPT_1 JLPT,F_K.fXalP!
+竿,さお,"rod, pole (e.g., for drying laundry)",JLPT_1 JLPT,v^.R1:=Y[p
+栄える,さかえる,"to flourish, to prosper, to thrive",JLPT_1 JLPT,w`<;(n%DdJ
+差額,さがく,"balance, difference, margin",JLPT_1 JLPT,gAXt@5CeYh
+杯,さかずき,wine cup,JLPT_1 JLPT,QIw#3oSw.:
+逆立ち,さかだち,"handstand, headstand",JLPT_1 JLPT,ec~&YKW}51
+さきに (いぜん),さきに (いぜん),"before, earlier than, previously",JLPT_1 JLPT,uh`5:/)TWv
+詐欺,さぎ,"fraud, swindle",JLPT_1 JLPT,w6]yB.g{E!
+削減,さくげん,"cut, reduction",JLPT_1 JLPT,k7zRyZ_D=o
+錯誤,さくご,mistake,JLPT_1 JLPT,IDfkC-Cw&L
+作戦,さくせん,"military operations, tactics, strategy",JLPT_1 JLPT,s$Xs?1nQ+e
+叫び,さけび,"shout, scream, outcry",JLPT_1 JLPT,nqYX]L]Y*r
+捧げる,ささげる,"to lift up, to give, to offer",JLPT_1 JLPT,KhanDj}|vd
+差し掛かる,さしかかる,"to come near to, to approach",JLPT_1 JLPT,IM%WW[zOZk
+指図,さしず,"instruction, mandate",JLPT_1 JLPT,N1]Ah`4~bh
+差し出す,さしだす,"to present, to submit, to hold out",JLPT_1 JLPT,A&xf;%;bo<
+差し支える,さしつかえる,"to interfere, to hinder",JLPT_1 JLPT,ve>x:VMBVJ
+授ける,さずける,"to grant, to award, to teach",JLPT_1 JLPT,h.+pAO9bEu
+摩する,さする,"to rub, to stroke",JLPT_1 JLPT,yQu&Wz5|+#
+さぞ (さぞや。さぞかし),さぞ (さぞや。さぞかし),"I am sure, certainly, no doubt",JLPT_1 JLPT,FE`C@V&t[f
+定まる,さだまる,"to become settled, to be fixed",JLPT_1 JLPT,"Ly=j.,,]V@"
+定める,さだめる,"to decide, to determine",JLPT_1 JLPT,MNqx6`F)B2
+座談会,ざだんかい,"symposium, round-table discussion",JLPT_1 JLPT,d!+{3%PNo}
+雑,ざつ,"rough, crude",JLPT_1 JLPT,PqMu^a?1a^
+雑貨,ざっか,"miscellaneous goods, general goods",JLPT_1 JLPT,r5VCxxHAy|
+殺人,さつじん,murder,JLPT_1 JLPT,tM%DouVsND
+察する,さっする,"to guess, to sense, to judge",JLPT_1 JLPT,LGG(>{BjoV
+雑談,ざつだん,"chatting, idle talk",JLPT_1 JLPT,DK#>y3UE4B
+さっと,さっと,"suddenly, smoothly",JLPT_1 JLPT,EKYb(VaO4Q
+さっぱりする,さっぱりする,to refresh,JLPT_1 JLPT,H|ANTa=Wl{
+悟る,さとる,"to attain enlightenment, to understand",JLPT_1 JLPT,v:Q4euCfA7
+最中,さなか,"in the middle of, midst",JLPT_1 JLPT,A!j+&nF3Wn
+座標,ざひょう,coordinates,JLPT_1 JLPT,B0L0!.A0?}
+さほど,さほど,"not so, not that much",JLPT_1 JLPT,Eqh)/a:JaN
+サボる,サボる,to cut (skip) classes; to loaf on the job; to idle away one's time,JLPT Genki_Ln.11 Intermediate_Japanese JLPT_1 Intermediate_Japanese_Ln.13 Genki,AVLvOaz~KF
+様,さま,state; way (a person does something); Mr. or Mrs.,JLPT_1 JLPT Intermediate_Japanese Intermediate_Japanese_Ln.11,lj0_)hI7Ez
+寒気,さむけ,"chill, shiver, cold",JLPT_1 JLPT,N#;$qw^KPE
+侍,さむらい,samurai,JLPT_1 JLPT Intermediate_Japanese_Ln.7 Intermediate_Japanese,g}?p(/xug4
+さも,さも,"with gusto, with satisfaction",JLPT_1 JLPT,Gm-[^5Ln&h
+作用,さよう,"operation, effect, function",JLPT_1 JLPT,"Oof8u=,|uS"
+さらう (こどもを～),さらう (こどもを～),to kidnap,JLPT_1 JLPT,B@RtBWjh/W
+障る,さわる,"to hinder, to interfere with, to affect",JLPT_1 JLPT,Di(J(kaH;V
+酸,さん,acid,JLPT_1 JLPT,k/LaLYL|r#
+山岳,さんがく,mountains,JLPT_1 JLPT,nJs0S#DzgO
+参議院,さんぎいん,House of Councilors,JLPT_1 JLPT,O7n.x?;S]&
+産休,さんきゅう,maternity leave,JLPT_1 JLPT,k`Pzt}i$UW
+サンキュー,サンキュー,thank you,JLPT_1 JLPT,rQ2myGNLp<
+残金,ざんきん,remaining money,JLPT_1 JLPT,E</lr>b527
+産後,さんご,"postpartum, after childbirth",JLPT_1 JLPT,"Pge/h!,u.x"
+残酷,ざんこく,"cruelty, harshness",JLPT_1 JLPT,snLE.]5(UV
+産出,さんしゅつ,"yield, produce",JLPT_1 JLPT,AItAE0vKn;
+参照,さんしょう,"reference, consultation, consultation",JLPT_1 JLPT,Q=29PP)W-_
+参上,さんじょう,"calling on, visiting",JLPT_1 JLPT,w#SP~u0yM;
+残高,ざんだか,"(bank) balance, remainder",JLPT_1 JLPT,K4gXaj[Vyi
+サンタクロース,サンタクロース,Santa Claus,JLPT_1 JLPT Intermediate_Japanese_Ln.8 Intermediate_Japanese,f/QC`5/{Un
+桟橋,さんばし,"wharf, jetty, pier",JLPT_1 JLPT,qY2!_v~;bZ
+賛美,さんび,"praise, adoration, glorification",JLPT_1 JLPT,e.-RuHb{48
+山腹,さんぷく,"hillside, mountainside",JLPT_1 JLPT,o2ZZ0`v<eS
+産婦人科,さんふじんか,maternity and gynecology department,JLPT_1 JLPT,C-(.5yIOQP
+産物,さんぶつ,"product, result, fruit",JLPT_1 JLPT,E~s#%JNaV$
+山脈,さんみゃく,mountain range,JLPT_1 JLPT,x1O?:5^y|C
+仕上がり,しあがり,"finish, end, completion",JLPT_1 JLPT,yea;?+baU4
+仕上,しあげ,"end, finishing touches",JLPT_1 JLPT,oEx[)E@iYE
+仕上げる,しあげる,"to finish up, to complete",JLPT_1 JLPT,hK4h`Zw:aS
+飼育,しいく,"breeding, raising, rearing",JLPT_1 JLPT,e5/Z)LI]cr
+強いて,しいて,"to dare, to insist",JLPT_1 JLPT,Bomwd0N#[6
+シート,シート,seat; sheet,JLPT_1 JLPT,u]dm-2Z@p[
+ジーパン,ジーパン,jeans,JLPT_1 JLPT,HXr(ew@{F#
+仕入れる,しいれる,"to lay in stock, to replenish stock, to procure",JLPT_1 JLPT,IFIIG{$W)<
+強いる,しいる,"to force, to compel, to coerce",JLPT_1 JLPT,mim3NgV!o^
+潮,しお,tide,JLPT_1 JLPT,bk[V+Gm9:@
+歯科,しか,dentistry,JLPT_1 JLPT,OAZ`Wrx_o9
+自我,じが,"self, ego",JLPT_1 JLPT,b-m;dw=d{Y
+自覚,じかく,self-conscious,JLPT_1 JLPT,i/]v!LT[`[
+仕掛,しかけ,"device, trick, mechanism",JLPT_1 JLPT,Jsems8J4`^
+仕掛ける,しかける,"to lay, to set, to wage",JLPT_1 JLPT,Ac40<_hm$3
+しかしながら,しかしながら,"however, nevertheless",JLPT_1 JLPT,Hq^C6[L3R8
+色彩,しきさい,color,JLPT_1 JLPT,G$Z8Bsx{4U
+式場,しきじょう,"ceremonial hall, place of ceremony (e.g., marriage)",JLPT_1 JLPT,rHP.1FI!Xg
+しきたり,しきたり,"custom, conventional practice, tradition",JLPT_1 JLPT,sw_]y<P?Kn
+事業,じぎょう,"project, enterprise, business",JLPT_1 JLPT,A#sQ/bEEtj
+軽蔑,けいべつ,"scorn, disdain",JLPT_1 JLPT,"lOS,!wvUe["
+経歴,けいれき,"personal history, career",JLPT_1 JLPT,D*n(@DRyq`
+経路,けいろ,"course, route, channel",JLPT_1 JLPT,AQ(D;C-S!0
+けがらわしい,けがらわしい,"filthy, unfair",JLPT_1 JLPT,lJNQ&9#g@p
+劇団,げきだん,"troupe, theatrical company",JLPT_1 JLPT,%y17:4{hj
+激励,げきれい,encouragement,JLPT_1 JLPT,C6/gh1N08I
+ゲスト,ゲスト,guest,JLPT_1 JLPT,lW>d7fCUoL
+獣,けだもの,"beast, brute",JLPT_1 JLPT,"o.IW_<j!,1"
+決,けつ,"decision, vote",JLPT_1 JLPT,h7W;[eV_6*
+決意,けつい,"decision, determination",JLPT_1 JLPT,Gg{:k%<AT6
+結核,けっかく,tuberculosis,JLPT_1 JLPT,dB99/5N;ta
+決議,けつぎ,"resolution, vote, decision",JLPT_1 JLPT,tcKhTpRM%o
+結合,けつごう,"combination, union",JLPT_1 JLPT,Q*@FzK(@81
+決算,けっさん,"balance sheet, settlement of accounts",JLPT_1 JLPT,z2iqWC-nB~
+月謝,げっしゃ,monthly tuition fee,JLPT_1 JLPT,t[*0i:*.#i
+決勝,けっしょう,finals (in sports),JLPT_1 JLPT,NFjb:+3q7*
+結晶,けっしょう,"crystal, crystallization",JLPT_1 JLPT,x*(Q^EE$u3
+結成,けっせい,formation,JLPT_1 JLPT,c_%F>ZhYyr
+結束,けっそく,"union, unity",JLPT_1 JLPT,JdP5@BTWkb
+げっそり,げっそり,"being disheartened, losing weight",JLPT_1 JLPT,EtlnVvKbZd
+決断,けつだん,"decision, determination",JLPT_1 JLPT,w;j;5-!>6(
+月賦,げっぷ,monthly installment,JLPT_1 JLPT,I{X4ZTn7X9
+欠乏,けつぼう,shortage,JLPT_1 JLPT,x8kzLzQh~#
+蹴飛ばす,けとばす,"to kick away, to kick (someone)",JLPT_1 JLPT,b5){X3eg^W
+けなす,けなす,to speak ill of,JLPT_1 JLPT,BA]o8V-nRc
+煙たい,けむたい,"smoky, feeling awkward",JLPT_1 JLPT,M_8T~aeKk.
+煙る,けむる,"to smoke (e.g., fire)",JLPT_1 JLPT,"O+^L$,-au7"
+獣,けもの,"beast, brute",JLPT_1 JLPT,q-7J3|/7Vg
+家来,けらい,"retainer, retinue, servant",JLPT_1 JLPT,n|b=[)XZ>2
+下痢,げり,diarrhea,JLPT_1 JLPT Intermediate_Japanese_Ln.12 Intermediate_Japanese,D94n#KX+u`
+権威,けんい,"authority, power, influence",JLPT_1 JLPT,lZZG^l>c$z
+兼業,けんぎょう,holding two jobs at the same time,JLPT_1 Intermediate_Japanese_Ln.14 JLPT Intermediate_Japanese,x9DFE@YYzp
+原形,げんけい,"original form, base form",JLPT_1 JLPT,"y2|y)U#`,-"
+原型,げんけい,"prototype, model, archetypal",JLPT_1 JLPT,"d5x_w+I&U,"
+権限,けんげん,"power, authority, jurisdiction",JLPT_1 JLPT,wsBe&qWS]u
+現行,げんこう,"present, current, in operation",JLPT_1 JLPT,cB#>jxDt}]
+健在,けんざい,"in good health, well",JLPT_1 JLPT,K?xI8~wHA>
+原作,げんさく,original work,JLPT_1 JLPT,"K<e+,WSWtr"
+検事,けんじ,public prosecutor,JLPT_1 JLPT,H[xn?@;-+x
+原子,げんし,atom,JLPT_1 JLPT,"b[T}G,9]G?"
+元首,げんしゅ,"ruler, sovereign",JLPT_1 JLPT,cJ-$.|^5r+
+原書,げんしょ,original document,JLPT_1 JLPT,wBia;+PSDE
+懸賞,けんしょう,"offering prizes, winning, reward",JLPT_1 JLPT,B7|NMN9B[B
+健全,けんぜん,"health, soundness, wholesome",JLPT_1 JLPT,u-bm~%/EH(
+元素,げんそ,element,JLPT_1 JLPT,B2tvGhK[&9
+同調,どうちょう,"sympathy, agree with, alignment",JLPT_1 JLPT,n#0+>4}sN5
+到底,とうてい,(cannot) possibly,JLPT_1 JLPT,C.#O<.PWZ+
+動的,どうてき,"dynamic, kinetic",JLPT_1 JLPT,k^9j&Q>>|N
+尊い,とうとい,"precious, valuable, noble",JLPT_1 JLPT,o/:X}@s/ud
+貴い,とうとい,"precious, valuable, noble",JLPT_1 JLPT,uE?!53}hB@
+同等,どうとう,"equality, equal, same rank",JLPT_1 JLPT,sS(wNIrQN<
+堂々,どうどう,"magnificent, grand, impressive",JLPT_1 JLPT,O@p/U*&n{h
+尊ぶ,とうとぶ,"to value, to prize, to esteem",JLPT_1 JLPT,NH2!B2Yh2E
+どうにか,どうにか,"in some way or other, one way or another",JLPT_1 JLPT,l_xfmqX[ub
+投入,とうにゅう,"throw, investment, making (an electrical circuit)",JLPT_1 JLPT,mwsjMMb<d>
+導入,どうにゅう,"introduction, bringing in, leading in",JLPT_1 JLPT Intermediate_Japanese_Ln.12 Intermediate_Japanese,m1+j$HqcF;
+当人,とうにん,"the one concerned, the said person",JLPT_1 JLPT,l]4=/bCF3a
+同封,どうふう,"enclosure (e.g., in a letter)",JLPT_1 JLPT,hnY+6g21h_
+逃亡,とうぼう,escape,JLPT_1 JLPT,qqqC#4{p[V
+冬眠,とうみん,"hibernation, winter sleep",JLPT_1 JLPT,"B+T>Lb-B&,"
+同盟,どうめい,"alliance, union, league",JLPT_1 JLPT,oBig^AFvC5
+どうやら,どうやら,"it seems like, somehow or other",JLPT_1 JLPT,LZH$.!k~sm
+動力,どうりょく,"power, motive power, dynamic force",JLPT_1 JLPT,gcbdGzw%jw
+登録,とうろく,"registration, register, record",JLPT_1 JLPT,w(]v<(of^0
+討論,とうろん,discussion; debate,JLPT_1 JLPT Intermediate_Japanese_Ln.15 Intermediate_Japanese,ft/}AOp*ZE
+遠ざかる,とおざかる,to go far off,JLPT_1 JLPT,nANBsXm^[4
+遠回り,とおまわり,"detour, roundabout way",JLPT_1 JLPT,u;(Y+10j3P
+トーン,トーン,tone,JLPT_1 JLPT,O1)Y~lZnk@
+とかく,とかく,"anyhow, anyway, in any case",JLPT_1 JLPT,Jhr>yBj`X[
+とがめる,とがめる,"to blame, to rebuke",JLPT_1 JLPT,tCyhd<KEBb
+時折,ときおり,sometimes,JLPT_1 JLPT,cBC8l)@|Bd
+とぎれる,とぎれる,"to pause, to be interrupted",JLPT_1 JLPT,M`gmYE]A0;
+研ぐ,とぐ,"to sharpen, to grind, to polish",JLPT_1 JLPT,lUJgFysD==
+特技,とくぎ,special talent; skill,JLPT_1 JLPT Intermediate_Japanese_Ln.8 Intermediate_Japanese,"iyF,MXDXX4"
+独裁,どくさい,"dictatorship, despotism",JLPT_1 JLPT,"c+G[A,i*M0"
+特産,とくさん,"specialty, special product",JLPT_1 JLPT,Cyr8}5s:<j
+独自,どくじ,"original, peculiar, characteristic",JLPT_1 JLPT,iCBdeKS#GI
+特集,とくしゅう,"feature (e.g., newspaper, special edition, report)",JLPT_1 JLPT,wi!>SN]gEF
+独占,どくせん,monopoly,JLPT_1 JLPT,j~8Pw]-mt@
+独創,どくそう,originality,JLPT_1 JLPT,gXnxl+EiHr
+得点,とくてん,"score, points made",JLPT_1 JLPT,"u`t,J1?=>5"
+特派,とくは,"send specially, special envoy",JLPT_1 JLPT,HzEPo`9b]p
+特有,とくゆう,"characteristic (of, peculiar (to))",JLPT_1 JLPT,s!rvO*5;{%
+とげ (をさす),とげ (をさす),thorn,JLPT_1 JLPT,hJ#iZ92?#q
+遂げる,とげる,"to accomplish, to achieve, to carry out",JLPT_1 JLPT,xrXbhn4rr4
+～どころか,～どころか,"rather, far from",JLPT_1 JLPT,EHH{[82H7I
+年頃,としごろ,"age, marriageable age, adolescence",JLPT_1 JLPT,etGaTJBp9c
+戸締り,とじまり,"closing up, locking the doors",JLPT_1 JLPT,br8:Ms=|$#
+途上,とじょう,"en/in route, half way",JLPT_1 JLPT,u0JdXEY0c~
+土台,どだい,"foundation, base, basis",JLPT_1 JLPT,cvkea1V_|{
+途絶える,とだえる,"to stop, to cease, to come to an end",JLPT_1 JLPT,G6Wu+!]SF@
+特許,とっきょ,"special permission, patent",JLPT_1 JLPT,y;*Z>uq]4W
+特権,とっけん,"privilege, special right",JLPT_1 JLPT,k%B0csu$EA
+とっさに,とっさに,at once,JLPT_1 JLPT,q}5LIfDsGB
+突如,とつじょ,"suddenly, all of a sudden",JLPT_1 JLPT,vs{$6V?ZhH
+とって,とって,"handle, grip, knob",JLPT_1 JLPT,G05L%<Kvt?
+突破,とっぱ,"breaking through, breakthrough, penetration",JLPT_1 JLPT,BUU#!_nB`?
+土手,どて,"embankment, bank",JLPT_1 JLPT,P7Y3[uoFO/
+届,とどけ,"report, notification, registration",JLPT_1 JLPT,k&rtuoJHn+
+滞る,とどこおる,"to stagnate, to be delayed",JLPT_1 JLPT,K*Hz>u1V/7
+整える,ととのえる,"to put in order, to arrange, to adjust; to get ready, to prepare; to raise money",JLPT_1 JLPT,yz)tg)bvJH
+止める,とどめる,"to end, to stop, to cease, to resign",JLPT_1 JLPT,IgE:xC]C-g
+唱える,となえる,"to recite, to chant, to call upon",JLPT_1 JLPT,Gg`8L(I3?q
+殿様,とのさま,feudal lord,JLPT_1 JLPT,xjLi|(N)Y!
+土俵,どひょう,arena,JLPT_1 JLPT,kt7if2NoDZ
+扉,とびら,"door, opening",JLPT_1 JLPT,I24=_qRNG{
+溝,どぶ,"ditch, drain, gap",JLPT_1 JLPT,Hzol[}&YZl
+徒歩,とほ,"walking, going on foot",JLPT_1 JLPT,Fjm7hAD%fu
+土木,どぼく,public works,JLPT_1 JLPT,jgd#[Gmw^^
+とぼける,とぼける,"to play dumb, to feign ignorance, to play innocent, to have a blank facial expression; to play the fool; to be in one's dotage",JLPT_1 JLPT,HA39$4<O7S
+乏しい,とぼしい,"meager, scarce, hard up, poor",JLPT_1 JLPT,"wt#tsoF,$N"
+富,とみ,"wealth, fortune",JLPT_1 JLPT,kl&?2R4Ul?
+富む,とむ,"to be rich, to become rich",JLPT_1 JLPT,Q?~wK|+t|p
+共稼ぎ,ともかせぎ,"working together, (husband and wife) earning a living together",JLPT_1 JLPT,"K<|&apg,,5"
+伴う,ともなう,"to accompany, to bring with",JLPT_1 JLPT,ntk-`u.Caj
+共働き,ともばたらき,dual income (husband and wife both working),JLPT_1 Intermediate_Japanese_Ln.14 JLPT Intermediate_Japanese,KsJK.WMk9k
+ドライ,ドライ,dry,JLPT_1 JLPT,uyF82nwuCT
+ドライクリーニング,ドライクリーニング,dry cleaning,JLPT_1 JLPT,hI<4F;7$M(
+ドライバー,ドライバー,"driver, screwdriver",JLPT_1 JLPT,JR*AC1{b!P
+ドライブイン,ドライブイン,drive in,JLPT_1 JLPT,lGQ5H]umJ
+トラブル,トラブル,trouble (sometimes used as a verb),JLPT_1 JLPT,fF~?5;]hHp
+トランジスター,トランジスター,transistor,JLPT_1 JLPT,G8*[Jm%i5[
+とりあえず,とりあえず,"at once, first of all, for the time being",JLPT_1 JLPT,"A3E,EB~Q2G"
+取扱,とりあつかい,"treatment, handling, management",JLPT_1 JLPT,rBTr^DU*Cx
+取り扱う,とりあつかう,"to treat, to handle, to deal in",JLPT_1 JLPT,f<xt2FJB#W
+鳥居,とりい,Shinto shrine archway,JLPT_1 JLPT,bwgFGu0jgU
+取り替え,とりかえ,"swap, exchange",JLPT_1 JLPT,"LmK#s,9;im"
+取り組む,とりくむ,"to tackle, to engage in a bout, to come to grips with",JLPT_1 JLPT,FUhxb`Icnx
+取締り,とりしまり,"control, crackdown, supervision",JLPT_1 JLPT,Nn_#J1j`cb
+取り締まる,とりしまる,"to crack down, to control, to supervise",JLPT_1 JLPT,u>YtS}dO87
+取り調べる,とりしらべる,"to investigate, to examine",JLPT_1 JLPT,"lTv.J/i,RR"
+取り立てる,とりたてる,"to collect, to extort",JLPT_1 JLPT,u]pjW8@;4G
+取り次ぐ,とりつぐ,"to act as an agent for, to announce (someone), to convey (a message)",JLPT_1 JLPT,h81vV]thLx
+取り付ける,とりつける,"to furnish, to install; to get someone's agreement",JLPT_1 JLPT,OLVn)Sl<l<
+取り除く,とりのぞく,"to remove, to take away, to set apart",JLPT_1 JLPT,hNl.|rVPKI
+取引,とりひき,"transactions, dealings, business",JLPT_1 JLPT,QK;D?PC(Iv
+取り巻く,とりまく,"to surround, to circle, to enclose",JLPT_1 JLPT,E%Fl$NJpIJ
+取り混ぜる,とりまぜる,"to mix, to put together",JLPT_1 JLPT,Bo(wYaa}Ah
+取り戻す,とりもどす,"to take back, to regain",JLPT_1 JLPT,pPlunQ{V=M
+取り寄せる,とりよせる,"to order, to send away for",JLPT_1 JLPT,M^8;v4K?HH
+ドリル,ドリル,drill,JLPT_1 JLPT,tLuvrWP-bR
+副,とりわけ,"especially, above all",JLPT_1 JLPT,I|~T6euZ&R
+とろける,とろける,melt; to be enchanted with,JLPT_1 JLPT,zCt%1bEngS
+鈍感,どんかん,"thickheadedness, stolidity",JLPT_1 JLPT,AGgv#X94Iv
+とんだ,とんだ,"terrible, awful, serious, absolutely not",JLPT_1 JLPT,H?67/UOJ%d
+度忘れ,どわすれ,"lapse of memory, forget for a moment",JLPT_1 JLPT,O3@@XzGoQO
+問屋,とんや,wholesale store,JLPT_1 JLPT,L]HWWc9|Rk
+内閣,ないかく,"cabinet, (government)",JLPT_1 JLPT,y)df|:D=Sq
+乃至,ないし,"from...to, between...and, or",JLPT_1 JLPT,iAOF?Qa_8q
+内緒,ないしょ,"secrecy, privacy, secret",JLPT_1 JLPT,u~2eY8N1H4
+内心,ないしん,"innermost thoughts, real intention, inmost heart",JLPT_1 JLPT,qVMnXwPQkx
+内蔵,ないぞう,internal organ; built-in,JLPT_1 JLPT,L]Dm~E_?j[
+ナイター,ナイター,"game under lights (e.g., baseball), night game",JLPT_1 JLPT,w71YMp^g^|
+内部,ないぶ,"interior, inside, internal",JLPT_1 JLPT,Qc_^Hv.8K<
+内乱,ないらん,"civil war, domestic conflict",JLPT_1 JLPT,"nyNNE_],O!"
+内陸,ないりく,inland,JLPT_1 JLPT,G}P5V$Jk?4
+苗,なえ,rice seedling,JLPT_1 JLPT,D`y6b-_J-}
+なおさら,なおさら,"all the more, still less",JLPT_1 JLPT,D3]|seyAVE
+流し,ながし,sink,JLPT_1 JLPT,sUm$!Jp0[}
+長々,ながなが,"long, drawn-out, very long",JLPT_1 JLPT,OTwM?YMLfQ
+中程,なかほど,"middle, midway",JLPT_1 JLPT,A)F$iP@]z@
+渚,なぎさ,"water's edge, beach, shore",JLPT_1 JLPT,zd22=yfA9n
+嘆く,なげく,"to sigh, to lament, to grieve",JLPT_1 JLPT,ilzJ;<!YjV
+投げ出す,なげだす,"to abandon, to throw out",JLPT_1 JLPT,vl-:<#dR[!
+仲人,なこうど,"go-between, matchmaker",JLPT_1 JLPT,kknZLw#*&s
+和やか,なごやか,"mild, calm, harmonious",JLPT_1 JLPT,EbN._V9![%
+名残,なごり,"remains, traces, memory",JLPT_1 JLPT,oz>_]^qFZM
+情け,なさけ,"sympathy, compassion",JLPT_1 JLPT,D|r~;|9R]k
+情無い,なさけない,"miserable, pitiable, shameful",JLPT_1 JLPT,N<_jdqMHiS
+情深い,なさけぶかい,"tender-hearted, compassionate",JLPT_1 JLPT,P:u6w48-M4
+詰る,なじる,"to rebuke, to scold, to tell off",JLPT_1 JLPT,m2ug%F|{:P
+名高い,なだかい,"famous, celebrated, well-known",JLPT_1 JLPT,CAOqe%9eXa
+雪崩,なだれ,avalanche,JLPT_1 JLPT,i|el8n-PMm
+懐く,なつく,to become emotionally attached,JLPT_1 JLPT,g];Z(M#sXQ
+名付ける,なづける,to name,JLPT_1 JLPT,NJQx_8`$@d
+何気ない,なにげない,"casual, unconcerned",JLPT_1 JLPT,GCR5kv%JGq
+なにとぞ,なにとぞ,"please, kindly, by all means",JLPT_1 JLPT,lQ*Q=lmCB7
+なにより,なにより,"most, best",JLPT_1 JLPT,Ifj=x)`!7.
+ナプキン,ナプキン,napkin,JLPT_1 JLPT,dY;w6ETO=:
+名札,なふだ,"name plate, name tag",JLPT_1 JLPT,"H,LzU#iC|r"
+生臭い,なまぐさい,"smelling of fish or blood, fish or meat",JLPT_1 JLPT,vDPDWlb?&h
+生温い,なまぬるい,"lukewarm, halfhearted",JLPT_1 JLPT,G~a-u$_3U#
+生身,なまみ,"living flesh, flesh and blood, the quick",JLPT_1 JLPT,mdk5@{-d$q
+鉛,なまり,lead (the metal),JLPT_1 JLPT,clLq6d~d8L
+滑らか,なめらか,"smoothness, glassiness",JLPT_1 JLPT,F~B/LW)1su
+嘗める,なめる,to lick; to experience; to make fun of,JLPT_1 JLPT,"h&h,RaX>m("
+悩ましい,なやましい,"seductive, melancholy, languid",JLPT_1 JLPT,vf@^4N2dLC
+悩ます,なやます,"to bother, to harass, to molest",JLPT_1 JLPT,jR2E;(CfhM
+悩み,なやみ,"trouble(s), worry, distress",JLPT_1 JLPT Genki_Ln.19 Genki,"rYH,[!J71-"
+並びに,ならびに,and,JLPT_1 JLPT,Ny*4D`O(3Y
+成り立つ,なりたつ,"to consist of; to be practical (logical, feasible, viable), to be concluded, to hold true",JLPT_1 JLPT,m1{^Hc5[&f
+なるたけ,なるたけ,"as much as possible, if possible",JLPT_1 JLPT,y(q.AD0L#F
+慣れ,なれ,"practice, experience",JLPT_1 JLPT,j7[97Xg7/>
+馴々しい,なれなれしい,"familiar, make free with",JLPT_1 JLPT,shT?wsHw[_
+～なんか,～なんか,in the least ~,JLPT_1 JLPT,d.Q@D)R`y/
+ナンセンス,ナンセンス,nonsense,JLPT_1 JLPT,moW2Xjtt^+
+何だか,なんだか,"a little, somewhat, somehow",JLPT_1 JLPT Intermediate_Japanese Intermediate_Japanese_Ln.11,hYSEqVkL.V
+なんだかんだ,なんだかんだ,something or other,JLPT_1 JLPT,Hjnd-`9LXB
+なんなり,なんなり,"anything, whatever",JLPT_1 JLPT,w_?<3$dc`X
+荷,に,"load, baggage, cargo",JLPT_1 JLPT,yqk%}[]JXT
+似通う,にかよう,to resemble closely,JLPT_1 JLPT,Dm9*/_j8S;
+にきび,にきび,"pimple, acne",JLPT_1 JLPT,e&g:V:ku_]
+賑わう,にぎわう,"to prosper, to flourish, to be crowded with people",JLPT_1 JLPT,g#ovh${-3n
+憎しみ,にくしみ,hatred,JLPT_1 JLPT,QPkVwq]vjj
+肉親,にくしん,"blood relationship, blood relative",JLPT_1 JLPT,uWXLxRMJ+O
+肉体,にくたい,"the body, the flesh",JLPT_1 JLPT,gnN00<v<{9
+逃げ出す,にげだす,"to run away, to escape from",JLPT_1 JLPT,fl)eIr9*lI
+西日,にしび,westering sun,JLPT_1 JLPT,K3I7nq2l;L
+滲む,にじむ,"to run, to blur, to spread",JLPT_1 JLPT,o9up<Sz=ve
+にせ物,にせもの,"imitation, counterfeit",JLPT_1 JLPT,A=&EK6O#1I
+日夜,にちや,"day and night, always",JLPT_1 JLPT,i%dEbeqYtB
+荷造り,にづくり,"packing, baling, crating",JLPT_1 JLPT,qOwG&WZKL2
+担う,になう,"to carry on shoulder, to bear (burden), to shoulder (gun)",JLPT_1 JLPT,F#SgKxy?S*
+鈍る,にぶる,"to become less capable, to grow dull, to become blunt, to weaken",JLPT_1 JLPT,L.(Z=bmrwj
+にも関わらず,にもかかわらず,"in spite of, nevertheless",JLPT_1 JLPT,KlWPE-D`h0
+ニュアンス,ニュアンス,nuance,JLPT_1 JLPT,LUTAFMalyV
+ニュー,ニュー,new,JLPT_1 JLPT,"Gfvoid,rAZ"
+入手,にゅうしゅ,"obtaining, coming to hand",JLPT_1 JLPT,KYs]w;nq{f
+入賞,にゅうしょう,winning a prize or place (in a contest,JLPT_1 JLPT,"QQ,s.4v3{f"
+入浴,にゅうよく,"bathe, bathing",JLPT_1 JLPT,K$j=e4Tdlp
+尿,にょう,urine,JLPT_1 JLPT,jT5|c!zG9i
+認識,にんしき,"recognition, cognizance",JLPT_1 JLPT,"sX|,Qiq}<w"
+妊娠,にんしん,"conception, pregnancy",JLPT_1 JLPT,j|`SG%:20Y
+任務,にんむ,"duty, mission, task",JLPT_1 JLPT,h6lc;]{2nu
+任命,にんめい,"appointment, nomination, ordination",JLPT_1 JLPT,En]Zo|mh[y
+抜かす,ぬかす,"to omit, to leave out",JLPT_1 JLPT,B_-9.@R#h`
+抜け出す,ぬけだす,"to slip out, to sneak away, to excel",JLPT_1 JLPT,pLSh/TV^OR
+主,ぬし,"owner, master, god",JLPT_1 JLPT Intermediate_Japanese_Ln.13 Intermediate_Japanese,f$iPQS#{]6
+沼,ぬま,"swamp, bog, pond",JLPT_1 JLPT,q-TqHFf#eJ
+音色,ねいろ,"tone color, timbre",JLPT_1 JLPT,C=~bfd:qmo
+値打ち,ねうち,"value, worth, price",JLPT_1 JLPT,s_}27&HmzM
+ネガ,ネガ,(photographic) negative,JLPT_1 JLPT,tRtoeF@*NA
+寝かせる,ねかせる,"to put to bed, to lay down, to ferment",JLPT_1 JLPT,i8aC;^zTA&
+ねじまわし,ねじまわし,screwdriver,JLPT_1 JLPT,lC3$+z.Dp9
+捩れる,ねじれる,"twist, strain",JLPT_1 JLPT,Shp4gNU#M
+妬む,ねたむ,"to be jealous, to be envious",JLPT_1 JLPT,LkwOsP2luZ
+ねだる,ねだる,"to nag, to demand",JLPT_1 JLPT,bqJI({hGlV
+熱意,ねつい,"zeal, enthusiasm",JLPT_1 JLPT,rd11dz%oP<
+熱湯,ねっとう,boiling water,JLPT_1 JLPT,yBQ@*k[rMd
+熱量,ねつりょう,calorific value,JLPT_1 JLPT,yVC<gDS.Nb
+粘り,ねばり,"stickiness, viscosity",JLPT_1 JLPT,BvIS%RjDgh
+粘る,ねばる,"to be sticky, to be adhesive, to persist, to stick to",JLPT_1 JLPT,q5idXyJ?~3
+値引き,ねびき,"price reduction, discount",JLPT_1 JLPT,ppHz}aRok7
+根回し,ねまわし,making necessary arrangements,JLPT_1 JLPT,k|jB&4ScOn
+眠たい,ねむたい,sleepy,JLPT_1 JLPT,A:U[i:g3Mu
+練る,ねる,"to knead, to work over, to polish up",JLPT_1 JLPT,OcA{._U(He
+念,ねん,"sense, feeling, desire",JLPT_1 JLPT,uVWX2{yDLk
+年賀,ねんが,"New Year's greetings, New Year's card",JLPT_1 JLPT,P$?kkzx-4;
+念願,ねんがん,"one's heart's desire, earnest petition",JLPT_1 JLPT,N2]ye^.%%-
+年号,ねんごう,"name of an era, year number",JLPT_1 JLPT,bLo0`T)GZr
+燃焼,ねんしょう,"burning, combustion",JLPT_1 JLPT,zKpI9!^gxJ
+年長,ねんちょう,seniority,JLPT_1 JLPT,L5;%C?!rKM
+燃料,ねんりょう,fuel,JLPT_1 JLPT,rltcX_fvi[
+年輪,ねんりん,annual tree ring,JLPT_1 JLPT,b+fwXle>0o
+ノイローゼ,ノイローゼ,neurosis (GER: Neurose),JLPT_1 JLPT,"J+@dVGG,?/"
+農耕,のうこう,"farming, agriculture",JLPT_1 JLPT,s|V;EQ<DFG
+農場,のうじょう,farm,JLPT_1 JLPT,f{r<5W&Bpu
+農地,のうち,agricultural land,JLPT_1 JLPT,gFlV*(m#WE
+納入,のうにゅう,"payment, supply",JLPT_1 JLPT,K9YdM1s/F>
+逃す,のがす,"to let loose, to set free, to let escape",JLPT_1 JLPT,cfjj1lW1R
+逃れる,のがれる,to escape,JLPT_1 JLPT,ur0/yS?G.F
+軒並,のきなみ,row of houses; uniformly,JLPT_1 JLPT,gYh0C^=J<1
+望ましい,のぞましい,"desirable, hoped for",JLPT_1 JLPT,O~bUfdZRZc
+乗っ取る,のっとる,"to capture, to occupy, to take over",JLPT_1 JLPT,D>275*`Xs9
+のどか,のどか,"tranquil, calm, quiet",JLPT_1 JLPT,IT.<Z@]SZ.
+罵る,ののしる,"to speak ill of, to abuse",JLPT_1 JLPT,o]7]HcCGpH
+延べ,のべ,"futures, credit (buying), stretching, total",JLPT_1 JLPT,Eb3R}G~vq&
+飲み込む,のみこむ,"to gulp down, to swallow deeply, to understand",JLPT_1 JLPT Intermediate_Japanese_Ln.12 Intermediate_Japanese,fwLCsj3c:^
+乗り込む,のりこむ,"to board, to get into (a car); to march into, to enter",JLPT_1 JLPT,"P^t~AIQ,:b"
+刃,は,"blade, sword",JLPT_1 JLPT,s8NuMFbIpb
+～派,～は,"group, party, section (mil)",JLPT_1 JLPT,qMeKLND8O$
+バー,バー,bar,JLPT_1 JLPT,xD;./&*C~}
+把握,はあく,"grasp, catch, understanding",JLPT_1 JLPT,DFve{Ag1B(
+パート,パート,part-time job,JLPT_1 JLPT Intermediate_Japanese_Ln.8 Intermediate_Japanese,OK)Lf1Yk5g
+廃棄,はいき,"disposal, abandon, discarding",JLPT_1 JLPT,"t,]x!4!SsB"
+配給,はいきゅう,"distribution (e.g., films, rice",JLPT_1 JLPT,BIJAh&96+q
+ばい菌,ばいきん,"bacteria, germ(s)",JLPT_1 JLPT,F@%B4+?fE|
+配偶者,はいぐうしゃ,spouse,JLPT_1 JLPT,j5as3|4RM2
+拝啓,はいけい,-- a formal greeting used at the beginning of a letter --,Intermediate_Japanese_Ln.4 JLPT_1 JLPT Intermediate_Japanese,+.sAx2wLV
+背景,はいけい,"background, scenery, setting",JLPT_1 JLPT,B;EWwcKw8a
+背後,はいご,"back, rear",JLPT_1 JLPT,"l$UvE^.,2i"
+廃止,はいし,"abolition, repeal",JLPT_1 JLPT,"D{,71BeMS8"
+拝借,はいしゃく,(humble) (polite) borrowing,JLPT_1 JLPT,"w!,O.|Pr}V"
+排除,はいじょ,"exclusion, removal, rejection",JLPT_1 JLPT,"e(cIaHsE,F"
+賠償,ばいしょう,"reparations, indemnity, compensation",JLPT_1 JLPT,i0;;9:0(Yb
+排水,はいすい,drainage,JLPT_1 JLPT,CI{]`I5(&E
+敗戦,はいせん,"defeat, losing a war",JLPT_1 JLPT,JSMF6y%Lj~
+配置,はいち,"arrangement (of resources), disposition",JLPT_1 JLPT,wZ<r/Id^hw
+配布,はいふ,distribution,JLPT_1 JLPT,j3UYv2B1e{
+配分,はいぶん,"distribution, allotment",JLPT_1 JLPT,sPEejO/d9<
+敗北,はいぼく,defeat (as a verb it means 'to be defeated'),JLPT_1 JLPT,=90:_^P$k
+倍率,ばいりつ,"diameter, magnification",JLPT_1 JLPT,h`ahPtUY;b
+配慮,はいりょ,"consideration, concern, forethought",JLPT_1 JLPT,poW=.ChJSm
+配列,はいれつ,"arrangement, array (programming)",JLPT_1 JLPT,cC<!?;J:<g
+破壊,はかい,destruction,JLPT_1 JLPT,v!Zp^6YAqE
+いたわる,いたわる,"to sympathize with, to console, to care for",JLPT_1 JLPT,wcGai|q>xT
+一概に,いちがいに,"unconditionally, necessarily",JLPT_1 JLPT,hLV>poM3Dq
+著しい,いちじるしい,"remarkable, considerable",JLPT_1 JLPT,"kPPz=m,gRR"
+一同,いちどう,"all present, all concerned, all of us",JLPT_1 JLPT,O|v*CB_J$V
+一部分,いちぶぶん,"a part, a portion",JLPT_1 JLPT,kC:AyoQ(VZ
+一別,いちべつ,parting,JLPT_1 JLPT,P}9Ns5lV8E
+一面,いちめん,"one side, the other hand",JLPT_1 JLPT,Nx0OsZUH*E
+一目,いちもく,"a glance, a look, a glimpse",JLPT_1 JLPT,saAg*cc00y
+一様,いちよう,"uniform, similar, equal",JLPT_1 JLPT,4Npj$}s^v
+一律,いちりつ,"even, uniform, equal",JLPT_1 JLPT,s7Bp#3`c^s
+一連,いちれん,"a series, a chain, a ream (of paper)",JLPT_1 JLPT,"K`?fU[;],#"
+一括,いっかつ,"all together, batch",JLPT_1 JLPT,hhovzuJKNB
+一気,いっき,"at one push, in one gulp",JLPT_1 JLPT,CgBD$%2<51
+一挙に,いっきょに,"at a stroke, with a single swoop",JLPT_1 JLPT,F:IKX%#S}~
+一見,いっけん,"a look, a glimpse, glance; first meeting",JLPT_1 JLPT,NZ6>sHobC*
+一切,いっさい,"without exception, the whole",JLPT_1 JLPT,v}WLTgJ@1I
+一心,いっしん,"one mind, with rapt attention",JLPT_1 JLPT,cClq^_-/LZ
+いっそ,いっそ,"rather, sooner, might as well",JLPT_1 JLPT,Ii]&B%6J^H
+一変,いっぺん,complete change,JLPT_1 JLPT,ek#.`h}8]>
+意図,いと,"intention, aim, design",JLPT_1 JLPT,"Nv%*-6B!(,"
+営む,いとなむ,"to carry on (e.g., in ceremony), to run a business",JLPT_1 JLPT,DwKEu03*|H
+挑む,いどむ,to challenge,JLPT_1 JLPT,c_-t#iEGZZ
+稲光,いなびかり,(flash of) lightning,JLPT_1 JLPT,c#^JVd1}UB
+祈り,いのり,"prayer, supplication",JLPT_1 JLPT,Ma]tANx6d6
+いびき,いびき,snoring,JLPT_1 JLPT,C/{&bugX+}
+今更,いまさら,"now, again",JLPT_1 JLPT,hj*29Ug#1R
+未だ,いまだ,"yet, still",JLPT_1 JLPT,p:dli@Jl!z
+移民,いみん,"emigrant, immigrant",JLPT_1 JLPT,CLJ[Ns`Z6Z
+嫌々,いやいや,"reluctantly, by no means, unwillingly",JLPT_1 JLPT,QjHKtey?XJ
+卑しい,いやしい,"greedy, vulgar, shabby",JLPT_1 JLPT,vBh9gD/$!+
+いやに,いやに,"awfully, terribly",JLPT_1 JLPT,qpdLL_V*P#
+いやらしい,いやらしい,"unpleasant, disgusting, indecent",JLPT_1 JLPT,D<T6@Y-YD4
+意欲,いよく,"will, desire, ambition",JLPT_1 JLPT,Fq(`u%{Obm
+威力,いりょく,"power, might, authority",JLPT_1 JLPT,r5er8dT<)9
+衣類,いるい,"clothes, clothing, garments",JLPT_1 JLPT,QbNSCWqQ4!
+異論,いろん,"different opinion, objection",JLPT_1 JLPT,A?E^7mu[K@
+印鑑,いんかん,"stamp, seal",JLPT_1 JLPT,cTR~#z|<0M
+陰気,いんき,"gloom, melancholy",JLPT_1 JLPT,A-+&-Fy%1r
+隠居,いんきょ,retirement; retired person,JLPT_1 JLPT,b^vje[Ox#X
+インターチェンジ,インターチェンジ,interchange,JLPT_1 JLPT,"rBKXdv$/G,"
+インターナショナル,インターナショナル,international,JLPT_1 JLPT,JmV&U~p0X$
+インターフォン,インターフォン,"entry phone, intercom",JLPT_1 JLPT,AO3rDw-;8U
+インテリ,インテリ,"(abbr.) egghead, intelligentsia",JLPT_1 JLPT,piGc%@]7]l
+インフォメーション,インフォメーション,information,JLPT_1 JLPT,KO4Fli5w!*
+インフレ,インフレ,(abbr.) inflation,JLPT_1 JLPT,QC}1+m@@J*
+受かる,うかる,to pass (examination),JLPT_1 JLPT,gIq*pkmfp{
+受け入れ,うけいれ,"receiving, acceptance",JLPT_1 JLPT,j&5piEC:H:
+受け入れる,うけいれる,"to accept, to receive",JLPT_1 JLPT,i_JCrJB_9E
+受け継ぐ,うけつぐ,"to inherit, to succeed",JLPT_1 JLPT,x6H#Y*OpNS
+受け付ける,うけつける,"to be accepted, to receive (an application)",JLPT_1 JLPT,wJiQ/5Nn/x
+受け止める,うけとめる,"to catch, to react to, to take",JLPT_1 JLPT,kQB/rB@6#x
+受身,うけみ,"passive, passive voice",JLPT_1 JLPT,AB05ev+c>K
+受持ち,うけもち,"charge (of something), matter in one's charge",JLPT_1 JLPT,"DiB3?u$z,A"
+動き,うごき,"movement, activity, trend",JLPT_1 JLPT,u]mcX[(LyK
+埋める,うずめる,"to bury, to fill",JLPT_1 JLPT,s1}PR|XGjV
+嘘つき,うそつき,liar,JLPT_1 JLPT,huy&f$4B!!
+うたた寝,うたたね,"dozing, napping",JLPT_1 JLPT,g>}T9.Ly4K
+打ち明ける,うちあける,"to confess, to be open",JLPT_1 JLPT,m>OKlxKk@!
+打ち切る,うちきる,"to stop, to abort, to discontinue, to close",JLPT_1 JLPT,NY3MFaZc*o
+打ち消し,うちけし,"(gram) negation, denial, negative",JLPT_1 JLPT,FFlOc.L!8+
+打ち込む,うちこむ,"to devote oneself to, to shoot into",JLPT_1 JLPT,"iV,JA!*tZ)"
+団扇,うちわ,fan,JLPT_1 JLPT,AXix@CPuvn
+内訳,うちわけ,"the items, breakdown, classification",JLPT_1 JLPT,"kc.tS5mj},"
+写し,うつし,"copy, duplicate",JLPT_1 JLPT,o]mr>S?=4H
+訴え,うったえ,"lawsuit, complaint",JLPT_1 JLPT,L0%2@MBXxQ
+うっとうしい,うっとうしい,"weary, annoying",JLPT_1 JLPT,D_nkEIxjCi
+うつむく,うつむく,"to look downward, to stoop",JLPT_1 JLPT,vZ9f:pDf9{
+空ろ,うつろ,"blank, hollow, empty",JLPT_1 JLPT,gT)UMo=-nJ
+器,うつわ,"bowl, vessel, container",JLPT_1 JLPT,wCFSLHrDCy
+腕前,うでまえ,"ability, skill, facility",JLPT_1 JLPT,M#fh/cwlNl
+雨天,うてん,rainy weather,JLPT_1 JLPT,w*!:re!1<+
+促す,うながす,"to urge, to suggest, to demand",JLPT_1 JLPT,wV^GWyWg_j
+うぬぼれ,うぬぼれ,"pretension, conceit, hubris",JLPT_1 JLPT,m]YR4b{=@z
+生まれつき,うまれつき,"by nature, by birth, native",JLPT_1 JLPT,vf1rqkwzEV
+埋め込む,うめこむ,"to embed, implant",JLPT_1 JLPT,xua#+HlIBN
+梅干し,うめぼし,dried plum,JLPT_1 JLPT,y[D$6jL9AV
+裏返し,うらがえし,"inside out, reverse",JLPT_1 JLPT,x!`i3g6fj/
+売り出し,うりだし,(bargain) sale,JLPT_1 JLPT,e#9|l1/ymz
+売り出す,うりだす,"to put on sale, to market",JLPT_1 JLPT,gIddcx*`Ct
+潤う,うるおう,to be moist; to profit by,JLPT_1 JLPT,iEM[52wf::
+浮気,うわき,"affair, to cheat",JLPT_1 JLPT,niMRrvhuXD
+上回る,うわまわる,to exceed,JLPT_1 JLPT,xvIWa_An&S
+植わる,うわる,to be planted,JLPT_1 JLPT,q/mwW_I)&k
+運営,うんえい,"management, administration, operation",JLPT_1 JLPT,m*%9#Uxp/F
+うんざり,うんざり,"tedious, boring, being fed up with",JLPT_1 JLPT,G<U}3bYTX=
+運送,うんそう,"shipping, freight",JLPT_1 JLPT,DH/^v}5V5H
+運賃,うんちん,"freight rates, shipping expenses, (passenger) fare",JLPT_1 JLPT Intermediate_Japanese_Ln.10 Intermediate_Japanese,"OS<,k|.D(5"
+云々,うんぬん,"and so on, and so forth",JLPT_1 JLPT,LiOOViPg]s
+運搬,うんぱん,"transport, carriage",JLPT_1 JLPT,KHqZvxZ@6.
+運命,うんめい,fate,JLPT_1 JLPT,l3_#00|#9V
+運輸,うんゆ,transportation,JLPT_1 JLPT,"M~H0atu}?,"
+運用,うんよう,"making use of, application, practical use",JLPT_1 JLPT,P{!{:>o!_q
+エアメール,エアメール,air mail,JLPT_1 JLPT,q`%AC;;9Ta
+～営,～えい,~ run,JLPT_1 JLPT,dP^UCy0C~l
+英字,えいじ,English letter (character),JLPT_1 JLPT,"J1lN,M8$1h"
+映写,えいしゃ,projection,JLPT_1 JLPT,x`Mnz)m&qb
+映像,えいぞう,"reflection, image",JLPT_1 JLPT,m?:Se-SQN4
+英雄,えいゆう,"hero, great man",JLPT_1 JLPT,lpc:AiI>>Z
+液,えき,"liquid, fluid",JLPT_1 JLPT,r(jP%;ZEI5
+閲覧,えつらん,"inspection, reference, browse",JLPT_1 JLPT,hDsmHpZ7Os
+獲物,えもの,"game, spoils, trophy",JLPT_1 JLPT,5*sGNpi>A
+襟,えり,"neck, collar",JLPT_1 JLPT,tRB]@ee=lY
+エレガント,エレガント,elegant,JLPT_1 JLPT,efgo>`$5}C
+円滑,えんかつ,"harmony, smoothness",JLPT_1 JLPT,Kb_Dvgh:lA
+縁側,えんがわ,"veranda, porch, balcony, open corridor",JLPT_1 JLPT,wyHg^[mZl2
+沿岸,えんがん,"coast, shore",JLPT_1 JLPT,AovU9kG]Un
+婉曲,えんきょく,"euphemistic, indirect, insinuating",JLPT_1 JLPT,G;:<3(vTfF
+演出,えんしゅつ,"production (erg. play, direction)",JLPT_1 JLPT,"wf^,)@RdCb"
+エンジニア,エンジニア,engineer,JLPT_1 JLPT,B{mLrpXMY9
+演じる,えんじる,"to perform, to play (a part), to act",JLPT_1 JLPT,"w/:3TeD,r|"
+演ずる,えんずる,"to perform, to play (a part), to act",JLPT_1 JLPT,D7;+x/XKhh
+沿線,えんせん,along railway line,JLPT_1 JLPT,ALo8teWhD7
+縁談,えんだん,marriage proposal,JLPT_1 JLPT,noJgGKIj8x
+遠方,えんぽう,"long way, distant place",JLPT_1 JLPT,OzC<9.M=Ar
+円満,えんまん,"harmony, peace, smoothness",JLPT_1 JLPT,Ct:pLi;{3A
+追い込む,おいこむ,"to herd, to corner, to drive",JLPT_1 JLPT,AR1qUDM@P)
+追い出す,おいだす,"to expel, to drive out",JLPT_1 JLPT,"riRN3`p,`k"
+於いて,おいて,"at, in, on",JLPT_1 JLPT,ijyE>WQ}KT
+老いる,おいる,"to age, to grow old",JLPT_1 JLPT,Fq*tJ8V7V$
+応急,おうきゅう,emergency,JLPT_1 JLPT,P7w*v4FZJr
+黄金,おうごん,gold,JLPT_1 JLPT,mYt_k*xkZ.
+往診,おうしん,"doctor's visit, house call",JLPT_1 JLPT,KYeqnnZ=-9
+応募,おうぼ,"subscription, application",JLPT_1 JLPT,b[VDDlfAs0
+おおい (かん),おおい (かん),hey,JLPT_1 JLPT,"oI,HaDOI/S"
+大方,おおかた,"almost all, majority",JLPT_1 JLPT,xJaUka+CN:
+大柄,おおがら,"large build, large pattern",JLPT_1 JLPT,"GWS,d=cM(:"
+おおげさ,おおげさ,"grandiose, exaggerated",JLPT_1 JLPT,oddUsiCw^V
+大筋,おおすじ,"outline, summary",JLPT_1 JLPT,Hs`P|H+T!]
+大空,おおぞら,"heaven, the sky",JLPT_1 JLPT,x&4e(F[|Hd
+オートマチック,オートマチック,automatic,JLPT_1 JLPT,Ma<]_+LJWL
+大幅,おおはば,"full width, large scale, drastic",JLPT JLPT_1 MediaMissing,c`*FbFL7!*
+おおまかな,おおまかな,"rough, approximate",JLPT_1 JLPT,h|xK)[LK#`
+大水,おおみず,flood,JLPT_1 JLPT,lHnH3YrPE%
+公,おおやけ,public,JLPT_1 JLPT,oI.<`;>b`b
+犯す,おかす,"to perpetrate, to violate",JLPT_1 JLPT,r}qWP|]B{j
+侵す,おかす,"to invade, to raid, to trespass",JLPT_1 JLPT,JP!&.Z9_)1
+臆病,おくびょう,"cowardice, timidity",JLPT_1 JLPT,DR9F4{>w8i
+遅らす,おくらす,"to retard, to delay",JLPT_1 JLPT,BxX=0Td:Ra
+厳か,おごそか,"majestic, dignified",JLPT_1 JLPT,k^}q{Z*:ZU
+行い,おこない,"conduct, behavior, action",JLPT_1 JLPT,EPt}Y|moZw
+おごる (ゆうしょくを～),おごる (ゆうしょくを～),to give (someone) a treat,JLPT_1 JLPT,nplO^(LG?d
+収まる,おさまる,to settle into; to be obtained,JLPT_1 JLPT,blHU8/+m@I
+納まる,おさまる,to settle into; to be obtained,JLPT_1 JLPT,cv8FX+R{$0
+治まる,おさまる,"to be at peace, to calm down",JLPT_1 JLPT,vn/~]L;$eG
+お産,おさん,(giving) birth,JLPT_1 JLPT,euz]Ka!XAe
+押し切る,おしきる,to have one's own way,JLPT_1 JLPT,djU<$hJj6~
+押し込む,おしこむ,"to push into, to crowd into",JLPT_1 JLPT,xrb|Hb|isj
+惜しむ,おしむ,"to be frugal, to value, to regret",JLPT_1 JLPT,eSj?}z3f2/
+押し寄せる,おしよせる,"to push aside, to advance on",JLPT_1 JLPT,G6S^.J|&^/
+雄,おす,male (animal),JLPT_1 JLPT,gZ*7YqB0w(
+御世辞,おせじ,"flattery, compliment",JLPT_1 JLPT,d$tF`<~=wO
+襲う,おそう,to attack,JLPT_1 JLPT,d*HJIF;zrC
+遅くとも,おそくとも,at the latest,JLPT_1 JLPT,"p,08OPe)d%"
+恐れ,おそれ,"fear, horror",JLPT_1 JLPT,mG1{:BxE;
+恐れ入る,おそれいる,"to be filled with awe, to feel small",JLPT_1 JLPT,o7$@i&/e=j
+おだてる,おだてる,to flatter,JLPT_1 JLPT,"c}qANB`J7,"
+落ち込む,おちこむ,to get depressed,JLPT_1 Genki_Ln.16 JLPT Genki,B0Aq~FM[^o
+落ち着き,おちつき,"calm, composure",JLPT_1 JLPT,"k)L1,/cgqd"
+落葉,おちば,fallen leaves,JLPT_1 JLPT,qPS6$v<zNn
+乙,おつ,2nd in rank,JLPT_1 JLPT,"CTIZFIH,kM"
+お使い,おつかい,errand,JLPT_1 JLPT,"Q3Uu~eV;,,"
+おっかない,おっかない,"frightening, scary",JLPT_1 JLPT,r<$W[mdg(3
+お手上げ,おてあげ,"given in, given up hope",JLPT_1 JLPT,J({SY<_/!4
+おどおど,おどおど,"coweringly, hesitantly",JLPT_1 JLPT,hFdj&!1iUO
+脅す,おどす,"to threaten, to menace",JLPT_1 JLPT,l9J?^6gNw8
+訪れる,おとずれる,to visit,JLPT_1 JLPT,M;`!*}::|V
+お供,おとも,"attendant, companion",JLPT_1 JLPT,x[kh8D~cRx
+衰える,おとろえる,"to become weak, to decline",JLPT_1 JLPT,pxXWt`7[Xh
+同い年,おないどし,of the same age,JLPT_1 JLPT,uOL4]ka~4C
+自ずから,おのずから,"naturally, as a matter of course",JLPT_1 JLPT,CsPmT^E4si
+怯える,おびえる,to become frightened,JLPT_1 JLPT,Bil>aIK.P>
+おびただしい,おびただしい,"abundantly, innumerably",JLPT_1 JLPT,F0E@v8v<tK
+脅かす,おびやかす,"to threaten, to coerce",JLPT_1 JLPT,y}AqB/U_jH
+帯びる,おびる,"to bear, to carry, to be entrusted",JLPT_1 JLPT,zXZ(?*QD)1
+お袋,おふくろ,mother,JLPT_1 JLPT,Iky=(#jNrr
+覚え,おぼえ,"memory, sense, experience",JLPT_1 JLPT,z/W-oJ8vaW
+おまけ,おまけ,a discount; something additional,JLPT_1 JLPT,rsBcP;b`Jp
+お宮,おみや,Shinto shrine,JLPT_1 JLPT,COvUCQv?BW
+おむつ,おむつ,"diaper, nappy",JLPT_1 JLPT,FRkuxmL~/i
+思い付き,おもいつき,"plan, idea, suggestion",JLPT_1 JLPT,gk=p@=>B|;
+趣,おもむき,"flavor, appearance, quaint",JLPT_1 JLPT,o+otz^p(oN
+赴く,おもむく,"to go, to proceed",JLPT_1 JLPT,E5WffQ+ViL
+重んじる,おもんじる,"to respect, to honor, to esteem, to prize",JLPT_1 JLPT,"gj_$ok,;mR"
+重んずる,おもんずる,"to honor, to respect, to value",JLPT_1 JLPT,c;eXv;e7cc
+親父,おやじ,"one's father, old man, one's boss",JLPT_1 JLPT,g;f)J>kju#
+及び,および,"and, as well as",JLPT_1 JLPT,"F5z-<*3Tg,"
+及ぶ,およぶ,"to reach, to extend",JLPT_1 JLPT,Lj7$<D<:Dd
+折,おり,"chance, occasion",JLPT_1 JLPT,y[AaTw+T{(
+檻,おり,"cage, pen, jail cell",JLPT_1 JLPT,Lj@q6`R`I<
+オリエンテーション,オリエンテーション,orientation,JLPT_1 JLPT,i;fk@T:&ys
+折り返す,おりかえす,"to turn up, to fold back",JLPT_1 JLPT,x-(77`TIyH
+織物,おりもの,"textile, fabric",JLPT_1 JLPT,@6F9JKGsN
+俺,おれ,I (ego) (boastful first-person pronoun),JLPT_1 JLPT,M3v%b}<>}t
+愚か,おろか,"foolish, stupid",JLPT_1 JLPT,Ch>U~}L@[9
+おろそか,おろそか,"neglect, negligence, carelessness",JLPT_1 JLPT,H$%#VMqb~n
+おんぶ,おんぶ,carrying on one's back (erg. Baby),JLPT_1 JLPT,w[CU60-p%`
+オンライン,オンライン,on-line,JLPT_1 JLPT,i=qSrR2s#(
+温和,おんわ,"gentle, mild, moderate",JLPT_1 JLPT,II+hgA8I:B
+我,が～,ego,JLPT_1 JLPT,KEYq:ht}?d
+カーペット,カーペット,carpet,JLPT_1 JLPT,fn]9l!yDf>
+～界,～かい,"world, circle, kingdom",JLPT_1 JLPT,d]il$5=Qs$
+～街,～がい,town,JLPT_1 JLPT,PH:pbBSE|j
+改悪,かいあく,"deterioration, changing for the worse",JLPT_1 JLPT,/C5*Xn=Cv
+海運,かいうん,marine transportation,JLPT_1 JLPT,"CDcOa:,]6U"
+外貨,がいか,foreign money,JLPT_1 JLPT,P{MzU_0f=F
+改革,かいかく,"reform, reformation, innovation",JLPT_1 JLPT,"nxg,|fRPK9"
+貝殻,かいがら,shell,JLPT_1 JLPT,rr4Z^$`(_`
+外観,がいかん,"appearance, exterior, facade",JLPT_1 JLPT,JF[`}jk]g#
+階級,かいきゅう,"class, rank, grade",JLPT_1 JLPT,G#*h9O@`+|
+海峡,かいきょう,channel,JLPT_1 JLPT,jy18h1NAzv
+会見,かいけん,"interview, conference",JLPT_1 JLPT,umW!}@pgti
+介護,かいご,nursing,JLPT_1 JLPT,kEe>~$Z:bi
+開催,かいさい,"holding a meeting, open an exhibition",JLPT_1 JLPT,%(;Yq~m~L
+回収,かいしゅう,"collection, recovery",JLPT_1 JLPT,j[pPaa[c]=
+改修,かいしゅう,"repair, improvement",JLPT_1 JLPT,QiUw+PPipY
+怪獣,かいじゅう,monster,JLPT_1 JLPT,r8Gl`sM7J8
+解除,かいじょ,"cancellation, release, cancel",JLPT_1 JLPT,Mgd/-R9vWQ
+外相,がいしょう,Foreign Minister,JLPT_1 JLPT,yrLi>.nXho
+害する,がいする,"to harm, to offend",JLPT_1 JLPT,Hi`w1ksG:H
+概説,がいせつ,"general statement, outline",JLPT_1 JLPT,nT]AQT3`Q*
+回送,かいそう,forwarding,JLPT_1 JLPT,L?pD4!Fpg8
+階層,かいそう,"class, level, stratum, hierarchy",JLPT_1 JLPT,H^MD?o[__x
+開拓,かいたく,"cultivation, pioneer",JLPT_1 JLPT,FypVZrRtNH
+会談,かいだん,"conversation, interview",JLPT_1 JLPT,uN=.m/8Z~3
+改定,かいてい,reform,JLPT_1 JLPT,g6THSZ_v^<
+改訂,かいてい,revision,JLPT_1 JLPT,v0XHWw$0B0
+ガイド,ガイド,guide,JLPT_1 JLPT,CvJbP*(I@%
+街道,かいどう,highway,JLPT_1 JLPT,N$n&)AJVWA
+該当,がいとう,"corresponding, answering to, coming under",JLPT_1 JLPT,nkZ}`ld7f?
+街頭,がいとう,in the street,JLPT_1 JLPT,tQu}Nu#P].
+ガイドブック,ガイドブック,guidebook,JLPT_1 JLPT,Eo9u]7eh((
+介入,かいにゅう,intervention,JLPT_1 JLPT,pZJnTW/Kh#
+概念,がいねん,"general idea, concept, notion",JLPT_1 JLPT,E|SNJ<R/iJ
+開発,かいはつ,"development, exploitation",JLPT_1 JLPT,Kw[.UTN4^R
+海抜,かいばつ,height above sea level,JLPT_1 JLPT,jLVxr@vo2y
+介抱,かいほう,"nursing, looking after",JLPT_1 JLPT,j$OYFEbGs|
+解剖,かいぼう,"dissection, autopsy",JLPT_1 JLPT,iL)PO8n0NO
+外来,がいらい,"(abbr.) imported, outpatient clinic",JLPT_1 JLPT,~V$m/9|o}
+回覧,かいらん,circulation,JLPT_1 JLPT,E}}4:_!82P
+概略,がいりゃく,"outline, summary, gist",JLPT_1 JLPT,N)qY<nUP|*
+海流,かいりゅう,ocean current,JLPT_1 JLPT,xa/eyqaPDe
+改良,かいりょう,"improvement, reform",JLPT_1 JLPT,"v?jE,5xyr`"
+回路,かいろ,circuit (electric),JLPT_1 JLPT,fdIy<8[a*F
+海路,かいろ,sea route,JLPT_1 JLPT,t536M9u42&
+省みる,かえりみる,to reflect,JLPT_1 JLPT,taa>Gm>Nxx
+顧みる,かえりみる,"to look back, to turn around, to review",JLPT_1 JLPT,ho_c78W;*R
+顔付き,かおつき,facial expression,JLPT_1 JLPT,k<|EsPF(U~
+課外,かがい,extracurricular,JLPT_1 JLPT,ImdEjfLr)>
+掲げる,かかげる,"to hoist, to fly (a sail), to float (a flag)",JLPT_1 JLPT,Q[6r`gY-ir
+かかと,かかと,shoe heel,JLPT_1 JLPT,F`djJ$owDP
+書き取る,かきとる,"to write down, to take dictation",JLPT_1 JLPT,OeW)s:B>?h
+掻き回す,かきまわす,"to stir up, to churn, to disturb",JLPT_1 JLPT,"wp9#,9/+Z4"
+かく (はじを),かく (はじを),to humiliate oneself,JLPT_1 JLPT,h*j3Yxxcj{
+～画,～かく,~ strokes,JLPT_1 JLPT,G#l-jHUMTG
+学芸,がくげい,"arts and sciences, liberal arts",JLPT_1 JLPT,xM-CyLgdV}
+格差,かくさ,"difference, disparity",JLPT_1 JLPT,zvfu/3%U&J
+拡散,かくさん,"scattering, diffusion",JLPT_1 JLPT,y__Cg;3rb:
+学士,がくし,university graduate,JLPT_1 JLPT,Pq<3#+rCX)
+各種,かくしゅ,"every kind, all sorts",JLPT_1 JLPT,Jb^Vb%.N$q
+隔週,かくしゅう,every other week,JLPT_1 JLPT,QbwTj%&$c)
+確信,かくしん,"conviction, confidence",JLPT_1 JLPT,zEL{[Q8QNW
+革新,かくしん,"reform, innovation",JLPT_1 JLPT,ti4?AE7Yh@
+学説,がくせつ,theory,JLPT_1 JLPT,GlxSp@=1Ze
+確定,かくてい,"fixed, decision",JLPT_1 JLPT,"e18p,U0K#7"
+カクテル,カクテル,cocktail,JLPT_1 JLPT,"E($,YP#I6d"
+獲得,かくとく,"acquisition, possession",JLPT_1 JLPT,"B^,*K>>n_|"
+楽譜,がくふ,"score (music, sheet music)",JLPT_1 JLPT,qMA}9*EjCn
+確保,かくほ,"guarantee, insure, secure",JLPT_1 JLPT,uY<*K%.TG@
+革命,かくめい,revolution,JLPT_1 JLPT,O;mF68dq6Q
+確立,かくりつ,establishment,JLPT_1 JLPT,m(/`$&[BF3
+賭,かけ,"betting, gambling, a gamble",JLPT_1 JLPT,s:YO~5k/sp
+掛～,かけ～,credit,JLPT_1 JLPT,c#>^nQjhVy
+～掛け,～かけ,"rack, hanger",JLPT_1 JLPT,"Lr[e?zZ5,<"
+崖,がけ,cliff,JLPT_1 JLPT,lH2H25www/
+駆け足,かけあし,"running fast, double time",JLPT_1 JLPT,Nd5EP#88A|
+家計,かけい,"household economy, family finances",JLPT_1 JLPT,vh}KbR&s=#
+駆けっこ,かけっこ,(foot) race,JLPT_1 JLPT,"A8,h2([S[A"
+加工,かこう,"manufacturing, processing, treatment",JLPT_1 JLPT,E^@%K2YN]n
+化合,かごう,chemical combination,JLPT_1 JLPT,my>j<9l(Hz
+かさばる,かさばる,to be bulky,JLPT_1 JLPT,"nuG,E:/*HK"
+かさむ,かさむ,"to pile up, to increase",JLPT_1 JLPT,D*tj!&=/|(
+箇条書,かじょうがき,"itemized form, itemization",JLPT_1 JLPT,uU[=f*p0xK
+頭,かしら,"head, chief",JLPT_1 JLPT,qKQ^U]P!d/
+微か,かすか,"faint, dim, weak",JLPT_1 JLPT,"iuQ;E47,]H"
+霞む,かすむ,"to grow hazy, to be misty",JLPT_1 JLPT,Muk^XW#N{G
+擦る,かする,"to rub, to chafe",JLPT_1 JLPT,b*c:1ipqfg
+火星,かせい,Mars,JLPT_1 JLPT,hK6{i6DNme
+化石,かせき,"fossil, petrifaction, fossilization",JLPT_1 JLPT,i)2P[%uf@w
+河川,かせん,rivers,JLPT_1 JLPT,j9XYM<zDW5
+化繊,かせん,synthetic fibers,JLPT_1 JLPT,A<4D0W-y5X
+過疎,かそ,depopulation,JLPT_1 JLPT,C6FP<#I<*d
+片～,かた～,single ~,JLPT_1 JLPT,p/$/VrksK}
+片言,かたこと,"broken (in reference to speaking style, e.g., Japanese)",JLPT_1 JLPT Intermediate_Japanese_Ln.13 Intermediate_Japanese,nEkc_9&ki`
+傾ける,かたむける,"to incline, to tilt, to bend",JLPT_1 JLPT,g+aTq;z^TG
+固める,かためる,"to harden, to freeze, to fortify",JLPT_1 JLPT,M}jO{cRWN^
+傍ら,かたわら,"beside(s, while, nearby",JLPT_1 JLPT,H(u3_23(VR
+花壇,かだん,flower bed,JLPT_1 JLPT,vyDiG-w#Vb
+家畜,かちく,"domestic animals, livestock, cattle",JLPT_1 JLPT,sf(M2A{2zC
+且つ,かつ,"yet, and",JLPT_1 JLPT,"bxhWiXnmE,"
+がっくり,がっくり,heartbroken,JLPT_1 JLPT,n#j+;o[:]<
+合唱,がっしょう,"chorus, singing in a chorus",JLPT_1 JLPT,"ck-jle>!,g"
+がっしり,がっしり,"firmly, solidly, tough",JLPT_1 JLPT,Kl0>:WZG~Z
+合致,がっち,"agreement, concurrence, conforming to",JLPT_1 JLPT,Af^(s-@)C7
+がっちり,がっちり,"solidly built, tightly",JLPT_1 JLPT,dl.]7IVV60
+かつて,かつて,"once, before, formerly",JLPT_1 JLPT,fI;@sLyG_Q
+勝手,かって,"kitchen; one's way, selfishness",JLPT_1 JLPT,r+VI)d1wQ0
+カット,カット,"cut, cutting",JLPT_1 JLPT,Q+NVsyIn!c
+活発,かっぱつ,"vigor, active",JLPT_1 JLPT,M`7Eo@!%5A
+合併,がっぺい,"combination, amalgamation, merger",JLPT_1 JLPT,h>=`Vc9TZZ
+カテゴリー,カテゴリー,category,JLPT_1 JLPT,JAwB1=<{pF
+叶う,かなう,to come true,JLPT_1 JLPT,E5LD5p#as=
+叶える,かなえる,"to grant (request, wish)",JLPT_1 JLPT,x!3$MxvZF0
+金槌,かなづち,(iron) hammer,JLPT_1 JLPT,C7&9nlfhkO
+かなわない,かなわない,"be beyond one's power, be unable",JLPT_1 JLPT,i9$e:WA[rV
+加入,かにゅう,"becoming a member, admission",JLPT_1 JLPT,"w%]Rn6,Z,X"
+予て,かねて,"previously, already, lately",JLPT_1 JLPT,i+&=;*57v}
+庇う,かばう,"to protect someone, to&nbsp;&nbsp;cover up for someone",JLPT_1 JLPT,e-}GY5UR@1
+株式,かぶしき,stock,JLPT_1 JLPT,nMsDO&gGxt
+かぶれる,かぶれる,to react to; to be influenced by,JLPT_1 JLPT,C5U+~~@Gnd
+花粉,かふん,pollen,JLPT_1 JLPT,Gm8]&VGB-;
+貨幣,かへい,"money, currency, coinage",JLPT_1 JLPT,F<$WXw={D<
+構える,かまえる,to set up,JLPT_1 JLPT,jB<-nj(U&|
+過密,かみつ,crowded,JLPT_1 JLPT,AOD1mkToDl
+噛み切る,かみきる,"to bite off, to gnaw through",JLPT_1 JLPT,"hh,VOk`A<;"
+カムバック,カムバック,comeback,JLPT_1 JLPT,HjHeH1>k=t
+カメラマン,カメラマン,cameraman,JLPT_1 JLPT,:MlB;<{_:
+粥,かゆ,rice porridge,JLPT_1 JLPT,fFz9w`]5pq
+体付き,からだつき,"body build, figure",JLPT_1 JLPT,D?fkTo{@|E
+絡む,からむ,"to entangle, to entwine",JLPT_1 JLPT,O17r;^Y(oJ
+かりに,かりに,"temporarily; if, for argument's sake",JLPT_1 JLPT,c$0g$/@+f7
+カルテ,カルテ,clinical records (GER: Karte),JLPT_1 JLPT,GwQApsAV[E
+ガレージ,ガレージ,garage (at house),JLPT_1 JLPT,LKr$xf+m)f
+過労,かろう,"overwork, strain",JLPT_1 JLPT,Dx#E|nd<`@
+かろうじて,かろうじて,"barely, narrowly",JLPT_1 JLPT,wzpJb%R2eZ
+交す,かわす,to exchange,JLPT_1 JLPT,ytWMD-K7Sv
+代る代る,かわるがわる,alternately,JLPT_1 JLPT,Q<D|kTCMFu
+簡易,かんい,"simplicity, easiness, quasi-",JLPT_1 JLPT,Qdl&|7}97?
+灌漑,かんがい,irrigation,JLPT_1 JLPT,x3v&{30@Ie
+眼科,がんか,ophthalmology,JLPT_1 JLPT,y$)@b7Z=25
+眼球,がんきゅう,eyeball,JLPT_1 JLPT,ppa9QzmFoc
+玩具,がんぐ,toy,JLPT_1 JLPT,Fu?U%1UjU`
+簡潔,かんけつ,"brevity, concise, simple",JLPT_1 JLPT,Ch64u(7Zi6
+還元,かんげん,"resolution, reduction, return",JLPT_1 JLPT,b1~cd_rb8g
+看護,かんご,nursing,JLPT_1 JLPT,v]`cby4zI~
+漢語,かんご,"Chinese word, Sino-Japanese word",JLPT_1 JLPT,BzS`z3a0wD
+頑固,がんこ,"stubbornness, obstinacy",JLPT_1 JLPT,iS7AjV-r.~
+勧告,かんこく,"advice, counsel",JLPT_1 JLPT,ReTMd+-Cqd
+換算,かんさん,"conversion, change, exchange",JLPT_1 JLPT,V_iERi63U
+監視,かんし,"observation, guarding, surveillance",JLPT_1 JLPT,xYmgA~gB7D
+慣習,かんしゅう,usual (historical) custom,JLPT_1 JLPT,xb4/I5BD9M
+観衆,かんしゅう,"spectators, audience",JLPT_1 JLPT,suIg*_}y!}
+願書,がんしょ,application form,JLPT_1 JLPT,PJ0db[)2y/
+干渉,かんしょう,"interference, intervention",JLPT_1 JLPT,FlV}wK<+oD
+頑丈,がんじょう,"solid, firm, strong",JLPT_1 JLPT,o)b^-Y;KL)
+感触,かんしょく,"sense of touch, feeling, sensation",JLPT_1 JLPT,Ll+!^%W~Bg
+肝心,かんじん,"essential, fundamental, crucial",JLPT_1 JLPT,cGezcCU7jN
+肝腎,かんじん,"essential, fundamental, crucial",JLPT_1 JLPT,qQm@vZEhuX
+関税,かんぜい,"customs, duty, tariff",JLPT_1 JLPT,J<YhnUzDH9
+岩石,がんせき,rock,JLPT_1 JLPT,Fvc~*$ysUp
+感染,かんせん,"infection, contagion",JLPT_1 JLPT,yaKv$j-u9~
+幹線,かんせん,"main line, trunk line",JLPT_1 JLPT,qnR@^N<xB(
+簡素,かんそ,"simplicity, plain",JLPT_1 JLPT,jcV8%N9G]T
+観点,かんてん,point of view,JLPT_1 JLPT,sRkkbw!PVn
+感度,かんど,"sensitivity, severity (quake)",JLPT_1 JLPT,c!Eb1-<+V1
+カンニング,カンニング,"cunning, cheat",JLPT_1 JLPT,f{(PYG4OSM
+元年,がんねん,first year (of a specific reign),JLPT_1 JLPT,hmCuQzSd35
+幹部,かんぶ,"management, executive",JLPT_1 JLPT,L1KYyf^E^2
+完ぺき,かんぺき,"perfection, completeness, flawless",JLPT_1 JLPT,z+SJefr{>B
+勘弁,かんべん,"pardon, forgiveness, forbearance",JLPT_1 JLPT,"l*Q,*Lu2Mg"
+感無量,かんむりょう,"deep feeling, filled with emotion",JLPT_1 JLPT,h`NZ!a[CSf
+勧誘,かんゆう,"invitation, canvassing, inducement",JLPT_1 Intermediate_Japanese_Ln.5 JLPT Intermediate_Japanese,fyr>KNdC{T
+関与,かんよ,"participation, taking part in",JLPT_1 JLPT,d<Jle/NX</
+寛容,かんよう,"forbearance, tolerance, generosity, involvement",JLPT_1 JLPT,f|A2.V0M-n
+元来,がんらい,"originally, naturally",JLPT_1 JLPT,Cno5E):pRp
+観覧,かんらん,viewing,JLPT_1 JLPT,"A$Cx0<I,I0"
+慣例,かんれい,"custom, precedent, of convention",JLPT_1 JLPT,t0a}a`u9:H
+還暦,かんれき,60th birthday,JLPT_1 JLPT,4cAN40ulx
+貫禄,かんろく,"presence, dignity",JLPT_1 JLPT,I1]lC*Xh&L
+緩和,かんわ,"relief, mitigation",JLPT_1 JLPT,"k^:RZ|u,e@"
+議案,ぎあん,legislative bill,JLPT_1 JLPT,"I,VMbY@&-V"
+危害,きがい,"injury, harm, danger",JLPT_1 JLPT,F>Z;`xG3Np
+企画,きかく,"planning, project",JLPT_1 Intermediate_Japanese_Ln.14 JLPT Intermediate_Japanese,w*I2LS4{H:
+規格,きかく,"standard, norm",JLPT_1 JLPT,"xzs,)in_UO"
+着飾る,きかざる,to dress up,JLPT_1 JLPT,HoI9}BI#^/
+気兼ね,きがね,"hesitance, diffidence, feeling constraint",JLPT_1 JLPT,GRlL|p}26%
+気軽,きがる,"cheerful, buoyant, lighthearted",JLPT_1 JLPT,s;sgdqP}O.
+危機,きき,crisis,JLPT_1 JLPT,C.^&25N@a~
+聞き取り,ききとり,listening comprehension,JLPT_1 JLPT,soL?dWfD3o
+効き目,ききめ,"effect, virtue, efficacy",JLPT_1 JLPT,"i,@$ZV_BJi"
+帰京,ききょう,returning to Tokyo,JLPT_1 JLPT,wzR`J2j)`0
+戯曲,ぎきょく,"play, drama",JLPT_1 JLPT,Dx[W!Tbqvu
+基金,ききん,"fund, foundation",JLPT_1 JLPT,Jsw14fTONr
+喜劇,きげき,"comedy, funny show",JLPT_1 JLPT,vo)8mTt@2i
+議決,ぎけつ,"resolution, decision, vote",JLPT_1 JLPT,ina$-8>Dz[
+棄権,きけん,"abstain from voting, renunciation of a right",JLPT_1 JLPT,yPr@u5g:%p
+既婚,きこん,married,JLPT_1 JLPT,"zec,ws!-1^"
+気障,きざ,"affectation, conceit, snobbery",JLPT_1 JLPT,PIJe@Xxivf
+記載,きさい,"mention, entry",JLPT_1 JLPT,"AtF!,w].-2"
+兆,きざし,"sign, omen, indication",JLPT_1 JLPT,KEdc345jt(
+気質,きしつ,"character, trait, temperament",JLPT_1 JLPT,sH[}/atE{z
+期日,きじつ,"fixed date, settlement date",JLPT_1 JLPT,"v,pIo6nfY,"
+きしむ,きしむ,"to jar, to creak, to grate",JLPT_1 JLPT,JyV83hu3eM
+議事堂,ぎじどう,Diet building,JLPT_1 JLPT,ku.2udaM_
+記述,きじゅつ,"describing, descriptor",JLPT_1 JLPT,keg8V#>EyG
+気象,きしょう,"weather, climate",JLPT_1 JLPT,i8sg{g&{j*
+傷付く,きずつく,"to be hurt, to be wounded, to get injured",JLPT_1 JLPT,g#?]Ssa:Ux
+傷付ける,きずつける,"to wound, to hurt someone's feelings",JLPT_1 JLPT,W04_o[&8W
+犠牲,ぎせい,sacrifice,JLPT_1 JLPT,eAtE.H0;PV
+汽船,きせん,steamship,JLPT_1 JLPT,"gyZ:?sW,`("
+寄贈,きぞう,"donation, presentation",JLPT_1 JLPT,k3nUp@KIzg
+偽造,ぎぞう,"forgery, fabrication, counterfeiting",JLPT_1 JLPT,K;j2M?f~?!
+貴族,きぞく,"noble, aristocrat",JLPT_1 JLPT,inVAX<UF+i
+議題,ぎだい,"topic of discussion, agenda",JLPT_1 JLPT,Q@WjbgZGbs
+鍛える,きたえる,"to forge, to train, to discipline",JLPT_1 JLPT,G>3/bExrby
+気立て,きだて,"good-natured, kind-hearted",JLPT_1 JLPT,h61-}t=4fL
+来る,きたる,"to come, to approach,",JLPT_1 JLPT,s])r!JZ-b4
+きちっと,きちっと,"exactly, perfectly",JLPT_1 JLPT,D#t!(nebzD
+几帳面,きちょうめん,"methodical, punctual, steady",JLPT_1 JLPT,Idj9h;q|%y
+きっかり,きっかり,"exactly, precisely",JLPT_1 JLPT,cC(nm-eKo^
+きっちり,きっちり,"precisely, tightly",JLPT_1 JLPT,p.hrrI+jm1
+きっぱり,きっぱり,"clearly, plainly, distinctly",JLPT_1 JLPT,u>9}K{Kf.I
+規定,きてい,"regulation, provisions",JLPT_1 JLPT,KTPp;1&S1u
+起点,きてん,starting point,JLPT_1 JLPT,",M-]_[Vyp"
+軌道,きどう,orbit; track,JLPT_1 JLPT,P=9KAyqi}b
+技能,ぎのう,"technical skill, ability, capacity",JLPT_1 JLPT,waI%d;Y5LY
+規範,きはん,"model, standard, example",JLPT_1 JLPT,L8HXSBw0.5
+気品,きひん,"grace, elegance",JLPT_1 JLPT,cT4)YAkk45
+気風,きふう,"character, traits, ethos",JLPT_1 JLPT,cU@qu%MT$c
+起伏,きふく,undulation,JLPT_1 JLPT,DG3WXr]W9o
+規模,きぼ,"scale, scope, plan, structure",JLPT_1 JLPT,vN{{=xfB<k
+気まぐれ,きまぐれ,"whim, caprice, uneven temper",JLPT_1 JLPT,EUJagum[Gi
+生真面目,きまじめ,"serious, sincerity",JLPT_1 JLPT,B$#zm{x$(/
+期末,きまつ,(end of the season or term),JLPT_1 JLPT,rB>aq=EB!L
+きまりわるい,きまりわるい,"feeling awkward, being ashamed",JLPT_1 JLPT,i^-fu~OpOW
+記名,きめい,"signature, register",JLPT_1 JLPT,LeN-Up#$*/
+規約,きやく,"agreement, rules, code",JLPT_1 JLPT,p:ItXku)R]
+脚色,きゃくしょく,"dramatization (e.g., film",JLPT_1 JLPT,A3B8`j%szk
+逆転,ぎゃくてん,"(sudden) change, reversal, turn-around",JLPT_1 JLPT,b}F-L9oFMV
+脚本,きゃくほん,scenario,JLPT_1 JLPT,BqjNB^gQ4E
+華奢,きゃしゃ,"delicate, slender",JLPT_1 JLPT,K{%YNbdXo{
+客観,きゃっかん,objective,JLPT_1 JLPT,FE+)c7=xm.
+キャッチ,キャッチ,catch,JLPT_1 JLPT,EE+~Pnl{z$
+キャリア,キャリア,"career, career government employee",JLPT_1 JLPT,917%#^`DD
+救援,きゅうえん,"relief, rescue, reinforcement",JLPT_1 JLPT,"xis(gT,lCH"
+休学,きゅうがく,"temporary absence from school, suspension",JLPT_1 JLPT,peW#H`ri[=
+究極,きゅうきょく,"ultimate, final, eventual",JLPT_1 JLPT,Ft[`OH9ZtO
+窮屈,きゅうくつ,"narrow, tight, formal",JLPT_1 JLPT,"HH&,U(vAg`"
+球根,きゅうこん,(plant) bulb,JLPT_1 JLPT,Q6BKH*&nE1
+救済,きゅうさい,"relief, aid, rescue",JLPT_1 JLPT,c=d|._&IWr
+給仕,きゅうじ,waiter,JLPT_1 JLPT,pzoWY8TS(/
+給食,きゅうしょく,"school lunch, providing a meal",JLPT_1 JLPT,zeAtvQ@_)h
+休戦,きゅうせん,"truce, armistice",JLPT_1 JLPT,Q9p5.}YQtg
+宮殿,きゅうでん,palace,JLPT_1 JLPT,EOPs=A9D6~
+旧知,きゅうち,"old friend, old friendship",JLPT_1 JLPT,A}I5035vZ1
+窮乏,きゅうぼう,poverty,JLPT_1 JLPT,fEoLTLW@>]
+寄与,きよ,"contribution, service",JLPT_1 JLPT,hYW_RFKwv/
+強,きょう,strong,JLPT_1 JLPT,j5ZhDwA$S
+～狂,～きょう,"maniac, fan, freak",JLPT_1 JLPT,wkNK|ibT&!
+驚異,きょうい,"wonder, miracle",JLPT_1 JLPT,I!i(y?o6E:
+教科,きょうか,"subject, curriculum",JLPT_1 JLPT,M&=I]j0/Y0
+協会,きょうかい,"association, society, organization",JLPT_1 JLPT,Oz4*Mxo4//
+共学,きょうがく,coeducation,JLPT_1 JLPT,eKY($Dr5lQ
+共感,きょうかん,"sympathy, response",JLPT_1 JLPT,w0|w&}3|}:
+境遇,きょうぐう,"environment, circumstances",JLPT_1 JLPT,dN:;6sg&]2
+教訓,きょうくん,"lesson, precept, moral instruction",JLPT_1 JLPT,pOHPj(bnYG
+強行,きょうこう,"forcing, enforcement",JLPT_1 JLPT,tf7&|-V:n8
+強硬,きょうこう,"firm, vigorous, stubborn",JLPT_1 JLPT,bA*b92)[ZU
+教材,きょうざい,teaching materials,JLPT_1 JLPT,p)!Q@]*y>T
+凶作,きょうさく,"bad harvest, poor crop",JLPT_1 JLPT,I`.1X|DPXu
+業者,ぎょうしゃ,"trader, merchant",JLPT_1 JLPT,o&/6(ODjkj
+教習,きょうしゅう,"training, instruction",JLPT_1 JLPT,H/=&)s/)`t
+郷愁,きょうしゅう,"nostalgia, homesickness",JLPT_1 JLPT,eZKQ^QCO2_
+教職,きょうしょく,teaching profession,JLPT_1 JLPT,y`GfZjj}.E
+興じる,きょうじる,"to amuse oneself, to make merry",JLPT_1 JLPT,"Q;m4!,`BN,"
+強制,きょうせい,"obligation, compulsion, enforcement",JLPT_1 JLPT,Hm$>AvE1~h
+行政,ぎょうせい,administration,JLPT_1 JLPT,r~TWhqKvAt
+業績,ぎょうせき,"achievement, work, contribution",JLPT_1 JLPT,Lk<<za38cF
+共存,きょうぞん,coexistence,JLPT_1 JLPT,Ij!^n@6%SF
+協定,きょうてい,"arrangement, pact, agreement",JLPT_1 JLPT,K9?Jw]OMOi
+郷土,きょうど,homeland,JLPT_1 JLPT,Q4`7(5-Vb`
+脅迫,きょうはく,"threat, coercion",JLPT_1 JLPT,k[s}KC9iC{
+業務,ぎょうむ,"business, duties, work",JLPT_1 JLPT,b&$V6PlYM?
+共鳴,きょうめい,"resonance, sympathy",JLPT_1 JLPT,kl1yRR~Dbc
+郷里,きょうり,"birth-place, home town",JLPT_1 JLPT,J6)+at[SJG
+強烈,きょうれつ,"strong, intense, severe",JLPT_1 JLPT,r]=;%Z2Ns;
+共和,きょうわ,"republicanism, cooperation",JLPT_1 JLPT,GU{+)z^)dD
+局限,きょくげん,"limit, localize",JLPT_1 JLPT,xsMbwTI.xJ
+極端,きょくたん,"extreme, extremity",JLPT_1 JLPT,P.Mzv1I{9}
+居住,きょじゅう,residence,JLPT_1 JLPT,m]/OZ*9GsC
+拒絶,きょぜつ,"refusal, rejection",JLPT_1 JLPT,pF/Q.UL^fh
+漁船,ぎょせん,fishing boat,JLPT_1 JLPT,M@u:oyW>Kw
+漁村,ぎょそん,fishing village,JLPT_1 JLPT,oLHH[@w)KZ
+拒否,きょひ,"denial, rejection, refusal",JLPT_1 JLPT,xZG_N4@O9B
+許容,きょよう,"permission, pardon",JLPT_1 JLPT,"m;[9Tjw,qU"
+清らか,きよらか,"clean, pure, chaste",JLPT_1 JLPT,rPKJ~vEwnZ
+きらびやか,きらびやか,"gorgeous, gaudy, dazzling",JLPT_1 JLPT,t+RU;/m(KM
+～きり,～きり,only,JLPT_1 JLPT,uzRZwLFG-t
+義理,ぎり,"debt of gratitude, obligation",JLPT_1 JLPT,so:x7klic}
+切替,きりかえ,"exchange, conversion, switchover",JLPT_1 JLPT,B])<#Pn[DB
+気流,きりゅう,atmospheric current,JLPT_1 JLPT,ph[xS7hP4#
+切れ目,きれめ,"break, pause, gap",JLPT_1 JLPT,"C#,Pog7@LR"
+疑惑,ぎわく,"doubt, misgivings, suspicion",JLPT_1 JLPT,se:RwXAAh
+極めて,きわめて,"exceedingly, extremely (written expression)",JLPT_1 JLPT Intermediate_Japanese_Ln.13 Intermediate_Japanese,EKB18v#}a&
+近眼,きんがん,nearsightedness,JLPT_1 JLPT,dD[Q^z/~(w
+緊急,きんきゅう,"urgent, pressing, emergency",JLPT_1 JLPT,DgtR0$#5Qg
+近郊,きんこう,"suburbs, outskirts",JLPT_1 JLPT,JfO#&<*3[k
+均衡,きんこう,"equilibrium, balance",JLPT_1 JLPT,x>zIhBvkg*
+禁じる,きんじる,to prohibit,JLPT_1 JLPT,r7Q>%_(/mr
+勤勉,きんべん,"industry, diligence",JLPT_1 JLPT,uYoa=%x]!q
+吟味,ぎんみ,"examination, careful investigation",JLPT_1 JLPT,p>zee?sO9;
+勤務,きんむ,"service, duty, work",JLPT_1 JLPT,hhs(k1{TN}
+禁物,きんもつ,"taboo, forbidden thing",JLPT_1 JLPT,sWH*^U2<+H
+勤労,きんろう,"labor, exertion, diligent service",JLPT_1 JLPT,C^)QBm`a.U
+クイズ,クイズ,quiz,JLPT_1 JLPT,m9+]J[|ov;
+食い違う,くいちがう,"to cross each other, to differ",JLPT_1 JLPT,dlUQZZk[k&
+空間,くうかん,"space, room, airspace",JLPT_1 JLPT,"FOY$+>M@U,"
+空腹,くうふく,hunger,JLPT_1 JLPT,"o,>8F>0y;H"
+区画,くかく,"division, section, area",JLPT_1 JLPT,hbtu==:uia
+区間,くかん,section,JLPT_1 JLPT,tS6N_tjG&R
+茎,くき,stalk,JLPT_1 JLPT,O5c;9[C7}%
+区切り,くぎり,"an end, a stop, punctuation",JLPT_1 JLPT,zqK^J|1vVI
+くぐる,くぐる,to pass through; to go around,JLPT_1 JLPT,"bMchGH<.,G"
+くじ (～をひく),くじ (～をひく),"lottery, lot",JLPT_1 JLPT,ziu-}:42)#
+くじびき,くじびき,"lottery, drawn lot",JLPT_1 JLPT,t-q[>)aB/{
+くすぐったい,くすぐったい,ticklish,JLPT_1 JLPT,P[CLwgoK#I
+愚痴,ぐち,"idle complaint, grumble",JLPT_1 JLPT,C&*!h9}5ae
+口吟む,くちずさむ,to humble,JLPT_1 JLPT,v#IdlQfu^;
+嘴,くちばし,"beak, bill",JLPT_1 JLPT,q5`l.teeRT
+朽ちる,くちる,to rot,JLPT_1 JLPT,y1>SUYnb]m
+覆す,くつがえす,"to overturn, to upset, to overthrow",JLPT_1 JLPT,zp<0lkXp[6
+くっきり,くっきり,"distinctly, clearly, boldly",JLPT_1 JLPT,A%/]?I_gyZ
+屈折,くっせつ,"bending, indentation, refraction",JLPT_1 JLPT,0E4`Ur@Ig
+ぐっと,ぐっと,"firmly, fast, more",JLPT_1 JLPT,G/n$rvRj#F
+首飾り,くびかざり,necklace,JLPT_1 JLPT,"qFdJV,o7Z~"
+首輪,くびわ,"necklace, choker",JLPT_1 JLPT,"r$gf,6IuJ/"
+組み込む,くみこむ,"to insert, to include, to cut in (printing)",JLPT_1 JLPT,N5}[0JLW]q
+組み合わせる,くみあわせる,"to join together, to combine, to join up",JLPT_1 JLPT,qDs6:%T/3U
+蔵,くら,"warehouse, cellar",JLPT_1 JLPT,C=*)4H{doV
+グレー,グレー,"grey, gray",JLPT_1 JLPT,k$7)oghP*m
+クレーン,クレーン,crane,JLPT_1 JLPT,C(o|20rT;/
+玄人,くろうと,"expert, professional",JLPT_1 JLPT,N5@#f;qR7F
+黒字,くろじ,balance (figure) in the black,JLPT_1 JLPT,cw<1Zd}#`P
+軍艦,ぐんかん,"warship, battleship",JLPT_1 JLPT Intermediate_Japanese_Ln.8 Intermediate_Japanese,"j|9,<bl,`k"
+軍事,ぐんじ,military affairs,JLPT_1 JLPT,O/|8of/=vE
+君主,くんしゅ,"ruler, monarch",JLPT_1 JLPT,stPJuiua;x
+群集,ぐんしゅう,"(social) group, crowd, mob",JLPT_1 JLPT,p4G>}yfC)@
+群衆,ぐんしゅう,"(social) group, crowd, mob",JLPT_1 JLPT,m)#YkIUhBb
+軍備,ぐんび,"armaments, military preparations",JLPT_1 JLPT,Q<54bk-ZNv
+軍服,ぐんぷく,military or naval uniform,JLPT_1 JLPT,puGrsq&TAP
+芸,げい,"art, accomplishment, performance",JLPT_1 JLPT,zzMBfZ=xQL
+経過,けいか,"passage, progress",JLPT_1 JLPT,ok7SBPZ~(w
+軽快,けいかい,"lively, casual, light",JLPT_1 JLPT,H^eby;)zOc
+警戒,けいかい,"warning, admonition, vigilance",JLPT_1 JLPT,IlUsDbGTyB
+敬具,けいぐ,Sincerely (used at the end of letter),Intermediate_Japanese_Ln.4 JLPT_1 JLPT Intermediate_Japanese,B!lza1p.0?
+軽減,けいげん,"reduction, lessening",JLPT_1 JLPT,IbWZR<kR]W
+掲載,けいさい,"appearance (e.g., article in paper)",JLPT_1 JLPT,bq$YateC|k
+傾斜,けいしゃ,"inclination, slope, dip",JLPT_1 JLPT,D&m-*([U$6
+形成,けいせい,formation,JLPT_1 JLPT,"Q,O|6gZ,S_"
+形勢,けいせい,"condition, situation, prospects",JLPT_1 JLPT,tT1?SPXi1I
+軽率,けいそつ,"thoughtless, careless, hasty",JLPT_1 JLPT,mC$8ZBGBhL
+刑罰,けいばつ,"judgment, penalty, punishment",JLPT_1 JLPT,h!JCwBz@T7
+経費,けいひ,"expenses, cost, outlay",JLPT_1 JLPT,dA8rO;1&st
+警部,けいぶ,police inspector,JLPT_1 JLPT,f~U_eCQcuj
+転換,てんかん,"convert, divert",JLPT_1 JLPT,wq`yxTWAU4
+転居,てんきょ,"moving, changing residence",JLPT_1 JLPT,fpa)5#xLl3
+転勤,てんきん,transfer (to another office of a company),JLPT_1 Intermediate_Japanese_Ln.14 JLPT Intermediate_Japanese,Cj#Grcg7-k
+点検,てんけん,"inspection, examination, checking",JLPT_1 JLPT,nhsX!aB>^s
+電源,でんげん,"source of electricity, power (e.g., button on TV)",JLPT_1 JLPT,"O,Y?B?G0AC"
+天国,てんごく,"paradise, heaven, Kingdom of Heaven",JLPT_1 JLPT,y;7l~-6:U2
+天才,てんさい,a genius,JLPT_1 JLPT Intermediate_Japanese_Ln.8 Intermediate_Japanese,M=qf#].n@K
+天災,てんさい,"natural calamity, disaster",JLPT_1 JLPT,AbgU8k(]Fr
+展示,てんじ,"exhibition, display",JLPT_1 JLPT,BX?]-7Vf!l
+伝説,でんせつ,"tradition, legend, folklore",JLPT_1 JLPT Intermediate_Japanese_Ln.8 Intermediate_Japanese,"Rdd+X!dSu,"
+点線,てんせん,dotted line,JLPT_1 JLPT,"FYT!)Y,6rw"
+転じる,てんじる,"to turn, to shift",JLPT_1 JLPT,gk5Nvk`;hi
+転ずる,てんずる,"to turn, to shift",JLPT_1 JLPT,CI_As5:EDn
+天体,てんたい,heavenly body,JLPT_1 JLPT,jiDJT?nAAw
+伝達,でんたつ,"transmission (e.g., news, communication, delivery)",JLPT_1 JLPT,Fu*Vb?uBII
+天地,てんち,"heaven and earth, the universe",JLPT_1 JLPT,c+f-ty}$d!
+てんで,てんで,"(not) at all, altogether, entirely",JLPT_1 JLPT,iKsMS;CA<|
+転任,てんにん,change of post,JLPT_1 JLPT,rZvBTuhiHO
+展望,てんぼう,"view, outlook, prospect",JLPT_1 JLPT,q|(m+;cCHK
+伝来,でんらい,"ancestral, hereditary, imported",JLPT_1 JLPT,"fDUHN*l8c,"
+転落,てんらく,"fall, degradation",JLPT_1 JLPT,Et(iYLp%EH
+問い合わせる,といあわせる,"to inquire, to seek information",JLPT_1 JLPT,uvJB[75Tk}
+当～,とう～,"Our ~ (e.g., Hotel, plane, etc.)",JLPT_1 JLPT,Mu?thgozeE
+胴,どう,"trunk, body, frame",JLPT_1 JLPT,hDa8pFJqm0
+同意,どうい,"agreement, consent; same meaning",JLPT_1 JLPT,j3r]HMmU>:
+動員,どういん,mobilization,JLPT_1 JLPT,k#:gdO(AW5
+同感,どうかん,"agreement, same opinion, same feeling",JLPT_1 JLPT,Bc/Cv&bn2c
+陶器,とうき,"pottery, ceramics",JLPT_1 JLPT,E}elXp_wGW
+討議,とうぎ,"debate, discussion",JLPT_1 JLPT,BjpsxE0AcR
+動機,どうき,"motive, incentive",JLPT_1 JLPT,PXaG&3fRlH
+等級,とうきゅう,"grade, class",JLPT_1 JLPT,vFpm6[P%2G
+同級,どうきゅう,"the same grade, same class",JLPT_1 JLPT,eqQ2)5CzED
+同居,どうきょ,living together,JLPT_1 JLPT,QKzH>2eq3/
+登校,とうこう,attendance (at school),JLPT_1 JLPT,B([>~_d]8F
+統合,とうごう,"integration, unification, synthesis",JLPT_1 JLPT,ji0.^JH`^U
+動向,どうこう,"trend, tendency, movement, attitude",JLPT_1 JLPT,o.}lBa5|<`
+投資,とうし,investment,JLPT_1 JLPT,cy=[{o&!H$
+同情,どうじょう,"sympathy, compassion, sympathize",JLPT_1 JLPT,"Mbh,O)Kv:"
+道場,どうじょう,"(arch) dojo, hall used for martial arts training, mandala",JLPT_1 JLPT,OojlS!TK3i
+統制,とうせい,"regulation, control",JLPT_1 JLPT,K:r_8O#Kk`
+当選,とうせん,"being elected, winning the prize",JLPT_1 JLPT,m]O74#<tB:
+逃走,とうそう,"flight, desertion, escape",JLPT_1 JLPT,lS-lTa3)4.
+統率,とうそつ,"command, generalship, leadership",JLPT_1 JLPT,xpLjH)jf2X
+到達,とうたつ,"reaching, attaining, arrival",JLPT_1 JLPT,H#Flm1MG6>
+統治,とうち,"rule, reign, governing",JLPT_1 JLPT,F]R4doym8Q
+仕切る,しきる,"to partition, to divide, to mark off",JLPT_1 JLPT,G!$&r|A6Tu
+資金,しきん,"funds, capital",JLPT_1 JLPT,l}_f:.$:^S
+軸,じく,"axis, stem, shaft",JLPT_1 JLPT,h+9$DC_v-#
+しくじる,しくじる,"to fail, to fall through, to blunder",JLPT_1 JLPT,N22-lR<CJ#
+仕組,しくみ,"structure, mechanism",JLPT_1 JLPT,zu6.9a/_f(
+死刑,しけい,death penalty,JLPT_1 JLPT,d38&><SCHm
+湿気る,しける,"to be damp, to be moist",JLPT_1 JLPT,"j<,^YWvyDj"
+施行,しこう,"enforcement, operation",JLPT_1 JLPT,MC~*r371(H
+思考,しこう,thought,JLPT_1 JLPT,G|{{/)+LPZ
+志向,しこう,"intention, aim",JLPT_1 JLPT,O4`+5c5yv}
+嗜好,しこう,"taste, liking, preference",JLPT_1 JLPT,z6!>1ULyhO
+事項,じこう,"matter(s), item(s), facts",JLPT_1 JLPT Intermediate_Japanese_Ln.15 Intermediate_Japanese,p8bdtFtVNT
+時刻表,じこくひょう,"timetable, (train) schedule",JLPT_1 JLPT Intermediate_Japanese_Ln.10 Intermediate_Japanese,Fqowxp!1`}
+地獄,じごく,hell,JLPT_1 JLPT,Dm&QxHR(%1
+時差,じさ,time difference,JLPT_1 JLPT,AEdcWK:0]/
+自在,じざい,"freely, at will",JLPT_1 JLPT,sqc[jw93Mn
+視察,しさつ,"inspection, observation",JLPT_1 JLPT,"B,vh!;ocAA"
+資産,しさん,"property, fortune, assets",JLPT_1 JLPT,MI@T>IcVHN
+支持,しじ,support,JLPT_1 JLPT,oo0YtJF4ck
+自主,じしゅ,"independence, autonomy",JLPT_1 JLPT,ARYI~qJT^l
+自首,じしゅ,"surrender, give oneself up",JLPT_1 JLPT,qvNf_+tfMc
+刺繍,ししゅう,embroidery,JLPT_1 JLPT,w_uSABGrgB
+市場,しじょう,(the) market (as a concept),JLPT_1 JLPT,PAheY`kK%!
+辞職,じしょく,resignation,JLPT_1 JLPT,pwRmK+}S5n
+雫,しずく,drop (of water),JLPT_1 JLPT,q+DG7K-9zr
+システム,システム,system,JLPT_1 JLPT,QzGyU%s_=+
+沈める,しずめる,"to sink, to submerge",JLPT_1 JLPT,k#([X{>3G.
+施設,しせつ,"establishment, facility",JLPT_1 JLPT,NLo.Oj~LZQ
+事前,じぜん,"prior, beforehand, in advance",JLPT_1 JLPT,"B`.[5%YoP,"
+子息,しそく,(hon.) son,JLPT_1 JLPT,FTUd?vlNr&
+持続,じぞく,"continuation, endurance",JLPT_1 JLPT,z!R.0v{_I+
+自尊心,じそんしん,"self-respect, conceit",JLPT_1 JLPT,"db,ehs16g5"
+慕う,したう,to yearn to adore,JLPT_1 JLPT,Kg^oT02U+h
+下心,したごころ,"secret intention, motive",JLPT_1 JLPT,yNAARsc60)
+下地,したじ,"groundwork, foundation",JLPT_1 JLPT,C0{8:(@F]r
+親しむ,したしむ,"to be intimate with, to befriend",JLPT_1 JLPT,]t:px`?.Z
+下調べ,したしらべ,preliminary investigation,JLPT_1 JLPT,DxMjJ:J?n9
+愛想,あいそう,sociability,JLPT JLPT_1,D5/lX+C:0I
+間柄,あいだがら,relationship,JLPT JLPT_1,r){:>bdZ&g
+合間,あいま,interval,JLPT JLPT_1,"JUK537Y{:,"
+敢えて,あえて,"dare (to do), venture (to do), challenge (to do)",JLPT JLPT_1,s1!E#AVJt2
+仰ぐ,あおぐ,"to look up (to), to respect; to ask for",JLPT JLPT_1,jM1|yl:^{3
+垢,あか,"dirt, filth",JLPT JLPT_1,DBMz)Db=eM
+赤字,あかじ,"deficit, go in the red",JLPT JLPT_1,HI03WP|@HB
+明かす,あかす,to reveal; to stay up,JLPT JLPT_1,KwYk}cvf;4
+赤らむ,あからむ,"to become red, to blush",JLPT JLPT_1,j<sn*Q2&fX
+上がり,あがり,"ascent; income; completion, stop",JLPT JLPT_1,P4)VsPElC3
+諦め,あきらめ,"resignation, reconciliation, consolation",JLPT JLPT_1,t[6Mba+ksr
+アクセル,アクセル,(abbr.) accelerator,JLPT JLPT_1,Ne4X+cGeo>
+あくどい,あくどい,gaudy vicious,JLPT JLPT_1,lc&@RDrWR_
+顎,あご,chin,JLPT JLPT_1,Ptm5MS8ifU
+憧れ,あこがれ,"yearning, longing, aspiration",Intermediate_Japanese Intermediate_Japanese_Ln.8 JLPT JLPT_1,xBeDF#=-sz
+麻,あさ,hemp,JLPT JLPT_1,w(rcEk/VmK
+あざ,あざ,"birthmark, bruise",JLPT JLPT_1,d*;1c9:{uT
+浅ましい,あさましい,"shameful, mean, despicable",JLPT JLPT_1,s)pIL-ZA22
+欺く,あざむく,to deceive,JLPT JLPT_1,A$ma^<[.oV
+鮮やか,あざやか,"vivid, clear",JLPT JLPT_1,NLW7^$tsZW
+嘲笑う,あざわらう,"to sneer at, to ridicule",JLPT JLPT_1,JUQ*e7*7@1
+悪しからず,あしからず,"don't take me wrong, but..., I'm sorry",JLPT JLPT_1,mzY7to>XD=
+味わい,あじわい,"flavor, relish",JLPT JLPT_1,AnF0/M>eGJ
+焦る,あせる,"to be in a hurry, to be impatient",JLPT JLPT_1,CQ6a[yufGz
+あせる (こえが～),あせる (こえが～),"to fade, to discolor",JLPT JLPT_1,z&GHas=YL$
+値,あたい,"value, price, worth",JLPT JLPT_1,npzK5/Lv`K
+値する,あたいする,"to be worth, to deserve",JLPT JLPT_1,ft<yLz[qaG
+悪化,あっか,"deterioration, worsen",JLPT JLPT_1,sbr2W2n7MW
+扱い,あつかい,"treatment, service",JLPT JLPT_1,mENSd|EXrx
+呆気ない,あっけない,"not enough, too quick (short, long, etc.)",JLPT JLPT_1,Ia5OpTaxp^
+あっさり,あっさり,"easily, readily, quickly",JLPT JLPT_1,oXkv96df2[
+斡旋,あっせん,"kind offices, mediation",JLPT JLPT_1,e&lS=AStXV
+圧倒,あっとう,"overwhelm, overpower",JLPT JLPT_1,K|Yu^{#OdF
+圧迫,あっぱく,"pressure, coercion, oppression",JLPT JLPT_1,lV=]6c^zXy
+あつらえる,あつらえる,"to give an order, to place an order",JLPT JLPT_1,w5:fR-]SC?
+圧力,あつりょく,"stress, pressure",JLPT JLPT_1,MjVQW+>`YR
+当て,あて,expectations; depend,JLPT JLPT_1,jo;`0^*cS-
+～宛,～あて,"for…(e.g., In a letter)",JLPT JLPT_1,FnD29QA$}R
+当て字,あてじ,"phonetic-equivalent character, substitute character",JLPT JLPT_1,"Q]8,F~AaiU"
+跡継ぎ,あとつぎ,"heir, successor",JLPT JLPT_1,FOSj&QueO&
+後回し,あとまわし,"putting off, postponing",JLPT JLPT_1,gtJh53r?xb
+油絵,あぶらえ,oil painting,JLPT JLPT_1,D+4-`qnb~N
+アプローチ,アプローチ,approach (in golf),JLPT JLPT_1,jEr0e9w(yl
+あべこべ,あべこべ,"contrary, opposite, inverse",JLPT JLPT_1,"H,+X<T.gD6"
+甘える,あまえる,"to behave like a spoiled child, to fawn on",JLPT JLPT_1,Ive+A5(inn
+雨具,あまぐ,rain gear,JLPT JLPT_1,I?IUPpQj*?
+甘口,あまくち,sweet flavor,JLPT JLPT_1,RiEI$=-[gq
+アマチュア,アマチュア,amateur,JLPT JLPT_1,cX1.fT!T=M
+網,あみ,net,JLPT JLPT_1,H|d6ZL#<h!
+操る,あやつる,"to manipulate, to operate, to pull strings",JLPT JLPT_1,NxyDR}@Pt9
+危ぶむ,あやぶむ,"to fear, to have misgivings, to be doubtful",JLPT_1 JLPT,NLhG0QOC$/
+あやふや,あやふや,"uncertain, vague, ambiguous",JLPT_1 JLPT,LTY%:.1iV#
+過ち,あやまち,"fault, error, indiscretion",JLPT_1 JLPT,tiN`@Or{&y
+誤る,あやまる,to make a mistake,JLPT_1 JLPT,y69Q^~B7be
+歩み,あゆみ,"step, progress, history",JLPT_1 JLPT,d|SHU+C9ln
+歩む,あゆむ,to walk,JLPT_1 JLPT,wd7~%O7i%s
+予め,あらかじめ,"in advance, previously",JLPT_1 JLPT,M^Q%nck}}~
+荒らす,あらす,to damage; to invade,JLPT_1 JLPT,F`n@R=:)nH
+争い,あらそい,"dispute, quarrel, conflict",JLPT_1 JLPT,iM26j%{^}<
+改まる,あらたまる,to be renewed; to be formal,JLPT_1 JLPT,POJ?~MwZC;
+荒っぽい,あらっぽい,"rough, rude",JLPT_1 JLPT,"b<,B2X1W>,"
+アラブ,アラブ,Arab,JLPT_1 JLPT,w?fz6N5_8f
+霰,あられ,"hail (e.g., falling ice balls)",JLPT_1 JLPT,l3>xH[yiS~
+有り様,ありさま,"state, condition",JLPT_1 JLPT,riAt}Dj+*6
+ありのまま,ありのまま,"the truth, as it is, frankly",JLPT_1 JLPT,u#p2]kp|]n
+ありふれる,ありふれる,"common, ordinary, routine",JLPT_1 JLPT,L>m1Qj9_w`
+アルカリ,アルカリ,alkali,JLPT_1 JLPT,bjn}>(kN_4
+アルミ,アルミ,"aluminum (Al, aluminum)",JLPT_1 JLPT,hd2y8v&/eK
+アワー,アワー,hour,JLPT_1 JLPT,mk~JH>ZLLt
+合わす,あわす,"to join together, to face, to unite",JLPT_1 JLPT,NbeP;-&Q9x
+～合せ,～あわせ,in all,JLPT_1 JLPT,txB~izZs$4
+アンコール,アンコール,encore,JLPT_1 JLPT,Nor`ur!?#f
+暗殺,あんさつ,assassination,JLPT_1 JLPT,k9nuX~0z?!
+暗算,あんざん,mental arithmetic,JLPT_1 JLPT,iVkFrF?o$Q
+暗示,あんじ,"hint, suggestion",JLPT_1 JLPT,v]TQH!b:3E
+案じる,あんじる,"to be anxious, to ponder",JLPT_1 JLPT,A+tw-W2up/
+安静,あんせい,rest,JLPT_1 JLPT,m~/57eSA#(
+案の定,あんのじょう,"sure enough, as usual",JLPT_1 JLPT,hA}d;?>d]S
+いい加減,いいかげん,"random, irresponsible",JLPT_1 JLPT,m&1q/@m2Fo
+言い訳,いいわけ,"excuse, explanation",JLPT_1 JLPT,bHn3PYYDDh
+イェス,イェス,yes; Jesus,JLPT_1 JLPT,JNh+4Yr8ef
+家出,いえで,running away from home,JLPT_1 JLPT,Q=S6%hckV-
+生かす,いかす,to keep something alive; to make use of,JLPT_1 JLPT,I!~Ls+W17l
+いかに,いかに,"how, in what way",JLPT_1 JLPT,wc[[YL_8xy
+いかにも,いかにも,truly (same as 実に (じつに)),JLPT_1 JLPT Intermediate_Japanese_Ln.13 Intermediate_Japanese,pGTXJh*xKy
+異議,いぎ,"objection, dissent, protest",JLPT_1 JLPT,Ipl}wWGO>v
+生き甲斐,いきがい,"something one lives for, very important",JLPT_1 JLPT,q|opo=i1Z%
+行き違い,いきちがい,"misunderstanding, disagreement",JLPT_1 JLPT,Kn3O$k3Ndh
+意気込む,いきごむ,to be enthusiastic about,JLPT_1 JLPT,"uCP,dS?ITJ"
+育成,いくせい,"rearing, training, cultivation",JLPT_1 JLPT,xgDyhh?MvF
+幾多,いくた,"many, numerous",JLPT_1 JLPT,sVgAdcK5_K
+"(花を〜) 生ける, 活ける",(はなを～) いける,to arrange (flowers),JLPT JLPT_1 MediaMissing,"cEGS[d,K$s"
+異見,いけん,"different opinion, objection",JLPT_1 JLPT,C`nnyFMEP*
+意向,いこう,"intention, idea, inclination",JLPT_1 JLPT,c<RmCn8fq1
+移行,いこう,switching over to,JLPT_1 JLPT,zCUU7WXKx4
+いざ,いざ,"now, come (now), crucial moment",JLPT_1 JLPT,i:/h1W-xdl
+移住,いじゅう,"migration, immigration",JLPT_1 JLPT,yfmy@>bgJz
+衣装,いしょう,"clothing, costume, outfit",JLPT_1 JLPT,JM:)/^6vfs
+いじる,いじる,"to touch, to tamper with",JLPT_1 JLPT,9Nx^_^#j8
+異性,いせい,the opposite sex,JLPT_1 JLPT,c(LysD`~z]
+遺跡,いせき,historic ruins,JLPT_1 JLPT,FHxuAULxsj
+依存,いぞん,"dependence, dependent, reliance",JLPT_1 JLPT,vHQ}.~FHmp
+委託,いたく,"consign (goods (for sale) to a firm), entrust",JLPT_1 JLPT,"JRy,(Dx:,n"
+いたって,いたって,"very much, exceedingly, extremely",JLPT_1 JLPT,%<{<.)4xj
+出世,しゅっせ,"promotion, successful career, eminence",JLPT_1 JLPT,"E,W%,6&bwX"
+出題,しゅつだい,proposing a question,JLPT_1 JLPT,s9z]c<[6wR
+出動,しゅつどう,"mobilization, action",JLPT_1 JLPT,DVV5Q3:VIK
+出費,しゅっぴ,"expenses, disbursements",JLPT_1 JLPT,t(JNS{XhuZ
+出品,しゅっぴん,"exhibit, display",JLPT_1 JLPT,w}1f=TEQZ|
+主導,しゅどう,main leadership,JLPT_1 JLPT,"d-6;%xC,V("
+主任,しゅにん,"person in charge, responsible official",JLPT_1 JLPT Intermediate_Japanese_Ln.8 Intermediate_Japanese,P`pi2j!/Zn
+首脳,しゅのう,"head, leader",JLPT_1 JLPT,mH>udydI<)
+守備,しゅび,defense,JLPT_1 JLPT,QyYK8_+Gx6
+手法,しゅほう,technique,JLPT_1 JLPT,fWl){e*%x`
+樹木,じゅもく,"trees and shrubs, arbor",JLPT_1 JLPT,A6EcuVTEn~
+樹立,じゅりつ,"establish, create",JLPT_1 JLPT,<gHQ~x_IM
+準急,じゅんきゅう,"local express (train, slower than an express)",JLPT_1 JLPT,s!T{c]d?zv
+準じる,じゅんじる,"to follow, to conform, to apply to",JLPT_1 JLPT,j=V@~uS;G4
+～署,～しょ,department,JLPT_1 JLPT,A<!E3T_0vF
+～症,～しょう,disease,JLPT_1 JLPT,y^!rJ~5v8t
+～証,～しょう,"proof, certificate",JLPT_1 JLPT,w[XPaJS[}z
+～嬢,～じょう,young woman,JLPT_1 JLPT,P&R@B~a4:4
+上位,じょうい,"superior, higher order",JLPT_1 JLPT,s<}P@-YNu`
+上演,じょうえん,art performance,JLPT_1 JLPT,Ih+PnzSX5U
+城下,じょうか,land near the castle,JLPT_1 JLPT,FP&uiV(R^g
+消去,しょうきょ,"elimination, erasing",JLPT_1 JLPT,KIr]^O720X
+上空,じょうくう,"sky, high-altitude sky, upper air",JLPT_1 JLPT,AT)AL!}Jds
+衝撃,しょうげき,"shock, crash, impact, ballistic",JLPT_1 JLPT,rK5G)+e65!
+証言,しょうげん,"evidence, testimony",JLPT_1 JLPT,s_3h<=-PI[
+証拠,しょうこ,"evidence, proof",JLPT_1 JLPT,H}OPDaDiwx
+照合,しょうごう,"check, verification",JLPT_1 JLPT,hlgHN62g|{
+詳細,しょうさい,"detail, particulars",JLPT_1 JLPT,K:oLa1D.!N
+上昇,じょうしょう,"rising, ascending, climbing",JLPT_1 JLPT,sWkm1|AEBC
+昇進,しょうしん,promotion,JLPT_1 JLPT,d~xF3H=[az
+称する,しょうする,"to take the name of, to call oneself",JLPT_1 JLPT,tSb%>:%%!V
+情勢,じょうせい,"state of things, condition, situation",JLPT_1 JLPT,MJ1D.[x{)c
+消息,しょうそく,"news, letter, circumstances",JLPT_1 JLPT,u6>otPY%%b
+承諾,しょうだく,"consent, agreement",JLPT_1 JLPT,qBKI4V%6RZ
+情緒,じょうちょ,"emotion, feeling",JLPT_1 JLPT,k3To8MWJIl
+情緒,じょうしょ,"emotion, feeling",JLPT_1 JLPT,tX-.yH%tsu
+象徴,しょうちょう,symbol,JLPT_1 JLPT,Nr_Pr2R$>-
+小児科,しょうにか,pediatrics,JLPT_1 JLPT,BV(PyO5`Xp
+使用人,しようにん,"employee, servant",JLPT_1 JLPT,LygcFyOci?
+情熱,じょうねつ,"passion, enthusiasm, zeal",JLPT_1 JLPT,I{iqV8B>VE
+譲歩,じょうほ,"concession, conciliation, compromise",JLPT_1 JLPT,qTRRmo8`cg
+条約,じょうやく,"treaty, pact",JLPT_1 JLPT Intermediate_Japanese_Ln.8 Intermediate_Japanese,mBj5_YKg@T
+勝利,しょうり,"victory, triumph, win",JLPT_1 JLPT,G@C3MHqMp~
+上陸,じょうりく,"landing, disembarkation",JLPT_1 JLPT,P?*6mTt|Ou
+蒸溜,じょうりゅう,distillation,JLPT_1 JLPT,N0wHhg4iZ}
+奨励,しょうれい,"encouragement, promotion",JLPT_1 JLPT,m8|HwkmQWl
+ショー,ショー,show,JLPT_1 JLPT,i~@270zDDg
+除外,じょがい,"exception, exclusion",JLPT_1 JLPT,An-_sCcDl?
+職員,しょくいん,"staff member, personnel",JLPT_1 JLPT,"c/)%MF,^yx"
+植民地,しょくみんち,colony,JLPT_1 JLPT,pqv+nRs.EA
+職務,しょくむ,professional duties,JLPT_1 JLPT,M%7$<MDK;D
+諸君,しょくん,"Gentlemen!, Ladies!",JLPT_1 JLPT,w8&8<Oq8q1
+助言,じょげん,"advice, suggestion",JLPT_1 JLPT Intermediate_Japanese Intermediate_Japanese_Ln.11,jgva&{5Yv}
+徐行,じょこう,going slowly,JLPT_1 JLPT,1}h4@}[.}
+所在,しょざい,whereabouts,JLPT_1 JLPT,HYCS:(5sD5
+所持,しょじ,"possession, owning",JLPT_1 JLPT,FFV#Fu]e{M
+所属,しょぞく,"attached to, belong to",JLPT_1 JLPT,kcA;O>C=q2
+処置,しょち,treatment,JLPT_1 JLPT,oElimwftu&
+しょっちゅう,しょっちゅう,"always, constantly",JLPT_1 JLPT,qt.$TI&_S;
+所定,しょてい,"fixed, prescribed",JLPT_1 JLPT,lE2*Emk;Hc
+所得,しょとく,income,JLPT_1 JLPT,x{~.Tp:rb[
+処罰,しょばつ,punishment,JLPT_1 JLPT,"gNz:>*,MG$"
+初版,しょはん,first edition,JLPT_1 JLPT,fiRSr!;Y&A
+書評,しょひょう,book review,JLPT_1 JLPT,x:`od~M8;V
+処分,しょぶん,"disposal, dealing, punishment",JLPT_1 JLPT,ob921zNQ/x
+庶民,しょみん,"masses, common people",JLPT_1 JLPT,m?>)`ISejw
+庶務,しょむ,general affairs,JLPT_1 JLPT,ibnBaKrH9N
+所有,しょゆう,"one's possessions, ownership",JLPT_1 JLPT,M/&X&72l%L
+調べ,しらべ,"investigation, inspection",JLPT_1 JLPT,K1M}#OQ[$e
+自立,じりつ,"independence, self-reliance",JLPT_1 JLPT,AxK*wI27?U
+記す,しるす,"to note, to write down",JLPT_1 JLPT,IY#:UXg$YC
+指令,しれい,"orders, instructions, directive",JLPT_1 JLPT,f3?Z1%=TF7
+～心,～しん,mind of ~,JLPT_1 JLPT,jQ&{mv~mg}
+陣,じん,"battle formation, camp, encampment",JLPT_1 JLPT,P;NE${7wn9
+進化,しんか,"evolution, progress",JLPT_1 JLPT,N0sG+rp=}d
+人格,じんかく,"personality, character",JLPT_1 JLPT,bv:L&X%{w_
+審議,しんぎ,deliberation,JLPT_1 JLPT,ljmGvuxGK[
+新婚,しんこん,newly-wed,JLPT_1 JLPT,kXZM5E]M1a
+審査,しんさ,"judging, inspection, examination",JLPT_1 JLPT,Aov$8-^cUL
+人材,じんざい,man of talent,JLPT_1 JLPT,C?4X*:ZTpD
+紳士,しんし,gentleman,JLPT_1 JLPT,x9OmT9u38P
+真実,しんじつ,"truth, reality",JLPT_1 JLPT,oVA.}`H~AT
+信者,しんじゃ,"believer, devotee",JLPT_1 JLPT,xS[kK:ZdWC
+真珠,しんじゅ,pearl,JLPT_1 JLPT,AK4RS}QdNe
+進出,しんしゅつ,advancement,JLPT_1 Intermediate_Japanese_Ln.14 JLPT Intermediate_Japanese,K-D|x_JFrP
+心情,しんじょう,mentality,JLPT_1 JLPT,PHxCA~>U^}
+新人,しんじん,"new face, newcomer",JLPT_1 JLPT,n<1jM&wYZ&
+神聖,しんせい,"holiness, sacredness, dignity",JLPT_1 JLPT,N+v0O:SZ6<
+親善,しんぜん,friendship,JLPT_1 JLPT,e$!ZsAnYeT
+真相,しんそう,"truth, real situation",JLPT_1 JLPT,"IQ@9>LJ,&M"
+迅速,じんそく,"quick, fast, prompt",JLPT_1 JLPT,g^-!|Cie-4
+人体,じんたい,human body,JLPT_1 JLPT,wqIT;%IHe9
+新築,しんちく,"new building, new construction",JLPT_1 JLPT,Ozg8V>5l.l
+心中,しんじゅう,double suicide,JLPT_1 JLPT,H1pTQNX=9t
+進呈,しんてい,presentation,JLPT_1 JLPT,CZ`K3:aqAR
+進展,しんてん,"progress, development",JLPT_1 JLPT,b(>k}9=qxl
+神殿,しんでん,"temple, sacred place",JLPT_1 JLPT,y(skY$ucA+
+進度,しんど,progress,JLPT_1 JLPT,yu/)M8)V(L
+振動,しんどう,"oscillation, vibration",JLPT_1 JLPT,sad?lNEJ3g
+新入生,しんにゅうせい,"new student, first-year student, freshman",JLPT_1 Intermediate_Japanese_Ln.5 JLPT Intermediate_Japanese,x)<B[r6{jj
+信任,しんにん,"trust, confidence, credence",JLPT_1 JLPT,"hWLnw4y,]t"
+神秘,しんぴ,mystery,JLPT_1 JLPT,"N,Y7P[tIGQ"
+辛抱,しんぼう,"patience, endurance",JLPT_1 JLPT,uU~=4Y)qMA
+人民,じんみん,"people, public",JLPT_1 JLPT,nAw=2?(bZX
+侵略,しんりゃく,"aggression, invasion, raid",JLPT_1 JLPT,hsxv1184OS
+診療,しんりょう,medical examination and treatment,JLPT_1 JLPT,x1%iVb>rlb
+粋,すい,essence,JLPT_1 JLPT,zsq|f`1Yv
+水源,すいげん,source of river,JLPT_1 JLPT,n/^g6e7/@{
+推進,すいしん,"propulsion, driving force",JLPT_1 JLPT,"J08-VaUM,s"
+吹奏,すいそう,playing wind instruments,JLPT_1 JLPT,m]6xm=<uJ6
+推測,すいそく,"guess, conjecture",JLPT_1 JLPT,zvP)r1F]3S
+水田,すいでん,(water-filled) paddy field,JLPT_1 JLPT,v5ySQN]{G>
+推理,すいり,"reasoning, inference, mystery or detective genre",JLPT_1 JLPT,jer`Bu/O84
+数詞,すうし,numeral,JLPT_1 JLPT,p</Ez{aJ5+
+崇拝,すうはい,"worship, adoration",JLPT_1 JLPT,Hw_TI!gx2(
+据え付ける,すえつける,"to install, to equip, to mount",JLPT_1 JLPT,BP/>6=lZh5
+据える,すえる,"to set, to lay, to place",JLPT_1 JLPT,t!g&pW29AZ
+すがすがしい,すがすがしい,"fresh, refreshing",JLPT_1 JLPT,rK/?@VVUlf
+救い,すくい,"help, aid, relief",JLPT_1 JLPT,qsOm7CX`b8
+すくう (みずを～),すくう (みずを～),to scoop,JLPT_1 JLPT,iDqa!wq<Tq
+健やか,すこやか,"vigorous, healthy, sound",JLPT_1 JLPT,"hH9J*t,rc_"
+濯ぐ,すすぐ,"to rinse, to wash out",JLPT_1 JLPT,E0ffUY?7qt
+進み,すすみ,progress,JLPT_1 JLPT,p1:(iOmlNJ
+裾,すそ,"(trouser) cuff, (skirt) hem, cut edge of a hairdo",JLPT_1 JLPT,xF_(AQj}lF
+スタジオ,スタジオ,studio,JLPT_1 JLPT,ic%[^BEKt/
+スチーム,スチーム,steam,JLPT_1 JLPT,nXB;]AdyMC
+ストライキ,ストライキ,strike,JLPT_1 JLPT,nf-SMH*rKm
+スト,スト,(abbr.) strike,JLPT_1 JLPT,oc==H8k2kf
+ストロー,ストロー,straw,JLPT_1 JLPT,A.~AmwkH4Z
+ストロボ,ストロボ,"stroboscope (literally: strobo, strobe lamp, stroboscopic lamp)",JLPT_1 JLPT,rNiv+g8N.Q
+すばしこい,すばしこい,"nimble, smart, quick",JLPT_1 JLPT,p[HsSa}_~h
+素早い,すばやい,"fast, quick",JLPT_1 JLPT,qLzUXrbxxM
+ずばり,ずばり,"decisively, unreservedly, frankly",JLPT_1 JLPT,zNubn^c5m8
+スプリング,スプリング,spring,JLPT_1 JLPT,M&<1|Qyfm^
+スペース,スペース,space,JLPT_1 JLPT,"mfYc5:,T$)"
+ずぶぬれ,ずぶぬれ,"soaked, dripping wet",JLPT_1 JLPT,O=YLrvca-#
+スポーツカー,スポーツカー,sports car,JLPT_1 JLPT,ILQ_{U)ioI
+澄ます,すます,"to clear, to make clear, to listen for",JLPT_1 JLPT,o+[:%ypXAI
+清ます,すます,"to clear, to make clear, to listen for",JLPT_1 JLPT,gWgE<)O|pN
+済ます,すます,to finish; to settle; to do without,JLPT_1 JLPT,BI9b~SlUc1
+すみやか,すみやか,speedy,JLPT_1 JLPT,MC/)GM9mOK
+スラックス,スラックス,slacks,JLPT_1 JLPT,tpKEoAzoEC
+ずらっと,ずらっと,"in a line, in a row",JLPT_1 JLPT,GHI-Z0iw2Q
+ずるずる,ずるずる,"dragging on, sound of sniffling",JLPT_1 JLPT,xPdB)weA$j
+ずれ,ずれ,"difference, gap",JLPT_1 JLPT,ml<Cz:NIm9
+すれちがい,すれちがい,chance encounter,JLPT_1 JLPT,h}n%.0]G*]
+擦れる,すれる,"to rub, to chafe",JLPT_1 JLPT,y1pczASP(>
+すんなり,すんなり,"pass with no objection, slim, slender",JLPT_1 JLPT,c{rT9&J2OZ
+生育,せいいく,"growth, development, breeding",JLPT_1 JLPT,A*eQ]~1bJ/
+成育,せいいく,"growth, raising",JLPT_1 JLPT,A=.t}i>GW3
+成果,せいか,"results, fruits",JLPT_1 JLPT,BVYQfcf%9
+正解,せいかい,"correct, right answer, solution",JLPT_1 JLPT,Lt;.HzCJ&F
+正義,せいぎ,"justice, right, righteousness",JLPT_1 JLPT,C*lSCCu$Is
+生計,せいけい,"livelihood, living",JLPT_1 JLPT,sFe^vK-tW[
+政権,せいけん,"(political) administration, political power",JLPT_1 JLPT,ySl]BBHxv|
+星座,せいざ,constellation,JLPT_1 JLPT,v8-]C(eL~-
+制裁,せいさい,"restraint, sanctions, punishment",JLPT_1 JLPT,"&>5Y-0M,/"
+政策,せいさく,"political measures, policy",JLPT_1 JLPT,"hAD&H|lfX,"
+生死,せいし,life and death,JLPT_1 JLPT,[jWyFv3NW
+静止,せいし,"stillness, repose, standing still",JLPT_1 JLPT,o*g2}G_T7@
+誠実,せいじつ,"sincere, honest, faithful",JLPT_1 JLPT,bL3/~B_@Jx
+成熟,せいじゅく,"maturity, ripeness",JLPT_1 JLPT,mi&AvT*VW%
+青春,せいしゅん,"youth, springtime of life, adolescent",JLPT_1 JLPT,r1RCkb<y|$
+清純,せいじゅん,"purity, innocence",JLPT_1 JLPT,ONr5>]A5d|
+聖書,せいしょ,Bible,JLPT_1 JLPT,Q@S9S%oEQ1
+正常,せいじょう,"normalcy, normality, normal",JLPT_1 JLPT,wA-k/9L$M{
+制する,せいする,"to control, to command",JLPT_1 JLPT,rf}l5O&Iya
+整然,せいぜん,"orderly, regular, well-organized",JLPT_1 JLPT,PN>H*K1;6z
+盛装,せいそう,"be dressed up, wear rich clothes",JLPT_1 JLPT,"NT,a6{jkV^"
+盛大,せいだい,"grand, prosperous, magnificent",JLPT_1 JLPT,oA#/^#fynU
+清濁,せいだく,"good and evil, purity and impurity",JLPT_1 JLPT,LIBty_QSI!
+制定,せいてい,"enactment, establishment, creation",JLPT_1 JLPT,w/{{PKSO-l
+静的,せいてき,static,JLPT_1 JLPT,qS/}NK^[E0
+製鉄,せいてつ,iron manufacture,JLPT_1 JLPT,q1#~15/jx^
+晴天,せいてん,fine weather,JLPT_1 JLPT,O`AKp9t/nh
+正当,せいとう,"just, due, proper",JLPT_1 JLPT,KYfFW0c&^H
+制服,せいふく,uniform,JLPT_1 JLPT,KjpnwgIuCJ
+征服,せいふく,"conquest, subjugation, overcoming",JLPT_1 JLPT,UI+/g3/T<
+製法,せいほう,"manufacturing method, recipe, formula",JLPT_1 JLPT,r$Viif`6:S
+精密,せいみつ,"precise, exact, detailed, minute",JLPT_1 JLPT,k?w!_L!izK
+税務署,ぜいむしょ,tax office,JLPT_1 JLPT,cu&VjhU0YM
+制約,せいやく,"limitation, constraints",JLPT_1 JLPT,eGs}Rjdjyu
+勢力,せいりょく,"influence, power, might, strength",JLPT_1 JLPT,jCKk=3Gx//
+整列,せいれつ,"stand in a row, form a line",JLPT_1 JLPT,K=?{2[EdLY
+セール,セール,sale,JLPT_1 JLPT,bTb.7j.bY0
+急かす,せかす,"to hurry, to urge on",JLPT_1 JLPT,r25!gS/G>A
+伜,せがれ,"son, my son",JLPT_1 JLPT,CVmDxN*tGx
+責務,せきむ,"duty, obligation",JLPT_1 JLPT,ct_SCVUYk9
+セクション,セクション,section,JLPT_1 JLPT,oE+>)~hYZ>
+世辞,せじ,"flattery, compliment",JLPT_1 JLPT,i2*b#^+2.G
+世帯,せたい,household,JLPT_1 JLPT,M;wkDh)_[-
+是正,ぜせい,"correction, revision",JLPT_1 JLPT,r4z<%];90$
+世代,せだい,generation,JLPT_1 JLPT,vXhkxYs)ro
+切開,せっかい,"opening up, cutting through",JLPT_1 JLPT,j3{#e(JGO?
+セックス,セックス,sex,JLPT_1 JLPT,p^XJZeb_m$
+切実,せつじつ,"compelling, serious, severe, acute",JLPT_1 JLPT,"b(%wDAP,4<"
+接触,せっしょく,"touch, contact",JLPT_1 JLPT,euP9o6khjK
+接続詞,せつぞくし,conjunction,JLPT_1 JLPT,jxx/dj^^[F
+設置,せっち,"establishment, institution",JLPT_1 JLPT,dTa#ev1!lY
+折衷,せっちゅう,"compromise, cross, blending, eclecticism",JLPT_1 JLPT,z.Jdo5|UwK
+設定,せってい,"establishment, creation",JLPT_1 JLPT,EL[q3!y3K%
+説得,せっとく,persuasion,JLPT_1 JLPT,p@nzS4e%Pe
+切ない,せつない,"painful, trying, sad",JLPT_1 JLPT,Op2N@ZY@PL
+絶版,ぜっぱん,out of print,JLPT_1 JLPT,wscau>2!!B
+設立,せつりつ,"establishment, foundation, institution",JLPT_1 JLPT,nV|*LLs6}!
+攻め,せめ,"attack, offense",JLPT_1 JLPT,lp+Bg:0JY+
+ゼリー,ゼリー,jelly,JLPT_1 JLPT,pUMI]4pC]5
+セレモニー,セレモニー,ceremony,JLPT_1 JLPT,ElF~:n|$Dm
+世論,せろん,public opinion,JLPT_1 JLPT,cn7+uG:k{Q
+先,せん,"priority, precedence, previous",JLPT_1 JLPT,K[s:+C@-V{
+繊維,せんい,"fiber, fiber, textile",JLPT_1 JLPT,IoI]vI^@?E
+全快,ぜんかい,complete recovery of health,JLPT_1 JLPT,jMG%U5Y*b]
+宣教,せんきょう,religious mission,JLPT_1 JLPT,t2!m+EN<kt
+宣言,せんげん,"declaration, proclamation, announcement",JLPT_1 JLPT,N*Sn3]6F}u
+戦災,せんさい,war damage,JLPT_1 JLPT,g*>*T{UX8V
+専修,せんしゅう,specialization,JLPT_1 JLPT,iF/[EjL/PH
+戦術,せんじゅつ,tactics,JLPT_1 JLPT,fClOu9u4S.
+センス,センス,"sense (for music, style, tact, etc.)",JLPT_1 JLPT,kOf@Kc#S!?
+潜水,せんすい,diving,JLPT_1 JLPT,kXmApIVn4{
+全盛,ぜんせい,height of prosperity,JLPT_1 JLPT,PA4!?*R&)6
+先代,せんだい,"family predecessor, previous age, previous generation",JLPT_1 JLPT,A@$Xh`C*#q
+先だって,せんだって,"recently, the other day",JLPT_1 JLPT,bpeAMs`g=B
+先着,せんちゃく,first arrival,JLPT_1 JLPT,s5`[<)lze/
+前提,ぜんてい,"preamble, premise, prerequisite",JLPT_1 JLPT,M^(]5)Q28q
+先天的,せんてんてき,"inherent, congenital, hereditary",JLPT_1 JLPT,e8-*cxos*(
+前途,ぜんと,"future prospects, outlook, the journey ahead",JLPT_1 JLPT,rUv_dSLlLH
+戦闘,せんとう,"battle, fight, combat",JLPT_1 JLPT,LE#Z8!)h7>
+潜入,せんにゅう,"infiltration, sneaking in",JLPT_1 JLPT,jwMP<D<nu+
+船舶,せんぱく,ship,JLPT_1 JLPT,yT?Wj-:Bft
+全滅,ぜんめつ,annihilation,JLPT_1 JLPT,gs]{cpbeS;
+専用,せんよう,"exclusive use, personal use",JLPT_1 JLPT,E|;c&Jmrd8
+占領,せんりょう,"occupation, possession, have a room to oneself",JLPT_1 JLPT,N-V{tXojX`
+善良,ぜんりょう,"goodness, excellence, virtue",JLPT_1 JLPT,eGNEV*g</#
+戦力,せんりょく,war potential,JLPT_1 JLPT,jsYNJMtfV.
+前例,ぜんれい,precedent,JLPT_1 JLPT,z6IRT7DoRm
+相応,そうおう,"suitability, fitness",JLPT_1 JLPT,Cm`/n`5$^$
+総会,そうかい,general meeting,JLPT_1 JLPT,v.Q]y8[=}p
+創刊,そうかん,"launching (e.g., newspaper, first issue)",JLPT_1 JLPT,k7n}7cIr>q
+雑木,ぞうき,"various kinds of small trees, assorted trees",JLPT_1 JLPT,K-dqvXawa`
+早急,そうきゅう,urgent,JLPT_1 JLPT,xFEe8[1r^m
+早急,さっきゅう,urgent,JLPT_1 JLPT,n`GeYo>FBk
+増強,ぞうきょう,"reinforce, increase",JLPT_1 JLPT,"rV,>ZZ=T]Q"
+送金,そうきん,"remittance, sending money",JLPT_1 JLPT,bDXNFraL0R
+走行,そうこう,"running a wheeled vehicle (e.g., car, traveling)",JLPT_1 JLPT,E{T/IqjEfE
+総合,そうごう,"synthesis, generalization",JLPT_1 JLPT,nY;2hmT##_
+捜索,そうさく,"search (esp. for someone or something missing, investigation)",JLPT_1 JLPT,Q:2J1qwTVc
+蔵相,ぞうしょう,Minister of Finance,JLPT_1 JLPT,fn1-ZB(4T-
+装飾,そうしょく,ornament,JLPT_1 JLPT,QA)=&Wj6HM
+増進,ぞうしん,"promoting, increase, advance",JLPT_1 JLPT,IZpN7AL;vh
+相対,そうたい,relative,JLPT_1 JLPT,I!n?!w[?BY
+壮大,そうだい,"magnificent, grand, majestic",JLPT_1 JLPT,"mVUTF,w/3&"
+騒動,そうどう,"strife, riot, rebellion",JLPT_1 JLPT,f=viWAh8g@
+遭難,そうなん,"disaster, shipwreck, accident",JLPT_1 JLPT,E:/^OnBk`
+相場,そうば,"market price, speculation, estimation",JLPT_1 JLPT,sA7SWg(`IK
+装備,そうび,equipment,JLPT_1 JLPT,k;e~1ueRAo
+創立,そうりつ,"establishment, founding",JLPT_1 JLPT,jki@VUPP0r
+添える,そえる,"to add to, to attach, to accompany",JLPT_1 JLPT,"h,nxD[s(P9"
+ソース,ソース,source,JLPT_1 JLPT,tTpwt)2AmK
+即座に,そくざに,"immediately, right away",JLPT_1 JLPT,P;B^M<8:(U
+促進,そくしん,"promotion, acceleration, encouragement",JLPT_1 JLPT,qh4@1q0m.W
+即する,そくする,"to conform to, to agree with, to be adapted to,",JLPT_1 JLPT,t:DoS~nc0!
+束縛,そくばく,"restraint, restriction, confinement",JLPT_1 JLPT,l|/yaf0Kt?
+側面,そくめん,"side, sidelight, lateral",JLPT_1 JLPT,g+c1Ex)t~@
+損う,そこなう,"to harm, to hurt",JLPT_1 JLPT,lT+Npb!3tv
+そこら,そこら,"everywhere, somewhere",JLPT_1 JLPT,sWp/2)qrjX
+素材,そざい,"raw materials, subject matter",JLPT_1 JLPT,k+jer~`){}
+阻止,そし,"obstruction, check, hindrance",JLPT_1 JLPT,H_Bg*f2w~u
+訴訟,そしょう,"litigation, lawsuit",JLPT_1 JLPT,r473?K:c)w
+育ち,そだち,"breeding, growth",JLPT_1 JLPT,I7y!o0nH<>
+措置,そち,"measure, step",JLPT_1 JLPT,wm=Ne<1R~K
+ソックス,ソックス,socks,JLPT_1 JLPT,bW`v0lIx&{
+素っ気無い,そっけない,"cold, short, curt, blunt",JLPT_1 JLPT,m@~(NcJuf8
+外方,そっぽ,look (or turn) the other way,JLPT_1 JLPT,mx1|xYC`zo
+備え付ける,そなえつける,"to provide, to equip, to install",JLPT_1 JLPT,?a*256zVd
+備わる,そなわる,to be furnished with,JLPT_1 JLPT,f0#k].O9>M
+具わる,そなわる,to be furnished with,JLPT_1 JLPT,hS*=fc5g`d
+聳える,そびえる,"to rise, to tower, to soar",JLPT_1 JLPT,N#XbC.4.6E
+素朴,そぼく,"simplicity, artlessness, naivety",JLPT_1 JLPT,i)~;{+Y_4I
+背く,そむく,"to run counter to, to go against",JLPT_1 JLPT,lwG+$Mpa}3
+染まる,そまる,to be dyed,JLPT_1 JLPT,D^_/a/#sXJ
+染める,そめる,"to dye, to color",JLPT_1 JLPT,"u,7!Dp;dsk"
+そらす,そらす,"to bend, to warp",JLPT_1 JLPT,O/=U<S;HO[
+そり (～にのる),そり (～にのる),"sleigh, sled",JLPT_1 JLPT,oD<qmOFt48
+反る,そる,"to warp, to be warped, to curve",JLPT_1 JLPT,IJaW-#q2K8
+それゆえ,それゆえ,"therefore, for that reason, so",JLPT_1 JLPT,fd1U3Eqd0z
+ソロ,ソロ,solo,JLPT_1 JLPT,r<H?#?:lfS
+揃い,そろい,"set, suit, uniform",JLPT_1 JLPT,d$?[e]vP*A
+ぞんざい,ぞんざい,"rude, careless, slovenly",JLPT_1 JLPT,IV/~qgGGDy
+損失,そんしつ,loss,JLPT_1 JLPT,q}vnE8Gq;U
+存続,そんぞく,"duration, continuance",JLPT_1 JLPT,k--fc+@]/s
+ダース,ダース,dozen,JLPT_1 JLPT,LJ)2+[0^`@
+対応,たいおう,dealing with,JLPT_1 JLPT,KZnf.&v={U
+大家,たいか,"rich family, distinguished family",JLPT_1 JLPT,Nrwns(8SbS
+退化,たいか,"degeneration, retrogression",JLPT_1 JLPT,gPs^-F*IXX
+大概,たいがい,"in general, mainly",JLPT_1 JLPT,h9/$[pq28V
+体格,たいかく,"physique, constitution",JLPT_1 JLPT,F<F1njV;[$
+大金,たいきん,large amount of money,JLPT_1 JLPT,m_p4U|6#<L
+待遇,たいぐう,"treatment, reception",JLPT_1 JLPT,F5l%#d#e`l
+対決,たいけつ,"confrontation, showdown",JLPT_1 JLPT,sKn[*vv=gw
+体験,たいけん,personal experience,JLPT_1 JLPT Intermediate_Japanese_Ln.13 Intermediate_Japanese,o%)Oc|W=Ka
+対抗,たいこう,"opposition, antagonism",JLPT_1 JLPT,Rd@pS:`}f/
+退治,たいじ,extermination,JLPT_1 JLPT,pC*Xx^dBSu
+大衆,たいしゅう,general public,JLPT_1 JLPT,nog=kohV~>
+対処,たいしょ,"deal with, cope",JLPT_1 JLPT,yMT#3SVsQ>
+退職,たいしょく,retirement (from office),JLPT_1 JLPT,zj2z79]QG@
+題する,だいする,to title,JLPT_1 JLPT,"F)V}e,NP?K"
+態勢,たいせい,"attitude, conditions, tendency",JLPT_1 JLPT,q2.f(w/7&
+対談,たいだん,"talk, dialogue",JLPT_1 JLPT,F(U~._UF.|
+大胆,だいたん,"bold, daring, audacious",JLPT_1 JLPT,NiV/^uCv:g
+対等,たいとう,equivalent,JLPT_1 JLPT,e2@L)L#}Hy
+台無し,だいなし,"mess, spoiled, (come to) nothing",JLPT_1 JLPT,O<W!7i{%=i
+滞納,たいのう,"non-payment, default",JLPT_1 JLPT,"EVFf,lL5*1"
+対比,たいひ,"contrast, comparison",JLPT_1 JLPT,QS^fJ(5L6U
+タイピスト,タイピスト,typist,JLPT_1 JLPT,rgU6t{db}6
+大部,たいぶ,"most (e.g., most part, greater, fairly, a good deal, much)",JLPT_1 JLPT,M:e6p(bi4/
+大便,だいべん,feces,JLPT_1 JLPT,bxG(1E~XYm
+代弁,だいべん,speak for another,JLPT_1 JLPT,MRN2]i=t=d
+待望,たいぼう,"long-expected, waiting",JLPT_1 JLPT,qE#$km{TWt
+台本,だいほん,"libretto, scenario",JLPT_1 JLPT,RgJye)6k}y
+タイマー,タイマー,timer,JLPT_1 JLPT,Jpmdj[Dy-8
+怠慢,たいまん,"negligence, carelessness",JLPT_1 JLPT,o+E(5HE.HE
+タイミング,タイミング,timing,JLPT_1 JLPT,xPwaZgIXR*
+タイム,タイム,time,JLPT_1 JLPT,jbo*<.eMG[
+タイムリー,タイムリー,"timely, run-batted-in (baseball), RBI",JLPT_1 JLPT,yP9[juCnL[
+対面,たいめん,"interview, meeting",JLPT_1 JLPT,i`k./6SP4;
+代用,だいよう,substitution,JLPT_1 JLPT,mu!!VPGcN/
+体力,たいりょく,physical strength,JLPT_1 JLPT,k5)wZQr4>y
+タイル,タイル,tile,JLPT_1 JLPT,ATn!+%/EU;
+対話,たいわ,"conversation, dialogue",JLPT_1 JLPT,dArvNg;d~A
+耐える,たえる,"to endure, to put up with",JLPT_1 JLPT,fX{nWJ2pLZ
+堪える,たえる,"to endure, to put up with",JLPT_1 JLPT,Lk-i;aQnR+
+絶える,たえる,"to die out, to become extinct",JLPT_1 JLPT,rTE!2k^D@
+断える,たえる,"to cease, to become extinct",JLPT_1 JLPT,Qs%N8rxgY7
+打開,だかい,"solution, breakthrough",JLPT_1 JLPT,mQ|SYI%fP]
+焚火,たきび,(open) fire,JLPT_1 JLPT,LcA{{ZbodA
+妥協,だきょう,"compromise, giving in",JLPT_1 JLPT,"s%Avc+h,O*"
+たくましい,たくましい,"burly, strong, sturdy",JLPT_1 JLPT,"P8,W5KAJY/"
+巧み,たくみ,"skill, cleverness",JLPT_1 JLPT,i]Z*A6(YX(
+丈,たけ,"length, height",JLPT_1 JLPT,enuUDdn`y|
+打撃,だげき,"blow, damage; batting (baseball)",JLPT_1 JLPT,"t;}gxU%<,g"
+妥結,だけつ,agreement,JLPT_1 JLPT,l2ZF^5r/@.
+駄作,ださく,poor work,JLPT_1 JLPT,Lw)j7o&?}o
+足し算,たしざん,addition,JLPT_1 JLPT,iE/CUShX8n
+多数決,たすうけつ,majority rule,JLPT_1 JLPT,"OJ~&,3EcJ/"
+助け,たすけ,assistance,JLPT_1 JLPT,j0*?atjOa+
+携わる,たずさわる,"to engage, to involve",JLPT_1 JLPT,McI/Z<qse(
+漂う,ただよう,"to drift about, to float, to hang in air",JLPT_1 JLPT,bR^R=T^]/Z
+立ち去る,たちさる,"to leave, to depart",JLPT_1 JLPT,x4xomzb{(l
+立ち寄る,たちよる,"to stop by, to drop in for a short visit",JLPT_1 JLPT,"i~*^/,u.M%"
+抱っこ,だっこ,(child's) hug,JLPT_1 JLPT,u]W;19*#xC
+達者,たっしゃ,"skillful, in good health",JLPT_1 JLPT,QMO]Jn&?Ra
+脱出,だっしゅつ,escape,JLPT_1 JLPT,rfK<qkCIf]
+脱する,だっする,"to escape from, to get out",JLPT_1 JLPT,t;JPYpd=u$
+達成,たっせい,achievement,JLPT_1 JLPT,y%qBRcv/jg
+脱退,だったい,"secession, withdrawal",JLPT_1 JLPT,ncettC@%js
+だったら,だったら,if it's the case,JLPT_1 JLPT,C/Y!eNd>%+
+立て替える,たてかえる,"to pay in advance, to pay for another",JLPT_1 JLPT,kf$XJ8^ry/
+建前,たてまえ,position; stance one takes in public; principle,JLPT_1 JLPT Intermediate_Japanese_Ln.15 Intermediate_Japanese,L3SqCRekB4
+奉る,たてまつる,"to offer, to do respectfully",JLPT_1 JLPT,f5~QK@<Z?-
+だと,だと,if it's the case,JLPT_1 JLPT,AdbIr)ODQy
+他動詞,たどうし,transitive verb (direct object),JLPT_1 JLPT,k%4*4&yY`0
+辿り着く,たどりつく,"to reach, to make it somehow",JLPT_1 JLPT,g7HZru1rgh
+辿る,たどる,"to follow (road, to pursue (course), to follow up",JLPT_1 JLPT,wGxS[a6&-W
+束ねる,たばねる,"to tie up in a bundle, to control",JLPT_1 JLPT,f-6#7v|syX
+だぶだぶ,だぶだぶ,"loose, baggy",JLPT_1 JLPT,gN6($!p`)9
+他方,たほう,"another side, on the other hand",JLPT_1 JLPT,kBVB0U>~W;
+多忙,たぼう,busy,JLPT_1 JLPT,&tDV5aeSi
+給う,たまう,"to receive, to grant",JLPT_1 JLPT,o3qNRs#MmC
+魂,たましい,"soul, spirit",JLPT_1 JLPT,Lule^<EV8B
+溜まり,たまり,"collected things, gathering place, arrears",JLPT_1 JLPT,vn*T!ewBaY
+賜る,たまわる,"to grant, to bestow",JLPT_1 JLPT,HP!zs26?IS
+保つ,たもつ,"to keep, to preserve, to sustain",JLPT_1 JLPT,gTbXu)j!`=
+たやすい,たやすい,"easy, simple, light",JLPT_1 JLPT,AG]dUK?GLW
+多様,たよう,"diversity, variety",JLPT_1 JLPT,vtZOkeWk&x
+だるい,だるい,"sluggish, feel heavy (tired), languid",JLPT_1 JLPT Intermediate_Japanese_Ln.12 Intermediate_Japanese,"ssq5O?,bMD"
+弛み,たるみ,"slack, slackening",JLPT_1 JLPT,CfA9KvwrNs
+弛む,たるむ,"to slacken, to loosen, to relax",JLPT_1 JLPT,Q3_&mJpm{q
+垂れる,たれる,"to hang, to droop; to drip",JLPT_1 JLPT,"dR~s,A!paY"
+タレント,タレント,"talent, star, personality",JLPT_1 JLPT,lrfU7E]iMP
+タワー,タワー,tower,JLPT_1 JLPT,v5:z0AFR9T
+単一,たんいつ,"single, simple, sole",JLPT_1 JLPT,h$`k(ir0Rg
+短歌,たんか,31-syllable Japanese poem,JLPT_1 JLPT,Ir#MY^13Ie
+担架,たんか,"stretcher, litter",JLPT_1 JLPT,HV+tZ)Qo19
+短気,たんき,quick temper,JLPT_1 JLPT,"q,u5ZnTUee"
+団結,だんけつ,"unity, union, solidarity",JLPT_1 JLPT,nY!|1{!OCq
+探検,たんけん,"exploration, expedition",JLPT_1 JLPT,sRi|/nSA`o
+断言,だんげん,"assertion, declaration, affirmation",JLPT_1 JLPT,w+Gv2p_R~h
+短縮,たんしゅく,"shortening, abbreviation, reduction",JLPT_1 JLPT,"loQag*w7,y"
+断然,だんぜん,"firmly, absolutely, definitely",JLPT_1 JLPT,i4oX5JR1dF
+炭素,たんそ,carbon (C),JLPT_1 JLPT,x^}A~2~z<O
+短大,たんだい,junior college,JLPT_1 JLPT,q^nCWsg[HX
+単調,たんちょう,"monotony, monotone, dullness",JLPT_1 JLPT,rL$X_?_Pk#
+単独,たんどく,"sole, single",JLPT_1 JLPT,esBhRW$7nM
+旦那,だんな,"master (of house), husband (informal)",JLPT_1 JLPT,Eg]wBS#KM/
+短波,たんぱ,short wave,JLPT_1 JLPT,i|6Bns+L;/
+蛋白質,たんぱくしつ,protein,JLPT_1 JLPT,Jp^dQ($699
+ダンプ,ダンプ,dump truck,JLPT_1 JLPT,Nw}Lm}Btbw
+断面,だんめん,cross section,JLPT_1 JLPT,GKBfUV.8Iw
+弾力,だんりょく,"elasticity, flexibility",JLPT_1 JLPT,msj@^X&|0|
+治安,ちあん,"public order, security",JLPT_1 JLPT,"BnO,YE-DZD"
+チームワーク,チームワーク,teamwork,JLPT_1 JLPT,P=nF6sUVt[
+チェンジ,チェンジ,change,JLPT_1 JLPT,Dijxw<8QAe
+違える,ちがえる,to change,JLPT_1 JLPT,l%F*x{2Z?s
+畜産,ちくさん,animal husbandry,JLPT_1 JLPT,JuGLp(:y{X
+畜生,ちくしょう,"beast, brute, damn",JLPT_1 JLPT,vq_X{4/863
+蓄積,ちくせき,"accumulation, accumulate, store",JLPT_1 JLPT,Pr<}&RmAQ(
+地形,ちけい,"landform, geographical features, topography",JLPT_1 JLPT,z9e8bk2QkU
+知性,ちせい,intelligence,JLPT_1 JLPT,O7tGamj6Tf
+乳,ちち,"milk, breast, loop",JLPT_1 JLPT,"l,=LW~Hy+r"
+縮まる,ちぢまる,"to be shortened, to be contracted, to shrink",JLPT_1 JLPT,wu7wbA:9_;
+秩序,ちつじょ,"order, regularity",JLPT_1 JLPT Intermediate_Japanese_Ln.10 Intermediate_Japanese,P)jMU1FkFO
+窒息,ちっそく,suffocation,JLPT_1 JLPT,fDBko;}]D
+知的,ちてき,intellectual,JLPT_1 JLPT,jiAkN.}ZmV
+着手,ちゃくしゅ,"embarkation, launch",JLPT_1 JLPT,F[_a*7LJN.
+着色,ちゃくしょく,"coloring, coloring",JLPT_1 JLPT,N#Q=xWnJKS
+着席,ちゃくせき,"sit down, seat",JLPT_1 JLPT,MeN__AKyp|
+着目,ちゃくもく,attention,JLPT_1 JLPT,wi@WVZX@m|
+着陸,ちゃくりく,"landing, touch down",JLPT_1 JLPT,b|+eNo%pfV
+着工,ちゃっこう,start of (construction) work,JLPT_1 JLPT,Ew6+3{D_ru
+茶の間,ちゃのま,living room (Japanese style),JLPT_1 JLPT,N9-wCuA<Rp
+茶の湯,ちゃのゆ,tea ceremony,JLPT_1 JLPT,ejvH[/WC(/
+ちやほや,ちやほや,"pamper, make a fuss of, spoil",JLPT_1 JLPT,p7xbFu82u*
+チャンネル,チャンネル,a channel,JLPT_1 JLPT,nV5l[5`h]F
+宙返り,ちゅうがえり,"somersault, looping-the-loop",JLPT_1 JLPT,G#D%$XG0_r
+中継,ちゅうけい,"relay, hook-up",JLPT_1 JLPT,MWNEDyrDN$
+忠告,ちゅうこく,"advice, warning",JLPT_1 JLPT,N9-O04D*/i
+中傷,ちゅうしょう,"slander, libel, defamation",JLPT_1 JLPT,p0CsH{8#JZ
+中枢,ちゅうすう,"center, mainstay, nucleus",JLPT_1 JLPT,r%Mjj+Ek{5
+抽選,ちゅうせん,"lottery, raffle, drawing (of lots)",JLPT_1 JLPT,0KYkNtfpJ
+中断,ちゅうだん,"interruption, suspension, break",JLPT_1 JLPT,w>%6r/va[-
+中毒,ちゅうどく,poisoning,JLPT_1 JLPT,LzJ=jxfHor
+中腹,ちゅうふく,"mountain side, halfway up",JLPT_1 JLPT,tB+gKvvwou
+中立,ちゅうりつ,neutrality,JLPT_1 JLPT,PZFB#``%5o
+中和,ちゅうわ,"neutralize, counteract",JLPT_1 JLPT,nyH&P(=%8Y
+～著,～ちょ,written by ~,JLPT_1 JLPT,fQ0a}K7p9f
+腸,ちょう,"bowels, intestines",JLPT_1 JLPT,K%kn{5[S%7
+蝶,ちょう,butterfly,JLPT_1 JLPT,q;0HqmYw1-
+超,ちょう,"super-, ultra-, hyper-",JLPT_1 JLPT,Eiftj43[ej
+調印,ちょういん,"signature, sign, sealing",JLPT_1 JLPT,+X8b+]_hF
+聴覚,ちょうかく,the sense of hearing,JLPT_1 JLPT,C>6Ay%IdDe
+長官,ちょうかん,"chief, (government) secretary",JLPT_1 JLPT,"H,v:QJS0Yi"
+聴講,ちょうこう,"lecture attendance, auditing",JLPT_1 JLPT,dMxJpHdu-m
+徴収,ちょうしゅう,"collection, levy",JLPT_1 JLPT,LIId5$2fh5
+聴診器,ちょうしんき,stethoscope,JLPT_1 JLPT,A2>D_NQ`=%
+調停,ちょうてい,"arbitration, conciliation, mediation",JLPT_1 JLPT,zrfL7jNQ@_
+重複,ちょうふく,"duplication, repetition, overlapping, redundancy, restoration",JLPT_1 JLPT,yXhchN!{a9
+長編,ちょうへん,"long (e.g., novel, film)",JLPT_1 JLPT,u19=nL^X<]
+重宝,ちょうほう,"convenient, useful",JLPT_1 JLPT,P`*HZ|)=W)
+調理,ちょうり,cooking,JLPT_1 JLPT,P`dt.f6=&.
+調和,ちょうわ,harmony,JLPT_1 JLPT,MQV-Mk:gSq
+ちょくちょく,ちょくちょく,"often, frequently, now and then, occasionally",JLPT_1 JLPT,eXEksqIu&w
+直面,ちょくめん,confrontation,JLPT_1 JLPT,Q%puR-vfcY
+著書,ちょしょ,"literary work, book",JLPT_1 JLPT,k8We;qzOF?
+貯蓄,ちょちく,savings,JLPT_1 JLPT,yk~={SS:?P
+直感,ちょっかん,"intuition, instinct",JLPT_1 JLPT,QySp}y0;^p
+著名,ちょめい,"well-known, noted, celebrated",JLPT_1 JLPT,X^slZ{jL{
+ちらっと,ちらっと,"at a glance, by accident",JLPT_1 JLPT,N3Y^D/sd+D
+塵,ちり,"dust, dirt",JLPT_1 JLPT,E+SU)Yck+x
+塵取り,ちりとり,dustpan,JLPT_1 JLPT,APKgG.~B~%
+賃金,ちんぎん,wages,JLPT_1 JLPT,R~b_`JWOQ
+沈殿,ちんでん,"precipitation, deposition, settlement",JLPT_1 JLPT,G+XQh2h;J
+沈没,ちんぼつ,"sinking, foundering",JLPT_1 JLPT,iW4PqKe`G4
+沈黙,ちんもく,"silence, reticence",JLPT_1 JLPT,px*6fcGx;&
+陳列,ちんれつ,"exhibition, display, show",JLPT_1 JLPT,iwMSM}M#]k
+追及,ついきゅう,"investigation, inquiry",JLPT_1 JLPT,noU*13b5O-
+追跡,ついせき,pursuit,JLPT_1 JLPT,x&s%FCI5Z$
+追放,ついほう,"exile, banishment",JLPT_1 JLPT,wlC&^*I(#k
+費やす,ついやす,"to spend, to devote, to waste",JLPT_1 JLPT,H-?H<E[N4R
+墜落,ついらく,"falling, crashing",JLPT_1 JLPT,GIlG86j>ft
+痛感,つうかん,"feeling keenly, fully realizing",JLPT_1 JLPT,w#*!ZaG>/&
+通常,つうじょう,"common, normal, usual",JLPT_1 JLPT,CK7#B(npW6
+痛切,つうせつ,"keen, deep",JLPT_1 JLPT,P)gMK#>#mQ
+杖,つえ,cane,JLPT_1 JLPT,E%FRI/LaC<
+使い道,つかいみち,use,JLPT_1 JLPT,C.3OB5&{uj
+仕える,つかえる,"to serve, to work for",JLPT_1 JLPT,"yJ9cY,O`h("
+司る,つかさどる,"to rule, to govern, to administer",JLPT_1 JLPT,N0ki8Oo?OJ
+つかの間,つかのま,"moment, brief time,",JLPT_1 JLPT,"HjZRq7,M3q"
+月並,つきなみ,"conventional, trite, common",JLPT_1 JLPT,"s,jIH8HGr)"
+継目,つぎめ,"joint, seam",JLPT_1 JLPT,g`*Hbj}:;n
+尽きる,つきる,"to be used up, to be run out",JLPT_1 JLPT,D@MfPrj.$e
+尽くす,つくす,"to exhaust, to run out; to devote, to serve",JLPT_1 JLPT,du~n(l-y;V
+つくづく,つくづく,"completely, really",JLPT_1 JLPT,sr:&|?%)^o
+作り,つくり,"make up, structure, physique",JLPT_1 JLPT,k)o<GJT`g{
+造り,つくり,"make up, structure, physique",JLPT_1 JLPT,yc(=JOoe^y
+繕う,つくろう,"to mend, to repair",JLPT_1 JLPT,rVgUbJ=*17
+付け加える,つけくわえる,to add one thing to another,JLPT_1 JLPT,G(BFo.4q2m
+告げる,つげる,to inform,JLPT_1 JLPT,<m$M~A%1_
+つじつま (はなしの～),つじつま (はなしの～),"coherence, consistency",JLPT_1 JLPT,jvc[~0R.1u
+筒,つつ,"pipe, tube",JLPT_1 JLPT,w^XrZ[jgo`
+突く,つつく,"to thrust, to strike, to attack; to poke, to nudge, to pick at",JLPT_1 JLPT,B*u&&$(Hd.
+突っ突く,つっつく,to prompt someone,JLPT_1 JLPT,"p5=i4N,JuA"
+謹む,つつしむ,"to be careful, to be chaste or discreet",JLPT_1 JLPT,gh_.MQ25nu
+突っ張る,つっぱる,"to support, to become stiff; to thrust (ones opponent), to stick to (ones opinion), to insist on",JLPT_1 JLPT,J%0:#u3#VS
+務まる,つとまる,"be equal, be fit",JLPT_1 JLPT,cvC_+6=O[(
+勤め先,つとめさき,place of work,JLPT_1 JLPT,d%0{lsg|M/
+努めて,つとめて,"make an effort!, work hard!",JLPT_1 JLPT,ie5f<%K4c(
+津波,つなみ,"tsunami, tidal wave",JLPT_1 JLPT,MNnk0OWf1x
+つねる,つねる,to pinch,JLPT_1 JLPT,uFreoT2Btm
+角,つの,horn,JLPT_1 JLPT,de#UEAK(5-
+募る,つのる,"to invite, to solicit help, participation, etc",JLPT_1 JLPT,LoJ`r.LWA^
+唾,つば,"saliva, spit, sputum",JLPT_1 JLPT,BsP8}KfBI.
+呟く,つぶやく,"to mutter, to murmur",JLPT_1 JLPT,ug.@5E|3HH
+つぶら,つぶら,"round, rotund",JLPT_1 JLPT,ef4-=?4kR%
+つぶる (めを～),つぶる (めを～),to close the eyes,JLPT_1 JLPT,ndE`WwYDbY
+壷,つぼ,"jar, pot, vase",JLPT_1 JLPT,C3S8JvZPeU
+蕾,つぼみ,"bud, flower bud",JLPT_1 JLPT,"QMJ,;+-HP?"
+連なる,つらなる,"to extend, to stretch out, to stand in a row",JLPT_1 JLPT,mp~Cp%LGWd
+貫く,つらぬく,to go through,JLPT_1 JLPT,j32^3)_a~A
+連ねる,つらねる,"to link, to join, to put together",JLPT_1 JLPT,"f,+4Zn,xV["
+釣り鐘,つりがね,temple bell (for striking),JLPT_1 JLPT,NCQt3~fkfu
+吊り革,つりかわ,strap,JLPT_1 JLPT,djH0o!(*c9
+手当,てあて,"allowance, compensation; treatment",JLPT_1 JLPT,"re,MYOrC&P"
+定義,ていぎ,definition,JLPT_1 JLPT,Ju;[Z@>(rL
+提供,ていきょう,"offer, program sponsoring",JLPT_1 JLPT,nfoi|;u&u/
+提携,ていけい,"cooperation, tie-up, joint business",JLPT_1 JLPT,LK&~}-CW`X
+体裁,ていさい,"decency, style, form, appearance",JLPT_1 JLPT,Pn+88/;c&{
+提示,ていじ,"presentation, exhibit, suggest, citation",JLPT_1 JLPT,"ghC1,HWr`q"
+ティシュペーパー,ティシュペーパー,tissue,JLPT_1 JLPT,E?F_x/Bz#;
+定食,ていしょく,"fixed-price lunch, set meal, dinner",JLPT_1 JLPT Intermediate_Japanese_Ln.13 Intermediate_Japanese,dh@a8noi3!
+訂正,ていせい,"correction, revision",JLPT_1 JLPT,xK_nbbN*:9
+停滞,ていたい,"stagnation, tie-up, congestion, retention",JLPT_1 JLPT,IS{H3A{d1v
+邸宅,ていたく,"mansion, residence",JLPT_1 JLPT,y<*6&i/ulR
+定年,ていねん,retirement age,JLPT_1 JLPT,L&j?pv3_Qz
+堤防,ていぼう,"bank, weir",JLPT_1 JLPT,vS/&|1=DC6
+手遅れ,ておくれ,being (too); belated treatment,JLPT_1 JLPT,nekju?5ubj
+でかい,でかい,huge,JLPT_1 JLPT,Jx@s8-_D#U
+手掛かり,てがかり,"hint, clue, key",JLPT_1 JLPT,tv6_fmP+C^
+手掛ける,てがける,"to handle, to manage, to work with",JLPT_1 JLPT,b`U6.}VMxH
+手数,てかず,"trouble, labor, handling",JLPT_1 JLPT,JN-JN1T)fO
+手軽,てがる,"easy, simple, cheap",JLPT_1 JLPT,O$[ge5&iL_
+適応,てきおう,"adaptation, accommodation, conformity",JLPT_1 JLPT,qk3tIV:T3#
+適宜,てきぎ,suitability,JLPT_1 JLPT,jN;;V2!rB&
+適性,てきせい,aptitude,JLPT_1 JLPT,piX3]-NbDU
+できもの,できもの,"boil, rash",JLPT_1 JLPT,O_GU07-J5^
+手際,てぎわ,"performance, skill, tact",JLPT_1 JLPT,bEAk|h>/cN
+出くわす,でくわす,"to happen to meet, to come across",JLPT_1 JLPT,Q2(sjkHGlO
+手順,てじゅん,"process, procedure, protocol",JLPT_1 JLPT Intermediate_Japanese_Ln.12 Intermediate_Japanese,c1%awvoN<G
+手錠,てじょう,"handcuffs, manacles",JLPT_1 JLPT,M]H9j1Gt/U
+手数,てすう,"trouble, labor, handling",JLPT_1 JLPT,f]Aus5bfMZ
+デコレーション,デコレーション,decoration,JLPT_1 JLPT,K-]Gk*htnp
+手近,てぢか,"near, handy, familiar",JLPT_1 JLPT,I~^!M@4Nmr
+てっきり,てっきり,"surely, certainly, beyond doubt",JLPT_1 JLPT,K?Vg%~I#2j
+鉄鋼,てっこう,iron and steel,JLPT_1 JLPT,rVT@BH(A<O
+デッサン,デッサン,rough sketch (FRE: dessin),JLPT_1 JLPT,E=Z>y*~.3/
+徹する,てっする,"to devote oneself, to believe in",JLPT_1 JLPT,"vaiF^,!jUj"
+てっぺん,てっぺん,"top, summit, apex",JLPT_1 JLPT,e*DdFUG2(%
+鉄棒,てつぼう,"iron rod, crowbar, horizontal bar (gymnastics)",JLPT_1 JLPT,r<o!(5nPnk
+出直し,でなおし,"adjustment, touch up",JLPT_1 JLPT,PF+k$MO93w
+掌,てのひら,the palm,JLPT_1 JLPT,D(Up6FVIZ(
+手配,てはい,"arrangement, search (by police)",JLPT_1 JLPT,J>A}Co`l`L
+手筈,てはず,"arrangement, plan, program",JLPT_1 JLPT,O--?RK?-XP
+手引,てびき,"guidance, guide, introduction",JLPT_1 JLPT,J{/gJ9FsV[
+手本,てほん,"model, pattern",JLPT_1 JLPT,"t|h[1W,pPs"
+手回し,てまわし,"preparations, arrangements",JLPT_1 JLPT,dy-/j^Gui]
+手元,てもと,"(money) on hand or at home, one's purse; usual skill",JLPT_1 JLPT,tu&}1&?g%w
+デモンストレーション,デモンストレーション,demonstration,JLPT_1 JLPT,I55gT%~:[j
+照り返す,てりかえす,"to reflect, to throw back light",JLPT_1 JLPT,kIkT2-(*J3
+テレックス,テレックス,"telex, teletypewriter exchange",JLPT_1 JLPT,v1+D>d&5H.
+手分け,てわけ,division of labor,JLPT_1 JLPT,m#VeALIb8e
+天,てん,"heaven, sky",JLPT_1 JLPT,NGMN.ktbZT
+田園,でんえん,"country, rural districts",JLPT_1 JLPT,u^Yf4=SXt+
+天下,てんか,"the world, whole country",JLPT_1 JLPT,c`j(?T6s|2
+転回,てんかい,"revolution, rotation",JLPT_1 JLPT,CdUnq5y&]D
+連休,れんきゅう,consecutive holidays,JLPT_1 JLPT,v&B%&=.umW
+レンジ,レンジ,"range, stove",JLPT_1 JLPT,"jL!E`UXR^,"
+連日,れんじつ,every day,JLPT_1 JLPT,CSkupzR%yX
+連帯,れんたい,solidarity,JLPT_1 JLPT,d+1viQ!EW$
+レンタカー,レンタカー,rented car,JLPT_1 JLPT,LHb}$Ksd`G
+連中,れんちゅう,"colleagues, company, a lot",JLPT_1 JLPT,fcpKtyDAP?
+レントゲン,レントゲン,X-ray (lit: Roentgen),JLPT_1 JLPT,GHk0mkE1#{
+連邦,れんぽう,"commonwealth, federation of states",JLPT_1 JLPT,xfk/&QS*u}
+連盟,れんめい,"league, union, alliance",JLPT_1 JLPT,rV)jw]&6Ih
+老衰,ろうすい,"senility, senile decay",JLPT_1 JLPT,w1ZJJ7QWeX
+朗読,ろうどく,"reading aloud, recitation",JLPT_1 JLPT,El2iMtJ(Sl
+浪費,ろうひ,"waste, extravagance",JLPT_1 JLPT,u{Vu7w)%?(
+労力,ろうりょく,"labor, effort, trouble",JLPT_1 JLPT,qiD=dg1#y~
+ロープウエイ,ロープウエイ,"ropeway, aerial tram",JLPT_1 JLPT,pKV@$<+q~Q
+ロープ,ロープ,rope,JLPT_1 JLPT,uDO_!v|0Dd
+ろくな,ろくな,"satisfactory, decent",JLPT_1 JLPT,s_@NG</ZI-
+露骨,ろこつ,"blunt, outspoken; conspicuous; broad, suggestive",JLPT_1 JLPT,okKA1R-|_f
+ロマンチック,ロマンチック,romantic,JLPT_1 JLPT,M?mRP8})iJ
+論議,ろんぎ,discussion,JLPT_1 JLPT,c_VVnx7{Qw
+論理,ろんり,logic,JLPT_1 JLPT,L6>bmEs.Go
+惑星,わくせい,planet,JLPT_1 JLPT,i(EF_1YXl@
+技,わざ,"art, technique",JLPT_1 JLPT,BM:PE.Zf/W
+わざわざ,わざわざ,"take the trouble (to do), doing something especially rather than incidentally",JLPT_1 JLPT Intermediate_Japanese_Ln.9 Intermediate_Japanese,t+s8u__g5@
+煩わしい,わずらわしい,"burdensome, troublesome, complicated",JLPT_1 JLPT Intermediate_Japanese_Ln.15 Intermediate_Japanese,d%nLdUaXBB
+渡り鳥,わたりどり,"migratory bird, bird of passage",JLPT_1 JLPT,OW4.0`K.za
+ワット,ワット,watt,JLPT_1 JLPT,Cl9:c$w_K0
+詫び,わび,apology,JLPT_1 JLPT,AUUCTG`g4{
+和文,わぶん,"Japanese text, sentence in Japanese",JLPT_1 JLPT,hA!eAFwp%C
+藁,わら,straw,JLPT_1 JLPT,IT5]>S[<%w
+～割,～わり,~ percent,JLPT_1 JLPT,lrri&x/?!~
+割当,わりあて,"allotment, allocation, quota",JLPT_1 JLPT,IlKj$LsL25
+割込む,わりこむ,"to cut in, to disturb",JLPT_1 JLPT,"ItKL,F,rvP"
+悪者,わるもの,"bad fellow, rascal",JLPT_1 JLPT,zqrlJ[/)nS
+我,われ,"me, oneself, self, ego",JLPT_1 JLPT,Cj(Z-pN+6@
+捗る,はかどる,"to make progress, to move right ahead (with the work), to advance",JLPT_1 JLPT,LcVyrW<_Ko
+はかない,はかない,"short-lived, momentary, ephemeral",JLPT_1 JLPT,wqukd{`F!4
+ばかばかしい,ばかばかしい,stupid,JLPT_1 JLPT,PG3w`deiE$
+破棄,はき,"revocation, annulment, breaking (e.g., treaty)",JLPT_1 JLPT,bm7xC^8X(_
+剥ぐ,はぐ,"to tear off, to peel off, to rip off",JLPT_1 JLPT,D@e1MI=??R
+迫害,はくがい,persecution,JLPT_1 JLPT,ApZ+iCu%0a
+薄弱,はくじゃく,"feebleness, weakness, weak",JLPT_1 JLPT,f:hfy$ygWT
+白状,はくじょう,confession,JLPT_1 JLPT,J/Jj0`N>b{
+漠然,ばくぜん,"obscure, vague, equivocal",JLPT_1 JLPT,z<3ukk)iX!
+爆弾,ばくだん,bomb,JLPT_1 JLPT,qYU+(QByX-
+爆破,ばくは,"blast, explosion, blow up",JLPT_1 JLPT,"m),XrBltSD"
+暴露,ばくろ,"disclosure, exposure, revelation",JLPT_1 JLPT,i/U;Q_t$DD
+励ます,はげます,"to encourage, to cheer, to raise (the voice)",JLPT_1 JLPT Intermediate_Japanese_Ln.13 Intermediate_Japanese,Ov]Au<DThv
+励む,はげむ,"to be zealous, to make an effort",JLPT_1 JLPT,eRMmv1gB8h
+剥げる,はげる,"to come off, to be worn off, to fade, to discolor",JLPT_1 JLPT,m#-VcH[ruD
+化ける,ばける,"to disguise, to take the form of",JLPT_1 JLPT,"zsj~iuc<,S"
+派遣,はけん,"dispatch, send",JLPT_1 JLPT,xZEi_Ueutn
+恥,はじ,"shame, embarrassment",JLPT_1 JLPT,H_9U]_^tqP
+弾く,はじく,"to play (piano, guitar)",JLPT_1 JLPT,p02dcV&o1#
+パジャマ,パジャマ,pajamas,JLPT_1 JLPT,Ipo@;IW-Nr
+恥じらう,はじらう,"to feel shy, to be bashful, to blush",JLPT_1 JLPT,"D}9,{%uTed"
+恥じる,はじる,to feel ashamed,JLPT_1 JLPT,p`-?T7SXQx
+橋渡し,はしわたし,"bridge building', mediation",JLPT_1 JLPT,l%|j(`9GzE
+弾む,はずむ,"to bounce, to be encouraged, to splurge on",JLPT_1 JLPT,jr]t()sL{)
+破損,はそん,damage,JLPT_1 JLPT,AcKSLKW:yW
+叩く,はたく,"to strike, to clap, to dust, to beat",JLPT_1 JLPT,"dWYi~RDgh,"
+裸足,はだし,barefoot,JLPT_1 JLPT,"po~Uf#TR,"
+果たす,はたす,"to accomplish, to fulfill, to carry out, to achieve",JLPT_1 JLPT,"DK+O{$,$^%"
+蜂蜜,はちみつ,honey,JLPT_1 JLPT,t2`Wi>Wvpr
+パチンコ,パチンコ,pachinko (Japanese pinball),JLPT_1 JLPT,"N,S-[g<N~X"
+罰,ばつ,"punishment, penalty",JLPT_1 JLPT,pak.tgGX7x
+発育,はついく,"(physical) growth, development",JLPT_1 JLPT,r)!<G?/hIO
+発芽,はつが,germination,JLPT_1 JLPT,odw.?IsV+e
+発掘,はっくつ,"excavation, exhumation; discovery (e.g., new talent)",JLPT_1 JLPT,EM>uH;4cf/
+発言,はつげん,"utterance, speech, proposal",JLPT_1 JLPT,LH_cLO;>A#
+バッジ,バッジ,badge,JLPT_1 JLPT,yC^3FORnX|
+発生,はっせい,"outbreak, spring forth, occurrence",JLPT_1 JLPT,[~75YIE]^
+仕立てる,したてる,"to tailor, to make, to prepare",JLPT_1 JLPT,c;3A;W&iox
+下取り,したどり,"trade in, part exchange",JLPT_1 JLPT,x00~X}Z@;z
+下火,したび,"burning low, waning, declining",JLPT_1 JLPT,GXttEHji#P
+実,じつ,"fruit, good result",JLPT_1 JLPT,"O,>]AbA1/T"
+実家,じっか,(one's parents') home,JLPT_1 JLPT,m9e#UdET8v
+失格,しっかく,"disqualification, elimination, incapacity (legal)",JLPT_1 JLPT,h!}VE0Z-kV
+質疑,しつぎ,question,JLPT_1 JLPT,Mk?<?~7ejy
+失脚,しっきゃく,"losing one's standing, being overthrown, falling",JLPT_1 JLPT,dyF+u*87v/
+実業家,じつぎょうか,"industrialist, businessman",JLPT_1 JLPT,j8A-]Sd~|q
+シック,シック,chic,JLPT_1 JLPT,b].GYST!sM
+じっくり,じっくり,"deliberately, carefully",JLPT_1 JLPT,OuD=.N_4bL
+躾,しつけ,"discipline, training",JLPT_1 JLPT,p&pKDPj+ET
+躾ける,しつける,"to discipline, to teach manners",JLPT_1 JLPT,M=EeDC2V^e
+実践,じっせん,"practice, put into practice",JLPT_1 JLPT,lCEkku)Adc
+質素,しっそ,"simplicity, modesty, frugality",JLPT_1 JLPT,Lg&>>9*&@$
+実態,じったい,"truth, fact",JLPT_1 JLPT,r05!(zrd*p
+失調,しっちょう,"lack of harmony, imbalance",JLPT_1 JLPT,wL|Xhp<^m}
+嫉妬,しっと,jealousy,JLPT_1 JLPT,"II[T1j,nrR"
+実費,じっぴ,"actual expense, cost price",JLPT_1 JLPT,"Brcf8cxL,]"
+指摘,してき,"pointing out, identification",JLPT_1 JLPT,0XMUSx1~^
+自転,じてん,"rotation, spin",JLPT_1 JLPT,eZnBlzL^Oi
+助動詞,じょどうし,auxiliary verb,JLPT_1 JLPT,MGBzC/KjZ/
+淑やか,しとやか,graceful,JLPT_1 JLPT,cs-RRQGVDP
+萎びる,しなびる,"to shrivel, to fade",JLPT_1 JLPT,n39PUN5yKB
+シナリオ,シナリオ,scenario,JLPT_1 JLPT,mcEC.#phJ/
+しなやか,しなやか,"supple, flexible, elastic",JLPT_1 JLPT,"llcgEUgd,}"
+屎尿,しにょう,human waste,JLPT_1 JLPT,L{NJwSJvE1
+地主,じぬし,landlord,JLPT_1 JLPT,P7lP?kfIYU
+凌ぐ,しのぐ,"to outdo, to surpass; to endure",JLPT_1 JLPT,G74MSKaZvn
+芝,しば,lawn,JLPT_1 JLPT,M1OofFOiDR
+始発,しはつ,first train,JLPT_1 JLPT,b5g^3snh;^
+耳鼻科,じびか,otolaryngology,JLPT_1 JLPT,M#I&@5u]tl
+私物,しぶつ,"private property, personal effects",JLPT_1 JLPT,vg>TaiCbc?
+しぶとい,しぶとい,"tenacious, stubborn",JLPT_1 JLPT,mEFQwL`E!]
+司法,しほう,administration of justice,JLPT_1 JLPT,^h2%#WFiG
+始末,しまつ,disposal; cleaning up afterwards,JLPT_1 JLPT,xVDH)/d;?h
+染みる,しみる,to soak; pierce,JLPT_1 JLPT,uv-Quw{L2O
+使命,しめい,"mission, errand, message",JLPT_1 JLPT,G+Vq)M-:^P
+地元,じもと,local,JLPT_1 JLPT,v:38b>tQ|E
+視野,しや,"field of vision, outlook",JLPT_1 JLPT,MXdrD7jy4!
+弱,じゃく,"delicate, supple",JLPT_1 JLPT,nRYFcY_m8}
+社交,しゃこう,social life,JLPT_1 JLPT,vg:~]#q8^J
+ジャズ,ジャズ,jazz,JLPT_1 JLPT,A5m[%vwV8S
+謝絶,しゃぜつ,refusal,JLPT_1 JLPT,MBe{>RfT0i
+社宅,しゃたく,company owned house,JLPT_1 JLPT,DbP-W*D~|w
+若干,じゃっかん,"some, few, number of",JLPT_1 JLPT,Q(Uny@e~8I
+三味線,しゃみせん,three-stringed Japanese guitar,JLPT_1 JLPT,s_z^^gPG!F
+斜面,しゃめん,"slope, slanting surface, bevel",JLPT_1 JLPT,x+=N.j3d7a
+砂利,じゃり,"gravel, ballast, pebbles",JLPT_1 JLPT,ATQMr:.4bz
+洒落る,しゃれる,"to joke, to play on words; stylish",JLPT_1 JLPT,H%!QFip;AM
+ジャンパー,ジャンパー,"jacket, jumper",JLPT_1 JLPT,"n,_jvSzMfG"
+ジャンプ,ジャンプ,jump,JLPT_1 JLPT,pw$gcH64r%
+ジャンボ,ジャンボ,jumbo,JLPT_1 JLPT,uk]{9`9Xq{
+ジャンル,ジャンル,genre,JLPT_1 JLPT,c5niOf<?L8
+主,しゅ,"owner, master, god",JLPT_1 JLPT,tZY2oe0@.s
+種,しゅ,seed; variety,JLPT_1 JLPT,rY$n|JRb)Y
+私有,しゆう,private ownership,JLPT_1 JLPT,jZOSWJzMsO
+～宗,～しゅう,sect,JLPT_1 JLPT,cpa^uYdTpm
+収益,しゅうえき,"earnings, proceeds, returns",JLPT_1 JLPT,u?TiI-~;B#
+修学,しゅうがく,learning,JLPT_1 JLPT,bPtmF5tna#
+周期,しゅうき,"cycle, period",JLPT_1 JLPT,CsG?_1Ru~6
+衆議院,しゅうぎいん,"Lower House, House of Representatives",JLPT_1 JLPT,tTQG>y9]$G
+就業,しゅうぎょう,"employment, starting work",JLPT_1 JLPT,cF>5iCVH#I
+従業員,じゅうぎょういん,"employee, worker",JLPT_1 JLPT,e0Gyloi?1+
+集計,しゅうけい,"totalization, aggregate",JLPT_1 JLPT,s4<5~0hL>(
+襲撃,しゅうげき,"attack, charge, raid",JLPT_1 JLPT,ogO5j2R_;R
+収支,しゅうし,income and expenditure,JLPT_1 JLPT,kLuRkT404Z
+終始,しゅうし,from beginning to end; consistent(ly),JLPT_1 JLPT,b9XF3_Vc&-
+修士,しゅうし,Masters degree program,JLPT_1 JLPT,eySOZRKm#K
+従事,じゅうじ,"engaging, pursuing, following",JLPT_1 JLPT,kZT/egI[mV
+終日,しゅうじつ,all day,JLPT_1 JLPT,AR^6lmvOwg
+充実,じゅうじつ,"fullness, perfection",JLPT_1 JLPT,tGa!Bufhy/
+収集,しゅうしゅう,"gathering up, collection",JLPT_1 JLPT,"g+wGkM,J!."
+十字路,じゅうじろ,crossroads,JLPT_1 JLPT,M-P484f.3r
+執着,しゅうじゃく,"attachment, adhesion, tenacity",JLPT_1 JLPT,u`m`$IGAEz
+執着,しゅうちゃく,"attachment, adhesion, tenacity",JLPT_1 JLPT,k5L#!.1c@y
+柔軟,じゅうなん,flexible,JLPT_1 JLPT,o$JEWneOMf
+重複,じゅうふく,"duplication, repetition, overlapping",JLPT_1 JLPT,xsR4^tk;%3
+収容,しゅうよう,accommodation; seating; custody,JLPT_1 JLPT,e@q$+H3N_E
+従来,じゅうらい,"up to now, so far, traditional",JLPT_1 JLPT,m&r$7kIG&x
+守衛,しゅえい,"security guard, doorkeeper",JLPT_1 JLPT,e^0%h@~lt8
+主演,しゅえん,"starring, playing the leading part",JLPT_1 JLPT,n]D<c|Caow
+主観,しゅかん,"subjectivity, subject, ego",JLPT_1 JLPT,lW5DbL!{A5
+修行,しゅぎょう,"pursuit of knowledge, training, ascetic practice",JLPT_1 JLPT,KirESaOr*_
+塾,じゅく,after-school (cram) school,JLPT Intermediate_Japanese JLPT_1 Intermediate_Japanese_Ln.5 Genki_Ln.22 Genki,r6*vU;-fx(
+祝賀,しゅくが,"celebration, congratulations",JLPT_1 JLPT,wRzD+</l;5
+宿命,しゅくめい,"fate, destiny, predestination",JLPT_1 JLPT,BFNKk^{M1j
+手芸,しゅげい,handicrafts,JLPT_1 JLPT,QuReZ-t?cb
+主権,しゅけん,sovereignty,JLPT_1 JLPT,bc]8:XVC+v
+主催,しゅさい,"organization, sponsorship, to host",JLPT_1 JLPT,Az?/+|wSuL
+取材,しゅざい,"coverage, collecting data",JLPT_1 JLPT,ALv+C0}[Uy
+趣旨,しゅし,"object, meaning",JLPT_1 JLPT,r#aoMGQ7ru
+種々,しゅじゅ,variety,JLPT_1 JLPT,L$zP;w1Dds
+主食,しゅしょく,staple food,JLPT_1 JLPT,Ff{n(i0=[l
+主人公,しゅじんこう,protagonist,JLPT_1 JLPT,Ci-hQYEll
+主体,しゅたい,"subject, main constituent",JLPT_1 JLPT,"wk,7:5Ulq:"
+主題,しゅだい,"subject, theme, motif",JLPT_1 JLPT,t4<KTH8w{.
+出演,しゅつえん,"leading performer, stage appearance",JLPT_1 JLPT,B>+JLE{F%w
+出血,しゅっけつ,bleeding,JLPT_1 JLPT,jt7Tvjw[T<
+出現,しゅつげん,"appearance, arrival",JLPT_1 JLPT,et$R3oC-m[
+出産,しゅっさん,childbirth,JLPT_1 Intermediate_Japanese_Ln.14 JLPT Intermediate_Japanese,CT4;+h>Ai7
+出社,しゅっしゃ,come to work,JLPT_1 JLPT,Gd$MA{t_:M
+出生,しゅっしょう,birth,JLPT_1 JLPT,CwJVE%al3B
+出生,しゅっせい,birth,JLPT_1 JLPT,cV$*)i2b6%
+微量,びりょう,"minuscule amount, extremely small quantity",JLPT_1 JLPT,Ix21c!hl+{
+昼飯,ひるめし,lunch (mid-day meal),JLPT_1 JLPT,B4a{kV3{l&
+比例,ひれい,proportion,JLPT_1 JLPT,u^9gz.!&Uk
+疲労,ひろう,"fatigue, weariness",JLPT_1 JLPT,m.KXL51O8=
+敏感,びんかん,"sensibility, susceptibility, sensitive (to)",JLPT_1 JLPT,i]}jt3Q.(f
+貧困,ひんこん,"poverty, lack",JLPT_1 JLPT,xy9G9E{K5M
+品質,ひんしつ,quality,JLPT_1 JLPT,v)0nMB=(Mu
+貧弱,ひんじゃく,"poor, meager, insubstantial",JLPT_1 JLPT,"AT#enW$Yd,"
+品種,ひんしゅ,"breed, type, variety",JLPT_1 JLPT,K%9{]!|f1(
+ヒント,ヒント,hint,JLPT_1 JLPT,l]_+v%b&%R
+頻繁,ひんぱん,frequency,JLPT_1 JLPT,D{nW!<u7<*
+貧乏,びんぼう,"poverty, destitute, poor",JLPT_1 JLPT,KjBzaYHZW.
+ファイト,ファイト,fight,JLPT_1 JLPT,"C?{V+<,&x0"
+ファイル,ファイル,file; portfolio,JLPT_1 Genki_Ln.16 JLPT Genki,srC<dgokBJ
+ファン,ファン,fan,JLPT_1 JLPT,hsy0ORScG&
+不意,ふい,"sudden, abrupt, unexpected",JLPT_1 JLPT,xgYlO*O}d~
+フィルタ,フィルタ,filter,JLPT_1 JLPT,jmKbIb6QcW
+封,ふう,seal,JLPT_1 JLPT,iHGcq7T#S>
+封鎖,ふうさ,"blockade, freezing (funds)",JLPT_1 JLPT,Ae_x+Wt0^{
+風車,ふうしゃ,windmill,JLPT_1 JLPT,m${YvIujFj
+風習,ふうしゅう,custom,JLPT_1 JLPT,IfkXX^HH}1
+風俗,ふうぞく,"manners, customs; sex industry",JLPT_1 JLPT,e3n120S&QB
+ブーツ,ブーツ,boots,JLPT_1 JLPT,Nihzy$?;~s
+風土,ふうど,"natural features, climate",JLPT_1 JLPT,B(IXgyGNd~
+ブーム,ブーム,boom,JLPT_1 JLPT,FMQ@X9![T+
+フォーム,フォーム,foam; form,JLPT_1 JLPT,N.>_aoM)4S
+部下,ぶか,one's subordinate,JLPT Intermediate_Japanese JLPT_1 Intermediate_Japanese_Ln.9 Genki_Ln.22 Genki,At:l-rSeL9
+不可欠,ふかけつ,"indispensable, essential",JLPT_1 JLPT,$D>BzY&Eq
+ぶかぶか,ぶかぶか,"too big, baggy",JLPT_1 JLPT,M4TQ1zs9*D
+不吉,ふきつ,"ominous, sinister, bad luck, ill omen",JLPT_1 JLPT,GG4guCQ>St
+不況,ふきょう,"recession, depression, slump",JLPT_1 JLPT,NAxBuR@3>.
+布巾,ふきん,dish cloth,JLPT_1 JLPT,P<Zf%&wJ!m
+複合,ふくごう,"composite, complex",JLPT_1 JLPT,p=QT;iGf;n
+福祉,ふくし,"welfare, well-being",JLPT_1 JLPT,b03!@u1#5V
+覆面,ふくめん,"mask, veil, disguise",JLPT_1 JLPT,QXg#lB9xS_
+膨れる,ふくれる,"to swell (out), to be inflated, to bulge",JLPT_1 JLPT,"Ie:O+1U,1j"
+不景気,ふけいき,"business recession, hard times, depression",JLPT_1 JLPT,"iNdMUnu]F,"
+耽る,ふける,"to indulge in, to give oneself up to, to be absorbed in",JLPT_1 JLPT,v[B)O.T7PD
+老ける,ふける,to age,JLPT_1 JLPT,QZ$)s`u+7V
+富豪,ふごう,"wealthy person, millionaire",JLPT_1 JLPT,de)G:rS8ob
+布告,ふこく,"edict, ordinance, proclamation",JLPT_1 JLPT,m`EP77(8*G
+ブザー,ブザー,buzzer,JLPT_1 JLPT,C0kjm{<IuS
+負債,ふさい,"debt, liabilities",JLPT_1 JLPT,qG<ySRudYV
+不在,ふざい,absence,JLPT_1 JLPT,rCM+ktTr!?
+ふさわしい,ふさわしい,appropriate,JLPT_1 JLPT,j1c*Q9d`L}
+不順,ふじゅん,"irregularity, unseasonableness",JLPT_1 JLPT,kwTZda>KFz
+負傷,ふしょう,"injury, wound",JLPT_1 JLPT,o+oZbWGZ`o
+侮辱,ぶじょく,"insult, contempt, slight",JLPT_1 JLPT,g>J&PTIuaT
+不審,ふしん,"suspicious, doubt, infidelity",JLPT_1 JLPT,jmIlRt&BUg
+不振,ふしん,"dullness, slump, stagnation",JLPT_1 JLPT,G]_~>elSdu
+武装,ぶそう,"arms, armament, armed",JLPT_1 JLPT,JTlLA8kPQ$
+札,ふだ,"token, label; ticket, card; charm, talisman",JLPT_1 JLPT,P_/*Zy2*:b
+負担,ふたん,burden; load,JLPT_1 Intermediate_Japanese_Ln.14 JLPT Intermediate_Japanese,Gta/;X`Z+t
+不調,ふちょう,"bad condition, disorder, slump",JLPT_1 JLPT,j!ymTpYo|(
+復活,ふっかつ,"revival (e.g., musical), restoration",JLPT_1 JLPT,Hga}Pqjl1G
+物議,ぶつぎ,public discussion (criticism),JLPT_1 JLPT,E>jQlZ<@Gi
+復旧,ふっきゅう,"restoration, restitution, rehabilitation",JLPT_1 JLPT,v+skQS.kck
+復興,ふっこう,"revival, renaissance, reconstruction",JLPT_1 JLPT,DSf6z@!#o3
+物資,ぶっし,"goods, materials",JLPT_1 JLPT,wx*<XPsco8
+仏像,ぶつぞう,Buddhist image (statue),JLPT_1 JLPT,oCnal+d5Dm
+物体,ぶったい,object,JLPT_1 JLPT,vQK(_s<&_e
+沸騰,ふっとう,"boiling, seething",JLPT_1 JLPT,K!6nK8uJ5*
+不当,ふとう,"injustice, impropriety, unfair",JLPT_1 JLPT,"AB;-J~^I,j"
+不動産,ふどうさん,real estate,JLPT_1 JLPT,Mv%siEq0S4
+無難,ぶなん,"safety, security",JLPT_1 JLPT,L:*{h+[3Gh
+赴任,ふにん,(proceeding to) new appointment,JLPT_1 JLPT,oAb.`u!o*I
+腐敗,ふはい,"decay, depravity",JLPT_1 JLPT,M`8*mP*qtg
+不評,ふひょう,"bad reputation, disgrace, unpopularity",JLPT_1 JLPT,uWKg6kq8N?
+不服,ふふく,"dissatisfaction, discontent, disapproval",JLPT_1 JLPT,efQHJ:1O+%
+普遍,ふへん,"universality, ubiquity, omnipresence",JLPT_1 JLPT,DU4nCA/=D7
+踏まえる,ふまえる,"to be based on, to have origin in",JLPT_1 JLPT,FbvWJQ2aYz
+踏み込む,ふみこむ,"to step into (someone else's territory, to break into, to raid",JLPT_1 JLPT,KsQ]!/u$%%
+不明,ふめい,"unknown, ambiguous",JLPT_1 JLPT,c[|*N}]Ng.
+部門,ぶもん,"class, group, category, department, field, branch",JLPT_1 JLPT,fW<r$/Xexi
+扶養,ふよう,"support, maintenance",JLPT_1 JLPT,c&|r4tzL6g
+ふらふら,ふらふら,"unsteady on one's feet, totter, dizzy",JLPT_1 JLPT,cGi)S~zu?F
+ぶらぶら,ぶらぶら,"dangle heavily, sway to and fro, stroll idly",JLPT_1 JLPT,"cSlQ|q,LD<"
+振り返る,ふりかえる,"to turn head, to turn around, to look back",JLPT_1 JLPT,i6Y*X-6gv)
+振り出し,ふりだし,"outset, starting point, drawing or issuing (draft)",JLPT_1 JLPT,"A2?E7UEb&,"
+不良,ふりょう,"badness, delinquent, failure",JLPT_1 JLPT,APww5XImb>
+浮力,ふりょく,buoyancy,JLPT_1 JLPT,DkFrZlvY6D
+武力,ぶりょく,"armed might, military power, the sword, force",JLPT_1 JLPT,l$;!dayR0#
+ブル,ブル,bull,JLPT_1 JLPT,vCf7eeE})t
+震わせる,ふるわせる,"to be shaking, to be trembling",JLPT_1 JLPT,j:m!@?JEXR
+無礼,ぶれい,"impolite, rude",JLPT_1 JLPT,hx5Ck[5*mQ
+付録,ふろく,"appendix, supplement",JLPT_1 JLPT,z3>_<:;2Kw
+フロント,フロント,front,JLPT_1 JLPT,QB*(L<))Uf
+憤慨,ふんがい,"indignation, resentment",JLPT_1 JLPT,M|ckH|tS}_
+文化財,ぶんかざい,"cultural assets, cultural property",JLPT_1 JLPT,GKrt{zi]?g
+分業,ぶんぎょう,"division of labor, specialization, assembly-line production",JLPT_1 JLPT,BTtV3{+^[7
+文語,ぶんご,"written language, literary language",JLPT_1 JLPT,O2yEclYZ/f
+分散,ぶんさん,"dispersion, decentralization, variance (statistics)",JLPT_1 JLPT,w2^IG)[nB&
+分子,ぶんし,"numerator, molecule",JLPT_1 JLPT,rK-5&@bZ0^
+紛失,ふんしつ,losing something,JLPT_1 JLPT,j5|sBvq.}8
+噴出,ふんしゅつ,"spewing, gushing, spouting",JLPT_1 JLPT,D3z2#~XD*U
+文書,ぶんしょ,"document, writing",JLPT_1 JLPT,bo]+8nZw?m
+紛争,ふんそう,"dispute, trouble, strife",JLPT_1 JLPT,OV3#PrQH78
+ふんだん,ふんだん,"plentiful, abundant, lavish",JLPT_1 JLPT,MwIZm`m=c%
+分担,ぶんたん,"apportionment, sharing",JLPT_1 JLPT,gy+k.s^o1O
+奮闘,ふんとう,"hard struggle, strenuous effort",JLPT_1 JLPT,L`X>(7GS~^
+分配,ぶんぱい,"division, sharing",JLPT_1 JLPT,r[[VI2iWnz
+分母,ぶんぼ,denominator,JLPT_1 JLPT,BM+H~/z91A
+粉末,ふんまつ,fine powder,JLPT_1 JLPT,O?vF%vQ*a#
+分離,ぶんり,"separation, detachment, segregation",JLPT_1 JLPT,u?^XP3ZSZ)
+分裂,ぶんれつ,"split, division, break up",JLPT_1 JLPT,FG95S7^tJT
+ペア,ペア,"pair, pear",JLPT_1 JLPT,k=Nb=9qw5N
+兵器,へいき,"arms, weapons, ordinance",JLPT_1 JLPT,wAUL<0|lY_
+閉口,へいこう,shut mouth,JLPT_1 JLPT,g74gm$0hDG
+閉鎖,へいさ,"closing, closure, shutdown",JLPT_1 JLPT,m*Y:Rj#(nz
+兵士,へいし,soldier,JLPT_1 JLPT,B3%=Tm.br`
+平常,へいじょう,"normal, usual",JLPT_1 JLPT,i$h--6kH#|
+平方,へいほう,"square (e.g., meter, square)",JLPT_1 JLPT,pZOmk8w#A@
+並列,へいれつ,"arrangement, parallel, abreast",JLPT_1 JLPT,QDMVtj-X)]
+ベース,ベース,"base, bass",JLPT_1 JLPT,m~Et>&CToA
+辟易,へきえき,"wince, shrink back, succumbing to, being frightened",JLPT_1 JLPT,wo~f0ok]vp
+ぺこぺこ,ぺこぺこ,"fawn, be very hungry",JLPT_1 JLPT,F.Cz<ZL1y8
+ベスト,ベスト,best; vest,JLPT_1 JLPT,kVQ_O=hpyu
+ベストセラー,ベストセラー,best-seller,JLPT_1 JLPT,"k[DIJ,exg`"
+隔たる,へだたる,to be distant,JLPT_1 JLPT,b4BPS$[Q>/
+縁,へり,edge,JLPT_1 JLPT,g}BbfTHa#|
+へりくだる,へりくだる,to deprecate oneself and praise the listener,JLPT_1 JLPT,fb3Sk}Zmt.
+弁解,べんかい,"explanation, justification, excuse",JLPT_1 JLPT,Eu*5BbIK^d
+変革,へんかく,"change, reform(the) Reformation",JLPT_1 JLPT,JH(PT>%qS{
+返還,へんかん,"return, restoration",JLPT_1 JLPT,F`|5A?wBp8
+便宜,べんぎ,"convenience, accommodation",JLPT_1 JLPT,uw9O+5v>m#
+偏見,へんけん,"prejudice, narrow view",JLPT_1 JLPT,H5~Io~/)~0
+弁護,べんご,"defense, pleading, advocacy",JLPT_1 JLPT,rHoP07l#m/
+返済,へんさい,repayment,JLPT_1 JLPT,G.5i-maV%u
+弁償,べんしょう,"compensation, reparation, reimbursement",JLPT_1 JLPT,H^-g_F:FjG
+変遷,へんせん,"change, transition, vicissitudes",JLPT_1 JLPT,qt*X5m;y07
+返答,へんとう,reply,JLPT_1 JLPT,A+kZ]*6U1q
+変動,へんどう,"change, fluctuation",JLPT_1 JLPT,"giBey3?e,4"
+弁論,べんろん,"discussion, debate, argument",JLPT_1 JLPT,A=n2+Ps#LJ
+穂,ほ,"ear (of plant), head (of plant)",JLPT_1 JLPT,c0##(*ojkQ
+保育,ほいく,"nursing, nurturing, rearing",JLPT_1 JLPT,i3iCkIhG8y
+ボイコット,ボイコット,boycott,JLPT_1 JLPT,mR[e%~Ga7o
+ポイント,ポイント,point,JLPT_1 JLPT,J#f7z)[.2}
+法案,ほうあん,bill (law),JLPT_1 JLPT,G67]H`pE*(
+防衛,ぼうえい,"defense, protection, self-defense",JLPT_1 JLPT,D~[_4zhU{o
+防火,ぼうか,"fire prevention, fire fighting, fire proof",JLPT_1 JLPT,nk53s<H-ud
+崩壊,ほうかい,"collapse, decay (physics), crumbling",JLPT_1 JLPT,"jGI8,H>%=u"
+妨害,ぼうがい,"disturbance, obstruction, interference",JLPT_1 JLPT,k0?pSKRG!b
+法学,ほうがく,"law, jurisprudence",JLPT_1 JLPT,Mp|Wasr2Aa
+封建,ほうけん,feudalistic,JLPT_1 JLPT,I3}@<tlawU
+豊作,ほうさく,"abundant harvest, bumper crop",JLPT_1 JLPT,DcQa/!NBRf
+方策,ほうさく,"plan, policy",JLPT_1 JLPT,jAYb5%jhb
+奉仕,ほうし,"attendance, service",JLPT_1 JLPT,jl!5Ew9{A&
+方式,ほうしき,"form, method, system",JLPT_1 JLPT,JK5hiz`$ai
+放射,ほうしゃ,"radiation, emission",JLPT_1 JLPT,s&NZ<R!wMX
+放射能,ほうしゃのう,radioactivity,JLPT_1 JLPT,gGVwqx%~R]
+報酬,ほうしゅう,"remuneration, recompense, reward",JLPT_1 JLPT,f3~#Hf{b;R
+放出,ほうしゅつ,"release, emit",JLPT_1 JLPT,sh*BL^`)[I
+報じる,ほうじる,"to inform, to report",JLPT_1 JLPT,JFEJ]`)bZ8
+報ずる,ほうずる,"to inform, to report",JLPT_1 JLPT,"KRvk3^-|,F"
+紡績,ぼうせき,spinning,JLPT_1 JLPT,c(WbBZ;AX4
+呆然,ぼうぜん,"dumbfounded, overcome with surprise",JLPT_1 JLPT,"D,29%Cq6kO"
+放置,ほうち,"leave as is, leave alone, neglect",JLPT_1 JLPT,v(CYy#&;?A
+膨張,ぼうちょう,"expansion, swelling, increase",JLPT_1 JLPT,yrEhMT2lD[
+法廷,ほうてい,courtroom,JLPT_1 JLPT,DT=sfW*:r&
+報道,ほうどう,"coverage, report",JLPT_1 JLPT,c6C5#ID_tl
+冒頭,ぼうとう,"beginning, start, outset",JLPT_1 JLPT,j#7sz+T+0t
+暴動,ぼうどう,"insurrection, riot, uprising",JLPT_1 JLPT,z>Vj=5Gt8G
+褒美,ほうび,"reward, prize",JLPT_1 JLPT,p$ZOw#.2V@
+暴風,ぼうふう,"storm, windstorm, gale",JLPT_1 JLPT,G7m5?HCHEG
+葬る,ほうむる,"to bury, to entomb",JLPT_1 JLPT,o:m}t1oj2f
+放り込む,ほうりこむ,to throw into,JLPT_1 JLPT,eWW}rHT.ef
+放り出す,ほうりだす,"to throw out, to give up, to abandon",JLPT_1 JLPT,x@6@j{vH4g
+暴力,ぼうりょく,violence,JLPT_1 JLPT,"bBwqHP,dIr"
+飽和,ほうわ,saturation,JLPT_1 JLPT,e-F){8|6>q
+ホース,ホース,hose,JLPT_1 JLPT,mR5}X@MWM{
+ポーズ,ポーズ,pause,JLPT_1 JLPT,o2eqJ-PY$U
+ホール,ホール,hall; hole,JLPT_1 JLPT,g=V#H+1mJd
+保温,ほおん,"retaining warmth, keeping heat in, heat insulation",JLPT_1 JLPT,caxU`1c?H}
+捕獲,ほかく,"capture, seizure",JLPT_1 JLPT,b>64#LmJ&_
+保管,ほかん,"custody, safekeeping, storage",JLPT_1 JLPT,dQ*M>yKiW}
+補給,ほきゅう,"supply, supplying, replenishment",JLPT_1 JLPT,Dc(.H5{&b@
+補強,ほきょう,reinforcement,JLPT_1 JLPT,J3$|<dn.re
+募金,ぼきん,"fund-raising, collection of funds",JLPT_1 JLPT,h)Vl=R>l^q
+牧師,ぼくし,"pastor, minister, clergyman",JLPT_1 JLPT,pz`YHSooKr
+捕鯨,ほげい,whaling,JLPT_1 JLPT,x$O*osSX;x
+惚ける,ぼける,"to grow senile, to fade",JLPT_1 JLPT,q*FJd;okG=
+保険,ほけん,"insurance, guarantee",JLPT_1 JLPT,Bet5?24idk
+母校,ぼこう,alma mater,JLPT_1 JLPT,qX^1y@?`G[
+母国,ぼこく,one's home country (same as 自分の国 (じぶんのくに)),JLPT_1 JLPT Intermediate_Japanese_Ln.15 Intermediate_Japanese,bSW6]:G@H?
+誇る,ほこる,"to boast of, to be proud of",JLPT_1 JLPT,M-#?~#CKEe
+綻びる,ほころびる,"to come apart at the seams, to smile broadly",JLPT_1 JLPT,IzpFoG;o+q
+干し～,ほし～,dried ~,JLPT_1 JLPT,is?TC|:$uN
+ポジション,ポジション,position,JLPT_1 JLPT,PnsJ9Y`/xy
+干し物,ほしもの,dried washing (clothes,JLPT_1 JLPT,fiEpVY&=zT
+保守,ほしゅ,"conservative, maintaining",JLPT_1 JLPT,HeA:gQu%kE
+補充,ほじゅう,"supplementation, replenishment, replenishing",JLPT_1 JLPT,ovQ+M7ILU)
+補助,ほじょ,"assistance, support, auxiliary",JLPT_1 JLPT,m?5D3_JP+}
+舗装,ほそう,"pavement, road surface",JLPT_1 JLPT,glr.;x9$x0
+補足,ほそく,"supplement, complement",JLPT_1 JLPT,inE4~;vRlL
+墓地,ぼち,"cemetery, graveyard",JLPT_1 JLPT,nNMpx>zT&}
+発作,ほっさ,"fit, attack",JLPT_1 JLPT,J-l0g]=x_p
+没収,ぼっしゅう,forfeited,JLPT_1 JLPT,FTZs|u+c%T
+発足,ほっそく,"starting, inauguration",JLPT_1 JLPT,zOAVt?|e(1
+ポット,ポット,pot,JLPT_1 JLPT,eLxlfyvQa!
+ほっぺた,ほっぺた,cheek,JLPT_1 JLPT,Jt@~gSztWD
+ぼつぼつ,ぼつぼつ,"gradually, here and there, spots",JLPT_1 JLPT,jz~OVH6f~Q
+没落,ぼつらく,"ruin, fall, collapse",JLPT_1 JLPT,qo9QqJE?e^
+解ける,ほどける,"to come untied, to come apart",JLPT_1 JLPT,DA{v}3+Lp$
+施す,ほどこす,"to give, to conduct, to perform",JLPT_1 JLPT,gYMa.e[yq>
+ほとり,ほとり,vicinity of lake; river,JLPT_1 JLPT,h5B>a}=Y4~
+ぼやく,ぼやく,"to grumble, to complain",JLPT_1 JLPT,DOH?PxBsC~
+ぼやける,ぼやける,"to become dim, to become blurred",JLPT_1 JLPT,"rB,1PHpB=G"
+保養,ほよう,"health preservation, recuperation, recreation",JLPT_1 JLPT,Q#{ir6[3o?
+捕虜,ほりょ,prisoner of war,JLPT_1 JLPT,qxd6jwjQC6
+ボルト,ボルト,volt; bolt,JLPT_1 JLPT,FZLDQ~YD+C
+滅びる,ほろびる,"to be ruined, to perish, to be destroyed",JLPT_1 JLPT,"O_YU5EzmO,"
+滅ぼす,ほろぼす,"to destroy, to overthrow, to ruin",JLPT_1 JLPT,eOA1)SbQq#
+本格,ほんかく,"propriety, full-scale",JLPT_1 JLPT,DzD$oDSZg.
+本館,ほんかん,main building,JLPT_1 JLPT,rO)PGxv/$V
+本気,ほんき,"seriousness, truth, sanctity",JLPT_1 JLPT,m?pL_oxeK4
+本国,ほんごく,one's own country,JLPT_1 JLPT,HviGkp(Y>O
+本質,ほんしつ,"essence, true nature, reality",JLPT_1 JLPT,HQcPpLF4DH
+本体,ほんたい,"substance, body, trunk",JLPT_1 JLPT,"f]jl3TlH~,"
+本音,ほんね,"(one's) real intention, motive",JLPT_1 JLPT Intermediate_Japanese_Ln.15 Intermediate_Japanese,Li:D?QHH;~
+本能,ほんのう,instinct,JLPT_1 JLPT,LYsP`F`>Yc
+本場,ほんば,"home, best place, genuine",JLPT_1 JLPT,L1wT%E>`J`
+ポンプ,ポンプ,pump,JLPT_1 JLPT,iq>r8*xxvq
+本文,ほんぶん,"text (of document), body (of letter)",JLPT_1 JLPT,OPcHo]s_IF
+本名,ほんみょう,real name,JLPT_1 JLPT,tgSVI-BSzp
+マーク,マーク,mark,JLPT_1 JLPT,xSmh(Hx|6s
+マイ～,マイ～,"my ~, one's own ~",JLPT_1 JLPT,M3C.y[*%DG
+マイクロフォン,マイクロフォン,microphone,JLPT_1 JLPT,"O(^,e1PC5c"
+埋蔵,まいぞう,"buried property, treasure trove",JLPT_1 JLPT,x=IBNay?qY
+舞う,まう,"to dance, to flutter about, to revolve",JLPT_1 JLPT,E~)$*yPg`;
+真上,まうえ,"just above, right overhead",JLPT_1 JLPT,d)IsOG^B=)
+前売,まえうり,"advance sale, booking",JLPT_1 JLPT,bq0PjYAHh(
+前置き,まえおき,"preface, introduction",JLPT_1 JLPT,w66ywP/&&4
+任す,まかす,"to entrust, to leave to a person",JLPT_1 JLPT,p:ILhp([Gw
+負かす,まかす,to defeat,JLPT_1 JLPT,qi|Hx;t;6u
+賄う,まかなう,"to give board to, to provide meals, to pay",JLPT_1 JLPT,z7=~3@j0#5
+紛らわしい,まぎらわしい,"confusing, misleading, ambiguous",JLPT_1 JLPT,"h,2f1PppwU"
+紛れる,まぎれる,"to be diverted, to slip into",JLPT_1 JLPT,d#WX3KXSxZ
+真心,まごころ,"sincerity, devotion",JLPT_1 JLPT,D6e()w&]x>
+まごつく,まごつく,"to be confused, to be flustered",JLPT_1 JLPT,f/~oJkW$x!
+誠,まこと,"truth, faith, fidelity",JLPT_1 JLPT,t$vv<u=?i:
+誠に,まことに,"indeed, really (very polite), absolutely",JLPT_1 JLPT Genki_Ln.20 Genki,P/8R*Tv!+F
+まさしく,まさしく,"surely, no doubt, evidently",JLPT_1 JLPT,zuz5Xe$DuA
+勝る,まさる,"to excel, to surpass, to out-rival",JLPT_1 JLPT,t<|1#xSX&T
+～増し,～まし,~increase,JLPT_1 JLPT,z5+QCF_t-U
+交える,まじえる,"to mix, to converse with, to cross (swords)",JLPT_1 JLPT,B~3MEZXI+!
+真下,ました,"right under, directly below",JLPT_1 JLPT,Iz;A7a]fD~
+まして,まして,"still more, still less (with neg. verb), to say nothing of",JLPT_1 JLPT,PY/0T[blt;
+交わる,まじわる,"to cross, to intersect, to mingle with,",JLPT_1 JLPT,mS|?u$Z<><
+麻酔,ますい,anesthesia,JLPT_1 JLPT,"mw>M%F[]D,"
+またがる (うまを～),またがる (うまを～),to straddle,JLPT_1 JLPT,uN3HnTL61M
+待ち合わせ,まちあわせ,appointment,JLPT_1 JLPT,IyY!Ll1/sj
+待ち遠しい,まちどおしい,looking forward to,JLPT_1 JLPT,w+0{4=a9>3
+待ち望む,まちのぞむ,"to look anxiously for, to wait eagerly for",JLPT_1 JLPT,CwJO9mIIMV
+まちまち,まちまち,"various, different",JLPT_1 JLPT,Ddw`;bcVVc
+末期,まっき,"deathbed, hour of death",JLPT_1 JLPT,GQt+3/1&iv
+真っ二つ,まっぷたつ,in two equal parts,JLPT_1 JLPT,rhE|8rVnO$
+まと,まと,"mark, target",JLPT_1 JLPT,Q*)wm/p9we
+纏まり,まとまり,"conclusion, settlement, consistency",JLPT_1 JLPT,"z55#c:D.,?"
+纏め,まとめ,"settlement, conclusion",JLPT_1 JLPT,oa&iF{vs})
+免れる,まぬがれる,"to escape from, to be exempted",JLPT_1 JLPT,s%K15EwNfz
+招き,まねき,invitation,JLPT_1 JLPT,yU~T`=>LDi
+瞬き,まばたき,"wink, twinkling (of stars), flicker (of light)",JLPT_1 JLPT,P9XKDg!![C
+麻痺,まひ,"paralysis, palsy, numbness",JLPT_1 JLPT,"E,_FTp$2/<"
+～まみれ,～まみれ,"covered with (by, in) ~",JLPT_1 JLPT,"sqX,LlH3-A"
+眉,まゆ,eyebrow,JLPT_1 JLPT,s]w/H=It~C
+鞠,まり,ball,JLPT_1 JLPT,L0Js7PDQey
+丸ごと,まるごと,"in its entirety, whole, wholly",JLPT_1 JLPT,oAOL{@?a=y
+まるっきり,まるっきり,"completely, perfectly, just as if",JLPT_1 JLPT,roz]qfa`JS
+丸々,まるまる,completely,JLPT_1 JLPT,eV$3aB(/)x
+丸める,まるめる,"to make round, to round off, to roll up",JLPT_1 JLPT,Nd=%r[H=>c
+満月,まんげつ,full moon,JLPT_1 JLPT,dZR3ROGpT$
+満場,まんじょう,"unanimous, whole audience",JLPT_1 JLPT,ffiOG%*5K_
+真ん前,まんまえ,"right in front, under the nose",JLPT_1 JLPT,B[GBnZiI4Z
+真ん丸い,まんまるい,perfectly circular,JLPT_1 JLPT,F)+$.BY>]K
+真ん円い,まんまるい,perfectly round,JLPT_1 JLPT,l73GW43&1I
+～味,～み,~ cast (sense of taste),JLPT_1 JLPT,JZMc!Ve6^U
+見合い,みあい,formal marriage interview,JLPT_1 JLPT,dP:cnU(>Lf
+見合わせる,みあわせる,to exchange glances; to postpone,JLPT_1 JLPT,o0gE$9N?58
+見落とす,みおとす,"to overlook, to fail to notice",JLPT_1 JLPT,pxrQq~WN~>
+未開,みかい,"savage land, backward region, uncivilized",JLPT_1 JLPT,A5z6h|*?{|
+味覚,みかく,"taste, palate, sense of taste",JLPT_1 JLPT,lw?sswB?B?
+幹,みき,(tree) trunk,JLPT_1 JLPT,l4N|@LrpFp
+見苦しい,みぐるしい,"unsightly, ugly",JLPT_1 JLPT,"zoS)q7/,pA"
+見込み,みこみ,"prospects, expectation, hope",JLPT_1 JLPT,AJ2+ju9lav
+未婚,みこん,unmarried,JLPT_1 JLPT,y~*KiMDApr
+未熟,みじゅく,"inexperience, unskilled, immature",JLPT_1 JLPT,Mm``I-uL4c
+微塵,みじん,"particle, atom",JLPT_1 JLPT,xr|L`N8dB@
+水気,みずけ,"moisture, dampness",JLPT_1 JLPT,"AAG,tXSTs&"
+ミスプリント,ミスプリント,misprint,JLPT_1 JLPT,MN~t-y(9f/
+みすぼらしい,みすぼらしい,"shabby, seedy",JLPT_1 JLPT,zZ?|#(.Ue2
+ミセス,ミセス,Mrs.,JLPT_1 JLPT,FN(%bDaCYE
+見せびらかす,みせびらかす,"to show off, to flaunt",JLPT_1 JLPT,vp0up+%&~4
+見せ物,みせもの,"show, exhibition",JLPT_1 JLPT,Cc24XA|;u.
+溝,みぞ,"ditch, drain, gutter, gap",JLPT_1 JLPT,"k,R(3N{_j9"
+満たす,みたす,"to satisfy, to ingratiate, to fill, to fulfill",JLPT_1 JLPT,B44j~=|$C}
+乱す,みだす,"to throw out of order, to disarrange, to disturb",JLPT_1 JLPT,C%T3isV/48
+乱れる,みだれる,"to get confused, to be disordered, to be disturbed",JLPT_1 JLPT,KLJg{.X@t^
+未知,みち,not yet known,JLPT_1 JLPT,LJ513rxoTO
+身近,みぢか,"near oneself, close to one, familiar",JLPT_1 JLPT,bkRa/9L=lh
+導く,みちびく,"to be guided, to be shown",JLPT_1 JLPT,"A,UwJ4E[I_"
+密集,みっしゅう,"crowd, close formation, dense",JLPT_1 JLPT,iiclZ|l}Fq
+密接,みっせつ,"connected, close, intimate",JLPT_1 JLPT,o{R4~BmT^x
+密度,みつど,density,JLPT_1 JLPT,t`MF+}P~d:
+見積もり,みつもり,"estimation, quotation",JLPT_1 JLPT,KD?@iY>SQH
+未定,みてい,"not yet fixed, undecided, pending",JLPT_1 JLPT,Q}7[YRL|?=
+見通し,みとおし,"perspective, unobstructed view, prospect",JLPT_1 JLPT,hHCL?CdIG]
+見なす,みなす,"to consider as, to regard",JLPT_1 JLPT,E8w4wKW7Y]
+源,みなもと,"source, origin",JLPT_1 JLPT,zO=gu0Zqs*
+見習う,みならう,to follow another's example,JLPT_1 JLPT,p&yDgKca2!
+身なり,みなり,personal appearance,JLPT_1 JLPT,s|<m`9tUtv
+峰,みね,"peak, ridge",JLPT_1 JLPT,wx-mVJq6fi
+身の上,みのうえ,"one's future, one's welfare, one's personal history",JLPT_1 JLPT,j-p$+}.^ac
+見逃す,みのがす,"to miss, to overlook, to leave at large",JLPT_1 JLPT,IsG@e1nb*B
+身の回り,みのまわり,"one's personal appearance, personal belongings",JLPT_1 JLPT,"[(&,B0kXN"
+見計らう,みはからう,to choose at one's own discretion,JLPT_1 JLPT,"z8AN&Zq,!-"
+見晴らし,みはらし,view,JLPT_1 JLPT,h3a00LHX8h
+身振り,みぶり,gesture,JLPT_1 JLPT Intermediate_Japanese Intermediate_Japanese_Ln.11,Lm.Fj=%/7a
+脈,みゃく,pulse,JLPT_1 JLPT,C|`|>zxQM+
+ミュージック,ミュージック,music,JLPT_1 JLPT,t9mG6QGvsw
+未練,みれん,"lingering affection, attachment, regret(s)",JLPT_1 JLPT,B=cwZ~017_
+見渡す,みわたす,"to look out over, to survey (scene), to take an extensive view of",JLPT_1 JLPT,x&]mO6(]ee
+民宿,みんしゅく,private house providing lodging and meals to tourists,JLPT_1 JLPT Intermediate_Japanese_Ln.10 Intermediate_Japanese,yy/1y<3;Yk
+民族,みんぞく,"people, race",JLPT_1 JLPT,p>p/|sT6Jg
+民俗,みんぞく,folk customs,JLPT_1 JLPT,M(tc2N/}z{
+無意味,むいみ,"nonsense, no meaning",JLPT_1 JLPT,B9C6%m[4lF
+ムード,ムード,mood,JLPT_1 JLPT,JZzdb{.Zc^
+無口,むくち,reticence,JLPT_1 JLPT,z:Ts^0TQ4#
+婿,むこ,son-in-law,JLPT_1 JLPT,bX1GlIQN8L
+無効,むこう,"invalid, no effect, unavailable",JLPT_1 JLPT,EqE:ixA-k+
+無言,むごん,silence,JLPT_1 JLPT,fZ{o?TF{7B
+無邪気,むじゃき,"innocence, simple-mindedness",JLPT_1 JLPT,L)xB!4E<k?
+むしる,むしる,"to pluck, to pick, to tear",JLPT_1 JLPT,.d8S>K-=k
+結び,むすび,"ending, conclusion, union",JLPT_1 JLPT,d{_<>*~x%J
+結び付き,むすびつき,"connection, relation",JLPT_1 JLPT,"O3KGVopE,2"
+結び付く,むすびつく,"to be connected or related, to join together",JLPT_1 JLPT,EMFAQ1Kh)m
+結び付ける,むすびつける,"to combine, to join, to tie on, to attach with a knot",JLPT_1 JLPT,fRB2/x*X`A
+無線,むせん,"wireless, radio",JLPT_1 JLPT,y?)Jdm`O>c
+無駄遣い,むだづかい,"waste money on, squander money on",JLPT_1 JLPT Genki_Ln.22 Genki,"O?A,`d=isH"
+無断,むだん,"without permission, without notice",JLPT_1 JLPT,I$Ua7qpQZH
+無知,むち,ignorance,JLPT_1 JLPT,g+^m*mx.<r
+無茶,むちゃ,"absurd, unreasonable",JLPT_1 JLPT Intermediate_Japanese_Ln.12 Intermediate_Japanese,AEYrHxjg#f
+無茶苦茶,むちゃくちゃ,"confused, jumbled, mixed up, unreasonable",JLPT_1 JLPT,KCqc4.UxPr
+空しい,むなしい,"vacant, futile, vain",JLPT_1 JLPT,P|:1(IV_+~
+無念,むねん,"chagrin, regret",JLPT_1 JLPT,b;piP^Vw+j
+無能,むのう,"inefficiency, incompetence",JLPT_1 JLPT,izu(:0$`9@
+無闇に,むやみに,"unreasonably, absurdly, at random",JLPT_1 JLPT,N)&c#LP7Bq
+無用,むよう,"useless, needlessness, unnecessariness",JLPT_1 JLPT,"Oc`U#P0i,-"
+斑,むら,"unevenness, inconsistency, irregularity",JLPT_1 JLPT,ejP4z=)m?O
+群がる,むらがる,"to swarm, to gather",JLPT_1 JLPT,vyc%)s7Efv
+無論,むろん,"of course, naturally",JLPT_1 JLPT,I(9V_xrT80
+名産,めいさん,noted product,JLPT_1 JLPT,KN>?5r|..h
+名称,めいしょう,name,JLPT_1 JLPT,P!9gSFK*GV
+命中,めいちゅう,a hit,JLPT_1 JLPT,Qq0/BP{lJ:
+明白,めいはく,"obvious, clear",JLPT_1 JLPT,g|K4[<><hX
+名簿,めいぼ,register of names,JLPT_1 JLPT,xkhYhi]K-$
+名誉,めいよ,"honor, credit, prestige",JLPT_1 JLPT,PiLIi1%_ER
+明瞭,めいりょう,clarity,JLPT_1 JLPT,"s[dks,f=+A"
+明朗,めいろう,"bright, clear, cheerful",JLPT_1 JLPT,Kzdx<dR.%]
+メーカー,メーカー,manufacturer,JLPT_1 JLPT,r)Eust:VuL
+目方,めかた,weight,JLPT_1 JLPT,"unS}*nsB,_"
+恵み,めぐみ,blessing,JLPT_1 JLPT,gdikXkV`X<
+恵む,めぐむ,"to bless, to show mercy to",JLPT_1 JLPT,u_D+Zdxyy/
+目覚しい,めざましい,"brilliant, remarkable",JLPT_1 JLPT,"z8UKuy,l`d"
+目覚める,めざめる,to wake up,JLPT_1 JLPT,~I1tdEiJ_
+召す,めす,"to call, to send for, to put on",JLPT_1 JLPT,K%!n2|&<A0
+雌,めす,female (animal),JLPT_1 JLPT,EW)C>Dc!w6
+目付き,めつき,"look, expression of the eyes, eyes",JLPT_1 JLPT,MWZLbZ@^R+
+滅亡,めつぼう,"downfall, collapse, destruction",JLPT_1 JLPT,"v,{^w}Wj5u"
+メディア,メディア,media,JLPT_1 JLPT,A?+IR*&l/Z
+目途,めど,"goal, outlook",JLPT_1 JLPT,iewKY)jVg]
+目盛,めもり,"scale, gradations",JLPT_1 JLPT,"q0F+,vU3vc"
+メロディー,メロディー,melody,JLPT_1 JLPT,coHp=(F!o=
+面会,めんかい,interview,JLPT_1 JLPT,QB;1.39?j>
+免除,めんじょ,"exemption, exoneration, discharge",JLPT_1 JLPT,ro}g@BYFqK
+面する,めんする,"to face on, to look out on to",JLPT_1 JLPT,oK/f+%co{~
+面目,めんぼく,"face, honor, reputation",JLPT_1 JLPT,xl=a%LW1Mr
+面目,めんもく,"face, honor, reputation",JLPT_1 JLPT,p4D(kkU&Ya
+～網,～もう,~ network,JLPT_1 JLPT,"kks{,EwPh"
+設ける,もうける,"to create, to establish",JLPT_1 JLPT,MQGAfGCn2s
+申し入れる,もうしいれる,"to propose, to suggest",JLPT_1 JLPT,A!/~oWN34l
+申込,もうしこみ,"application, request, proposal",JLPT_1 JLPT,iTX<OH$n{u
+申出,もうしで,"request, claim, report",JLPT_1 JLPT,"v,YJy~@#5$"
+申し出る,もうしでる,"to report to, to tell, to suggest",JLPT_1 JLPT,o$K|y3;=)!
+申し分,もうしぶん,"objection, shortcomings",JLPT_1 JLPT,GNY9])J3>&
+盲点,もうてん,blind spot,JLPT_1 JLPT,m.:>Z[agNy
+猛烈,もうれつ,"violent, vehement, rage",JLPT_1 JLPT,yLUeQW5(ZA
+モーテル,モーテル,motel,JLPT_1 JLPT,mg2c}$GoZg
+もがく,もがく,"to struggle, to wriggle, to be impatient",JLPT_1 JLPT,C7rE2*5O^8
+目録,もくろく,"catalogue, catalog, list",JLPT_1 JLPT,uL+agcp`WN
+目論見,もくろみ,"a plan, a scheme, intention",JLPT_1 JLPT,c9iE`D<`%d
+模型,もけい,"model, dummy, marquette",JLPT_1 JLPT,ed!.{WEf4?
+模索,もさく,groping (for),JLPT_1 JLPT,"B4,c<+ikaa"
+もしかして,もしかして,"perhaps, possibly",JLPT_1 JLPT,w5+%$rMA:M
+もしくは,もしくは,"or, otherwise",JLPT_1 JLPT,f24/]y_t7c
+もたらす,もたらす,"to bring, to take, to bring about",JLPT_1 JLPT,k=cp%Lr}Pw
+持ち切り,もちきり,"hot topic, talk of the town",JLPT_1 JLPT,Q~!SFE+j1*
+目下,もっか,"at present, now",JLPT_1 JLPT,J1]`GmmTSp
+専ら,もっぱら,"wholly, solely, entirely",JLPT_1 JLPT,tu&L<v;Fqv
+もてなす,もてなす,"to entertain, to make welcome",JLPT_1 JLPT,K@A<3)}2cZ
+もてる,もてる,"to be well liked, to be popular",JLPT_1 JLPT,K^XraA[CV!
+モニター,モニター,(computer) monitor,JLPT_1 JLPT,ztCrx#(s0[
+物好き,ものずき,(idle) curiosity,JLPT_1 JLPT,Rb?3(vt:f>
+物足りない,ものたりない,"unsatisfied, unsatisfactory",JLPT_1 JLPT,KI9JcrBw_2
+もはや,もはや,"already, now",JLPT_1 JLPT,fZ`+BeK9z~
+模範,もはん,"model, example",JLPT_1 JLPT,Mau9*C?C72
+模倣,もほう,"imitation, copying",JLPT_1 JLPT,yUL<]q3$8n
+もめる,もめる,"to disagree, to dispute",JLPT_1 JLPT,v(j?vVE;el
+股,もも,"thigh, femur",JLPT_1 JLPT,G_TQ_^K>(0
+腿,もも,"thigh, femur",JLPT_1 JLPT,Fl0F`YIkpg
+催す,もよおす,"to hold (a meeting), to give (a dinner)",JLPT_1 JLPT,qKmEag$Qr@
+漏らす,もらす,"to let leak, to reveal",JLPT_1 JLPT,k!U%{2y7j|
+盛り上がる,もりあがる,"to rouse, to swell, to rise",JLPT_1 JLPT,g[M=aCpEE[
+漏る,もる,"to leak, to run out",JLPT_1 JLPT,ke69%r#AD.
+漏れる,もれる,"to leak out, to escape, to filter out",JLPT_1 JLPT,f:|ir!hLeQ
+脆い,もろい,"brittle, fragile, tender-hearted",JLPT_1 JLPT,m7?rDT~~db
+もろに,もろに,"completely, altogether, bodily",JLPT_1 JLPT,K3fu7*E_vY
+矢,や,arrow,JLPT_1 JLPT,uA$qbca=&2
+野外,やがい,"fields, outskirts, open air, suburbs",JLPT_1 JLPT,"gD=,$2gpm|"
+～薬,～やく,medicine,JLPT_1 JLPT,O.[e|Y6E?j
+夜具,やぐ,bedding,JLPT_1 JLPT,EFUa$D)qGB
+役職,やくしょく,"post, managerial position, official position",JLPT_1 JLPT,o1K=ON/OTS
+役場,やくば,town hall,JLPT_1 JLPT,g(k9.|^KSZ
+やけに,やけに,"sure, very",JLPT_1 JLPT,tyF=qET&O!
+屋敷,やしき,mansion,JLPT_1 JLPT,kyE@%cV[?g
+養う,やしなう,"to rear, to maintain, to cultivate",JLPT_1 JLPT,neyyq^bU/c
+野心,やしん,"ambition, aspiration",JLPT_1 JLPT,n<1rbhOoTc
+安っぽい,やすっぽい,"cheap-looking, tawdry",JLPT_1 JLPT,q./Z7LJ%[7
+休める,やすめる,"to rest, to suspend, to give relief",JLPT_1 JLPT,JqF3vGaVV
+野生,やせい,wild,JLPT_1 JLPT,Fy^pVCXg]$
+奴,やつ,"(vulg.) fellow, guy, chap",JLPT_1 JLPT,"zof3FA<N,u"
+闇,やみ,"darkness, shady, illegal",JLPT_1 JLPT,s|4s:5(PD;
+病む,やむ,"to fall ill, to be ill",JLPT_1 JLPT,H5M2j-I:6B
+ややこしい,ややこしい,"puzzling, tangled, complicated, complex",JLPT_1 JLPT,ICemn<#!-X
+やりとおす,やりとおす,"to carry through, to achieve, to complete",JLPT_1 JLPT,J/n?:UTJiF
+やりとげる,やりとげる,to accomplish,JLPT_1 JLPT,pEIG3P~OVf
+和らげる,やわらげる,"to soften, to moderate, to relieve",JLPT_1 JLPT,kl6br!q.AY
+ヤング,ヤング,young,JLPT_1 JLPT,"gk{d%L,)K+"
+～油,～ゆ,~ oil,JLPT_1 JLPT,QcD#WpcqE6
+優位,ゆうい,"predominance, ascendancy, superiority",JLPT_1 JLPT,kt30`|;>Vo
+憂鬱,ゆううつ,"depression, melancholy",JLPT_1 JLPT,oT|*}x?p{D
+有益,ゆうえき,"beneficial, profitable",JLPT_1 JLPT,B/K9zqnWV+
+優越,ゆうえつ,"supremacy, predominance, being superior to",JLPT_1 JLPT,J@3^J2[Dqz
+勇敢,ゆうかん,"bravery, heroism, gallantry",JLPT_1 JLPT,ij|^m_ZF8l
+夕暮れ,ゆうぐれ,"evening, (evening) twilight",JLPT_1 JLPT,xn0Tp1JH0v
+融資,ゆうし,"financing, loan",JLPT_1 JLPT,G&m_H=N/D;
+有する,ゆうする,"to own, to be endowed with",JLPT_1 JLPT,vkF;K$-{=^
+優勢,ゆうせい,"superiority, superior power, predominance",JLPT_1 JLPT,L0nx>W(-e+
+優先,ゆうせん,"preference, priority",JLPT_1 JLPT,l)|YgL5_SN
+誘導,ゆうどう,"guidance, leading, inducement",JLPT_1 JLPT,uG_U[CknG5
+融通,ゆうずう,"adaptability, versatility, finance",JLPT_1 JLPT,n>A>S2P-0$
+優美,ゆうび,"grace, refinement, elegance",JLPT_1 JLPT,}Ap|`a2gY
+有望,ゆうぼう,"good prospects, full of hope, promising",JLPT_1 JLPT,oFsPf~4K.z
+遊牧,ゆうぼく,nomadism,JLPT_1 JLPT,gJX#eMq!5y
+夕焼け,ゆうやけ,sunset,JLPT_1 JLPT,H_x[IPS7*X
+有力,ゆうりょく,"influence, prominence; potent",JLPT_1 JLPT,uhNbfXeT%o
+幽霊,ゆうれい,"ghost, specter, phantom",JLPT_1 JLPT,d6/M)isa9B
+誘惑,ゆうわく,"temptation, allurement, lure",JLPT_1 JLPT,hy!Cy1YJLH
+故,ゆえ,"reason, cause, circumstances",JLPT_1 JLPT,h8UChh;E+0
+歪む,ゆがむ,"to warp, to be crooked, to be distorted",JLPT_1 JLPT,O/sWb*b+n=
+揺さぶる,ゆさぶる,"to shake, to jolt, to rock, to swing",JLPT_1 JLPT,o>L:}zi#N(
+濯ぐ,ゆすぐ,"to rinse, to wash out",JLPT_1 JLPT,z.SPsly;Tq
+ゆとり,ゆとり,"reserve, affluence, time (to spare)",JLPT_1 JLPT,NS_6$;R>$L
+ユニーク,ユニーク,unique,JLPT_1 JLPT,E5Uv4)V5=f
+ユニフォーム,ユニフォーム,uniform,JLPT_1 JLPT,n$7/R&Ww((
+指差す,ゆびさす,to point at,JLPT_1 JLPT,AE`Cr+k?sb
+弓,ゆみ,bow,JLPT_1 JLPT,mG05Jx(c4U
+揺らぐ,ゆらぐ,"to swing, to sway, to shake",JLPT_1 JLPT,zGZf|<JX8y
+緩む,ゆるむ,"to become loose, to slacken",JLPT_1 JLPT,m#?_Dh<o@V
+緩める,ゆるめる,"to loosen, to slow down",JLPT_1 JLPT,RfPhr}DF_M
+緩やか,ゆるやか,lenient,JLPT_1 JLPT,"jM`-s,o~rY"
+要因,よういん,"primary factor, main cause",JLPT_1 JLPT,"PDhRFT[0+,"
+溶液,ようえき,solution,JLPT_1 JLPT,"r|,.l+IJQ{"
+用件,ようけん,business,JLPT_1 JLPT,C-)X0ioICv
+養護,ようご,"protection, nursing, protective care",JLPT_1 JLPT,N|{MY>0Lab
+用紙,ようし,a form,JLPT_1 JLPT Intermediate_Japanese Intermediate_Japanese_Ln.3,bG0P/-5o6f
+様式,ようしき,"style, form, pattern",JLPT_1 JLPT,xVY.ZL|vDW
+要する,ようする,"to demand, to require, to take",JLPT_1 JLPT,P^j;$V:Pev
+要請,ようせい,"claim, demand, request, application",JLPT_1 JLPT,"Dy@,)<4%*N"
+様相,ようそう,aspect,JLPT_1 JLPT,jpni?rjeGN
+用品,ようひん,"articles, supplies, parts",JLPT_1 JLPT,M7dV_3mZ.d
+洋風,ようふう,western style,JLPT_1 JLPT,tBk{]R??>Z
+用法,ようほう,"directions, rules of use",JLPT_1 JLPT,NFkcD+Ao.H
+要望,ようぼう,"demand for, request",JLPT_1 JLPT,B{KHwh(BxM
+余暇,よか,"leisure, leisure time, spare time",JLPT_1 JLPT,u`/)9|k2cq
+予感,よかん,"presentiment, premonition",JLPT_1 JLPT,CdRj.vDXXz
+余興,よきょう,"side show, entertainment",JLPT_1 JLPT,se@{9}ijE~
+預金,よきん,"deposit, bank account",JLPT_1 JLPT,AT=*3Iv8cw
+欲,よく,"greed, wants",JLPT_1 JLPT,wL1+)L#<Om
+抑圧,よくあつ,"restraint, oppression, suppression",JLPT_1 JLPT,b!*U/^@Y/m
+浴室,よくしつ,"bathroom, bath",JLPT_1 JLPT,H)~?~hPVN<
+抑制,よくせい,"control, restraint, suppression",JLPT_1 JLPT,H)Ghd^1QF6
+欲深い,よくふかい,greedy,JLPT_1 JLPT,e?a3SOn$}u
+欲望,よくぼう,"desire, appetite",JLPT_1 JLPT Intermediate_Japanese_Ln.13 Intermediate_Japanese,o.og0WiUHF
+避ける,よける,"to avoid (physical contact with; to ward off, to avert",JLPT_1 JLPT,w}V+UOhCI~
+予言,よげん,"prediction, promise, prognostication",JLPT_1 JLPT,H_Z4P-@?E;
+横綱,よこづな,sumo grand champion,JLPT_1 JLPT,P#D)i6dV;s
+汚れ,よごれ,"dirt, filth",JLPT_1 JLPT,"jq?[h<.nx,"
+よし (かん),よし (かん),all right!,JLPT_1 JLPT,u5UVAmt|+p
+良し,よし,all right!,JLPT_1 JLPT,ze3SZ]}-(^
+善し悪し,よしあし,"good or bad, merits or demerits, quality",JLPT_1 JLPT,ub0?2]DZCo
+余所見,よそみ,"looking away, looking aside",JLPT_1 JLPT,rQWf8.vXBd
+余地,よち,"place, room, margin",JLPT_1 JLPT,cFUuXOAAN@
+よって (よりどころ),よって (よりどころ),"therefore, consequently",JLPT_1 JLPT,Jty=:!ShWn
+与党,よとう,"government party, (ruling) party in power, government",JLPT_1 JLPT,Pjs4V/6-Tk
+呼び止める,よびとめる,to flag down,JLPT_1 Intermediate_Japanese_Ln.6 JLPT Intermediate_Japanese,oQ(`IiM1(t
+夜更し,よふかし,"staying up late, keeping late hours",JLPT_1 JLPT,b2@Q&QWM~Z
+夜更け,よふけ,late at night,JLPT_1 JLPT,EAa.IIVk2{
+余程,よほど,"very, much, to a large extent, quite",JLPT_1 JLPT,r:W.A5F_=m
+読み上げる,よみあげる,"to read out loud (and clearly), to call a roll",JLPT_1 JLPT,c2W8@Ns@MB
+～寄り,～より,"near to ~ (e.g., North by East)",JLPT_1 JLPT,AF4/UYB9T5
+寄り掛かる,よりかかる,"to lean against, to recline on, to lean on, to rely on",JLPT_1 JLPT,n>&m--dPQu
+世論,よろん,public opinion,JLPT_1 JLPT,gryKv+N</S
+弱る,よわる,"to weaken, to be troubled, to be emaciated",JLPT_1 JLPT,K>FuuD!+>/
+来場,らいじょう,attendance,JLPT_1 JLPT,o#f@&YbcYY
+ライス,ライス,rice,JLPT_1 JLPT,q#0OB)RX;*
+酪農,らくのう,dairy farming,JLPT_1 JLPT,ym$h5c;ttT
+落下,らっか,"fall, drop, come down",JLPT_1 JLPT,A7]wCr6wWL
+楽観,らっかん,optimism,JLPT_1 JLPT,k~>dbLQz-7
+ランプ,ランプ,lamp; ramp,JLPT_1 JLPT,C!7~*Q0J*S
+濫用,らんよう,"abuse, misuse, using to excess",JLPT_1 JLPT,CFNU<F}Co&
+リード,リード,lead; reed,JLPT_1 JLPT,f;Gy:Z95DB
+理屈,りくつ,"theory, reason",JLPT_1 JLPT,"Mh,Xn3W#yG"
+利子,りし,interest (bank),JLPT_1 JLPT,AEJ.8_NM:H
+利潤,りじゅん,"profit, returns",JLPT_1 JLPT,LuA(&F@>8^
+理性,りせい,"reason, sense",JLPT_1 JLPT,hFk%V[}poF
+利息,りそく,interest (bank),JLPT_1 JLPT,jiW}gvaFbu
+立体,りったい,solid body,JLPT_1 JLPT,c$*Ro:kj?0
+立方,りっぽう,cube,JLPT_1 JLPT,f~_S5!(=mz
+立法,りっぽう,"legislation, lawmaking",JLPT_1 JLPT,Ap&ba>BFUP
+利点,りてん,"advantage, point in favor",JLPT_1 JLPT,tXy6bul-X8
+略奪,りゃくだつ,"pillage, looting, robbery",JLPT_1 JLPT,gDxp+5=#Xg
+略語,りゃくご,"abbreviation, acronym",JLPT_1 JLPT,K>oKmQ]kga
+流通,りゅうつう,"circulation of money or goods, distribution",JLPT_1 JLPT,H5O$EOa.I6
+領域,りょういき,"area, territory, region",JLPT_1 JLPT,HiA.[31{b|
+了解,りょうかい,"comprehension, consent, understanding",JLPT_1 JLPT,kxhJ=)Od=Q
+領海,りょうかい,territorial waters,JLPT_1 JLPT,MB@]yC;xab
+両極,りょうきょく,"both extremities, north and south poles",JLPT_1 JLPT,I]j83bI=8Q
+良好,りょうこう,"favorable, satisfactory",JLPT_1 JLPT,d:q8$rI;Jz
+良識,りょうしき,good sense,JLPT_1 JLPT,g^(nW>D*vj
+良質,りょうしつ,"good quality, superior quality",JLPT_1 JLPT,nVu=s-lEz|
+了承,りょうしょう,"acknowledgment, understanding",JLPT_1 JLPT,j]m*irzgE:
+良心,りょうしん,conscience,JLPT_1 JLPT,I#~pygL#h!
+領地,りょうち,territory,JLPT_1 JLPT,y}6|eQ/0%E
+領土,りょうど,"territory, possession",JLPT_1 JLPT,xYhB+8`@i2
+両立,りょうりつ,"compatibility, coexistence, standing together",JLPT_1 JLPT,p7by!eTW@3
+旅客,りょかく,passenger,JLPT_1 JLPT,I8wSM=gOtR
+旅券,りょけん,passport,JLPT_1 JLPT,u/udi_w#M!
+履歴,りれき,"personal history, background, log",JLPT_1 JLPT,lgw@;Sby)x
+理論,りろん,theory,JLPT_1 JLPT,Kkq/Vwo|)`
+林業,りんぎょう,forestry,JLPT_1 JLPT,l$qH?E<2YH
+類,るい,"kind, class, family",JLPT_1 JLPT,o&+Ivn(%oO
+類推,るいすい,analogy,JLPT_1 JLPT,MG!~-T=}_S
+類似,るいじ,analogous,JLPT_1 JLPT,l=?07xJqV=
+ルーズ,ルーズ,loose,JLPT_1 JLPT,t;l^jLhRxc
+冷酷,れいこく,"cruelty, coldheartedness, ruthless",JLPT_1 JLPT,Gpei)G)?`V
+冷蔵,れいぞう,refrigeration,JLPT_1 JLPT,"IYaX-(,sbM"
+冷淡,れいたん,"coolness, indifference",JLPT_1 JLPT,Q5Ez[qRMa0
+レース,レース,race; lace,JLPT_1 JLPT,kxs-fAUJum
+レギュラー,レギュラー,regular,JLPT_1 JLPT,"f@``;g,,Yd"
+レッスン,レッスン,lesson,JLPT_1 JLPT,JfvUf_?9-:
+レディー,レディー,lady,JLPT_1 JLPT,p!9sykDKO0
+レバー,レバー,lever; liver,JLPT_1 JLPT,Ml*IZFZKKl
+恋愛,れんあい,"love, romance",JLPT_1 JLPT,"g0Js_zq8,k"
+バッテリー,バッテリー,battery,JLPT_1 JLPT,p?ZvzxPq%b
+バット,バット,"bat, vat",JLPT_1 JLPT,Q^}DTOnkl|
+発病,はつびょう,"attack, to become sick",JLPT_1 JLPT,BvVN^85[N;
+初耳,はつみみ,something heard for the first time,JLPT_1 JLPT,DQ%JLcfuZZ
+果て,はて,"the end, the extremity, the limit(s)",JLPT_1 JLPT,"b57,px8J*K"
+果てる,はてる,"to end, to be finished, to be exhausted",JLPT_1 JLPT,"bAff*:bf*,"
+ばてる,ばてる,"to be exhausted, to be worn out",JLPT_1 JLPT,r>0SmD(F4h
+パトカー,パトカー,patrol car,JLPT_1 JLPT,"EO|xx2G2G,"
+甚だ,はなはだ,"very, greatly, exceedingly",JLPT_1 JLPT,OQgv[Rp`!?
+華々しい,はなばなしい,"brilliant, magnificent, spectacular",JLPT_1 JLPT,v^@Rm/*uYq
+花びら,はなびら,(flower) petal,JLPT_1 JLPT,gVEobi&glz
+華やか,はなやか,"brilliant, gorgeous, florid",JLPT_1 JLPT,b*1sjY=VE6
+阻む,はばむ,"to keep someone from doing, to stop, to oppose",JLPT_1 JLPT,KW0lr0LPyk
+浜,はま,"beach, seashore",JLPT_1 JLPT,gaeewOTy8/
+浜辺,はまべ,"beach, foreshore",JLPT_1 JLPT,AL_W(0hn&V
+はまる,はまる,"to get into, to go into, to fit, to be fit for, to suit",JLPT_1 JLPT,key3o7$aM}
+早める,はやめる,"to hasten, to quicken, to accelerate",JLPT_1 JLPT,hS]svbo-ig
+腹立ち,はらだち,anger,JLPT_1 JLPT,p.*AhT>Yg8
+原っぱ,はらっぱ,"open field, empty lot, plain",JLPT_1 JLPT,BF1(%i;>nB
+はらはら,はらはら,feel nervous,JLPT_1 JLPT,m<Y%mFA4zS
+ばらまく,ばらまく,"to disseminate, to scatter",JLPT_1 JLPT,wmN`A*3CG)
+張り紙,はりがみ,"notice, poster",JLPT_1 JLPT,BB7%DI+bc=
+遥か,はるか,"far, far-away, distant",JLPT_1 JLPT,fUD7d;W?9R
+破裂,はれつ,"explosion, rupture, break off",JLPT_1 JLPT,"b^2,E+JYkn"
+腫れる,はれる,"to swell (from inflammation, to become swollen)",JLPT_1 JLPT,z8C-Q:96;k
+繁栄,はんえい,"prospering, prosperity, flourishing",JLPT_1 JLPT,nH@_ep+1}j
+版画,はんが,art print,JLPT_1 JLPT,sBPn!C6|$0
+ハンガー,ハンガー,(coat) hanger,JLPT_1 JLPT,HNMn){L;p@
+反感,はんかん,"antipathy, revolt, animosity",JLPT_1 JLPT,KAT#$^~N=[
+反響,はんきょう,"echo, reverberation, repercussion",JLPT_1 JLPT,(!Sbp/Ryc
+パンク,パンク,"puncture, bursting; punk",JLPT_1 JLPT,LzYO%D<&Ei
+反撃,はんげき,"counterattack, counteroffensive, counterblow",JLPT_1 JLPT,BBy/kmWv|!
+判決,はんけつ,"judicial decision, judgment, sentence, decree",JLPT_1 JLPT,K@f^#cZ5Q`
+反射,はんしゃ,"reflection, reverberation",JLPT_1 JLPT,LDqIUH^=vr
+繁盛,はんじょう,"prosperity, flourishing, thriving",JLPT_1 JLPT,oD{V&C=!wS
+繁殖,はんしょく,"breed, multiply, propagation",JLPT_1 JLPT,Gps#@ydvak
+反する,はんする,"to be inconsistent with, to oppose, to contradict",JLPT_1 JLPT,fVrr[FObH2
+判定,はんてい,"judgment, decision, award, verdict",JLPT_1 JLPT,l.y^yE`fLF
+万人,ばんにん,"all people, everybody, 10000 people",JLPT_1 JLPT,gTmA]f8[{J
+晩年,ばんねん,(one's) last years,JLPT_1 JLPT,DKi7Lij}b#
+反応,はんのう,"reaction, response",JLPT_1 JLPT,tmAeij8aDL
+万能,ばんのう,"all-purpose, almighty, omnipotent",JLPT_1 JLPT,z`.g9zaN?
+半端,はんぱ,"fragment, fraction, incompleteness",JLPT_1 JLPT,eK}21?Q<uQ
+反発,はんぱつ,"repelling, rebound, oppose",JLPT_1 JLPT,rHA_.Kqp5U
+反乱,はんらん,"rebellion, revolt, uprising",JLPT_1 JLPT,"JJB,BD9|0D"
+氾濫,はんらん,"overflowing, flood",JLPT_1 JLPT,"Im~yS%,7(E"
+美,び,beauty,JLPT_1 JLPT,Oi9jkr_JC
+ひいては,ひいては,"not only…but also, in addition to, consequently",JLPT_1 JLPT,jOz98=%a=I
+ビールス,ビールス,virus,JLPT_1 JLPT,k4c<|hYsN{
+控室,ひかえしつ,waiting room,JLPT_1 JLPT,y&_T~x>Y8R
+控える,ひかえる,to hold back; to make notes,JLPT_1 JLPT,v:A0($lqMw
+悲観,ひかん,"pessimism, disappointment",JLPT_1 JLPT,b5j5UZJ)]S
+引き上げる,ひきあげる,"to withdraw, to leave, to pull out",JLPT_1 JLPT,N^;oc:0[e;
+率いる,ひきいる,"to lead, to spearhead (a group), to command (troops)",JLPT_1 JLPT,puJ9X.qkPt
+引き起こす,ひきおこす,to cause,JLPT_1 JLPT,wH2wMsnzkj
+引下げる,ひきさげる,"to pull down, to lower, to reduce, to withdraw",JLPT_1 JLPT,M7FZ16-#)F
+引きずる,ひきずる,"to drag along, to pull, to prolong",JLPT_1 JLPT,qTp%jki[ap
+引取る,ひきとる,to take back; to adopt; to leave,JLPT_1 JLPT,bqG=Sz>mVR
+否決,ひけつ,"rejection, negation, voting down",JLPT_1 JLPT,H=WQ4MO0SN
+日頃,ひごろ,"normally, habitually",JLPT_1 JLPT,y9J%2)~r.v
+久しい,ひさしい,"long, long-continued, old (story)",JLPT_1 JLPT,x^qb6Ainn%
+悲惨,ひさん,"tragedy, disaster; misery, wretched, pitiful",JLPT_1 JLPT,dkkS+?oHtT
+ビジネス,ビジネス,business,JLPT JLPT_1 Genki_Ln.2 Genki_Ln.1 Genki,stJO[>w5pM
+比重,ひじゅう,specific gravity,JLPT_1 JLPT,l4}j=7jzb:
+美術,びじゅつ,"art, fine arts",JLPT_1 JLPT,",I91nlD38"
+秘書,ひしょ,(private) secretary,JLPT_1 JLPT,HbDP7]^^wK
+微笑,びしょう,smile,JLPT_1 JLPT,"y,db|5_YaV"
+歪む,ひずむ,"to warp, to be distorted",JLPT_1 JLPT,KT[PkhY&vP
+密か,ひそか,"secret, private, surreptitious",JLPT_1 JLPT,jJ5o@8/`~@
+浸す,ひたす,"to soak, to dip, to drench",JLPT_1 JLPT,g_KlG}!uS#
+ひたすら,ひたすら,"nothing but, earnestly, intently",JLPT_1 JLPT,r_F?uM8zZq
+左利き,ひだりきき,"left-handedness, sake drinker, left-hander",JLPT_1 JLPT,k-sYD9-/$o
+引っ掻く,ひっかく,to scratch,JLPT_1 JLPT,E.o[!3b:Nm
+必修,ひっしゅう,required (subject),JLPT_1 JLPT,v$oSFhOWfe
+びっしょり,びっしょり,"wet through, drenched",JLPT_1 JLPT,z/^[4xCt0B
+必然,ひつぜん,"inevitable, necessary",JLPT_1 JLPT,Q)ow/ypncR
+匹敵,ひってき,"comparing with, rival, equal",JLPT_1 JLPT,JEil[{vK3q
+一息,ひといき,"a breath, a pause, an effort",JLPT_1 JLPT,E^BIFQp}ze
+人影,ひとかげ,"man's shadow, soul",JLPT_1 JLPT,lEh{t=A?Px
+人柄,ひとがら,"personality, character",JLPT_1 JLPT,dM5AOlir)Y
+人気,ひとけ,sign of life,JLPT_1 JLPT,NG2)}0vQ0h
+一頃,ひところ,"once, some time ago",JLPT_1 JLPT,g6jcX?>0?e
+人質,ひとじち,hostage,JLPT_1 JLPT,zJcHfH}ajC
+一筋,ひとすじ,"a line, earnestly, blindly, straightforwardly",JLPT_1 JLPT,Iw`AaG(p-#
+人目,ひとめ,"glimpse, public gaze",JLPT_1 JLPT,I=B$#9HzY_
+日取り,ひどり,"fixed date, appointed day",JLPT_1 JLPT,"E,%=}b)+ea"
+雛,ひな,"young bird, chick, doll",JLPT_1 JLPT,x|ru;#K_h[
+雛祭,ひなまつり,Girls' (dolls') Festival,JLPT_1 JLPT,"ExRH,Fb)`{"
+日向,ひなた,"sunny place, in the sun",JLPT_1 JLPT,"JkB,TYa,o3"
+非難,ひなん,"blame, attack, criticism",JLPT_1 JLPT,Dk(|@/*v__
+避難,ひなん,"taking refuge, finding shelter",JLPT_1 JLPT,L:}JI$`!GO
+日の丸,ひのまる,the Japanese flag,JLPT_1 JLPT,t9<.]@%ayT
+火花,ひばな,spark,JLPT_1 JLPT,um|5.IJ}3z
+ひび (かべの～),ひび (かべの～),"crack, fissure, flaw",JLPT_1 JLPT,"y]|C%f,K4~"
+悲鳴,ひめい,"shriek, scream",JLPT_1 JLPT,"iBM$!,wWJ6"
+冷やかす,ひやかす,"to banter, to make fun of, to jeer at, to cool, to refrigerate",JLPT_1 JLPT,g|eu{@|Ra<
+日焼け,ひやけ,sunburn,JLPT_1 JLPT,B*x^zGN+6l
+標語,ひょうご,"motto, slogan, catchword",JLPT_1 JLPT,q2-le>_XWl
+描写,びょうしゃ,"depiction, description, portrayal",JLPT_1 JLPT,JFYofDRI3{
+ひょっと,ひょっと,"possibly, accidentally",JLPT_1 JLPT,H?O[$H2[.i
+びら,びら,"handout, leaflet",JLPT_1 JLPT,t%GemgZ-on
+平たい,ひらたい,"flat, even, level",JLPT_1 JLPT,Gv<+$jy(Xp
+びり,びり,"last on the list, at the bottom",JLPT_1 JLPT,"B~`,swB&=7"
+比率,ひりつ,"ratio, proportion, percentage",JLPT_1 JLPT,r*He=~rO@q

--- a/src/n2.csv
+++ b/src/n2.csv
@@ -1,1749 +1,1749 @@
-expression,reading,meaning,tags
-就任,しゅうにん,"inauguration, assumption of office",JLPT JLPT_2
-周辺,しゅうへん,"circumference, peripheral",JLPT JLPT_2
-重役,じゅうやく,"director, high executive",JLPT JLPT_2
-終了,しゅうりょう,"end, close, termination",JLPT_1 JLPT JLPT_2
-重量,じゅうりょう,heavyweight,JLPT JLPT_2
-重力,じゅうりょく,gravity,JLPT JLPT_2
-熟語,じゅくご,"idiom, kanji compound",JLPT JLPT_2
-祝日,しゅくじつ,national holiday,JLPT JLPT_2
-縮小,しゅくしょう,"reduction, curtailment",JLPT JLPT_2
-受験,じゅけん,taking an examination,JLPT JLPT_2
-主語,しゅご,(gram) subject,JLPT JLPT_2
-主人,しゅじん,(one's own) husband,JLPT JLPT_2 Intermediate_Japanese_Ln.9 Intermediate_Japanese
-出勤,しゅっきん,"going to work, at work",JLPT JLPT_2
-述語,じゅつご,predicate,JLPT JLPT_2
-出張,しゅっちょう,"official tour, business trip",JLPT Intermediate_Japanese Genki_Ln.19 JLPT_2 Intermediate_Japanese_Ln.10 Genki
-寿命,じゅみょう,life span,JLPT JLPT_2
-主役,しゅやく,leading part,JLPT JLPT_2
-受話器,じゅわき,(telephone) receiver,JLPT JLPT_2
-循環,じゅんかん,"circulation, rotation, cycle",JLPT JLPT_2
-巡査,じゅんさ,policeman,JLPT JLPT_2
-順々,じゅんじゅん,"in order, in turn",JLPT JLPT_2
-順序,じゅんじょ,"order, sequence, procedure",JLPT JLPT_2
-純情,じゅんじょう,pure heart,JLPT JLPT_2
-純粋,じゅんすい,"pure, genuine, unmixed",JLPT JLPT_2
-初～,しょ～,first ~,JLPT JLPT_2
-諸～,しょ～,various ~,JLPT JLPT_2
-～所,～しょ,place,JLPT JLPT_2
-～所,～じょ,place,JLPT JLPT_2
-女～,じょ～,things done by women,JLPT JLPT_2
-～女,～じょ,count for sisters,JLPT JLPT_2
-省～,しょう～,economizing ~,JLPT JLPT_2
-～省,～しょう,kind of ministry,JLPT JLPT_2
-～商,～しょう,"merchant, business",JLPT JLPT_2
-～勝,～しょう,count for victory,JLPT JLPT_2
-～条,～じょう,counter for article,JLPT_1 JLPT JLPT_2
-～場,～じょう,"kind of field, ground",JLPT JLPT_2
-～畳,～じょう,"count for tatami, mat",JLPT JLPT_2
-消化,しょうか,digestion,JLPT JLPT_2
-小学生,しょうがくせい,elementary school pupil,JLPT JLPT_2
-しょうがない,しょうがない,It is not worth ~,JLPT JLPT_2
-将棋,しょうぎ,Japanese chess,JLPT JLPT_2
-蒸気,じょうき,"steam, vapor",JLPT JLPT_2
-定規,じょうぎ,(measuring) ruler,JLPT JLPT_2
-上級,じょうきゅう,"advanced level, high grade, senior",JLPT JLPT_2
-商業,しょうぎょう,"commerce, trade, business",JLPT JLPT_2 Intermediate_Japanese_Ln.10 Intermediate_Japanese
-消極的,しょうきょくてき,passive,JLPT JLPT_2
-賞金,しょうきん,"prize, monetary award",JLPT JLPT_2
-上下,じょうげ,"high and low, up and down",JLPT JLPT_2
-障子,しょうじ,paper sliding door,JLPT JLPT_2
-商社,しょうしゃ,trading company,JLPT JLPT_2
-乗車,じょうしゃ,"taking a train, entraining",JLPT JLPT_2
-上旬,じょうじゅん,first 10 days of month,JLPT JLPT_2
-生ずる,しょうずる,"to cause, to arise, to be generated",JLPT JLPT_2
-小数,しょうすう,"fraction (part of), decimal",JLPT JLPT_2
-商店,しょうてん,"shop, business firm",JLPT JLPT_2
-焦点,しょうてん,"focus, point",JLPT JLPT_2
-消毒,しょうどく,disinfection,JLPT JLPT_2
-勝敗,しょうはい,"victory or defeat, issue (of battle)",JLPT JLPT_2
-蒸発,じょうはつ,evaporation; unexplained disappearance,JLPT JLPT_2
-上品,じょうひん,"refined, elegant, well-mannered",JLPT JLPT_2
-勝負,しょうぶ,"victory or defeat, game",JLPT JLPT_2
-小便,しょうべん,"(col) urine, piss",JLPT JLPT_2
-消防署,しょうぼうしょ,fire station,JLPT JLPT_2
-正味,しょうみ,net (weight),JLPT JLPT_2
-正面,しょうめん,front,JLPT JLPT_2
-消耗,しょうもう,"exhaustion, consumption",JLPT JLPT_2
-初級,しょきゅう,elementary level,JLPT JLPT_2
-助教授,じょきょうじゅ,assistant professor,JLPT JLPT_2
-～色,～しょく,kind of color,JLPT JLPT_2
-食塩,しょくえん,table salt,JLPT JLPT_2
-職人,しょくにん,"artisan, craftsman",JLPT JLPT_2
-職場,しょくば,workplace,JLPT JLPT_2
-初旬,しょじゅん,first 10 days of the month,JLPT JLPT_2
-書籍,しょせき,"book, publication",JLPT JLPT_2
-食器,しょっき,tableware,JLPT JLPT_2
-ショップ,ショップ,a shop,JLPT JLPT_2
-書店,しょてん,bookshop,JLPT JLPT_2
-書道,しょどう,calligraphy,JLPT JLPT_2
-初歩,しょほ,"elements, rudiments",JLPT JLPT_2
-白髪,しらが,"white or grey hair, trendy hair bleaching",JLPT JLPT_2
-シリーズ,シリーズ,series,JLPT JLPT_2
-私立,しりつ,private (establishment),JLPT_2 JLPT Intermediate_Japanese_Ln.7 Intermediate_Japanese
-資料,しりょう,"materials, data",JLPT JLPT_2
-汁,しる,"juice, soup",JLPT JLPT_2
-素人,しろうと,"layman, amateur, novice",JLPT JLPT_2 Intermediate_Japanese_Ln.12 Intermediate_Japanese
-しわ (かおの～),しわ (かおの～),"wrinkles, creases",JLPT JLPT_2
-芯,しん,"core, heart, wick",JLPT JLPT_2
-新幹線,しんかんせん,"Shinkansen, ""Bullet Train""",JLPT Intermediate_Japanese JLPT_2 Genki_Ln.9 Intermediate_Japanese_Ln.10 Genki
-真空,しんくう,vacuum,JLPT JLPT_2
-人事,じんじ,"human resources, personnel management",JLPT JLPT_2
-信ずる,しんずる,to believe,JLPT JLPT_2
-心身,しんしん,mind and body,JLPT JLPT_2
-申請,しんせい,"application, request, petition",JLPT JLPT_2
-人造,じんぞう,"man-made, synthetic, artificial",JLPT JLPT_2
-寝台,しんだい,bed,JLPT JLPT_2
-診断,しんだん,diagnosis,JLPT JLPT_2
-侵入,しんにゅう,"invasion, raid, trespass",JLPT JLPT_2
-人文科学,じんぶんかがく,"social sciences, humanities",JLPT JLPT_2
-人命,じんめい,(human) life,JLPT JLPT_2
-深夜,しんや,late at night,JLPT JLPT_2
-森林,しんりん,"forest, woods",JLPT JLPT_2
-親類,しんるい,relative(s) (same as 親戚 (しんせき)),JLPT Intermediate_Japanese JLPT_2 Intermediate_Japanese_Ln.8 Intermediate_Japanese_Ln.9
-針路,しんろ,"course, direction",JLPT JLPT_2
-神話,しんわ,"myth, legend",JLPT JLPT_2
-水産,すいさん,"marine products, fisheries",JLPT JLPT_2
-炊事,すいじ,cooking,JLPT JLPT_2
-水蒸気,すいじょうき,"water vapor, steam",JLPT JLPT_2
-水素,すいそ,hydrogen,JLPT JLPT_2
-垂直,すいちょく,"vertical, perpendicular",JLPT JLPT_2
-推定,すいてい,"presumption, assumption, estimation",JLPT JLPT_2
-水滴,すいてき,drop of water,JLPT JLPT_2
-水筒,すいとう,"canteen, flask, water bottle",JLPT JLPT_2
-随筆,ずいひつ,"essays, miscellaneous writings",JLPT JLPT_2
-水分,すいぶん,moisture,JLPT JLPT_2
-水平,すいへい,"level, horizontal",JLPT JLPT_2
-水平線,すいへいせん,horizon,JLPT JLPT_2
-水面,すいめん,water's surface,JLPT JLPT_2
-図々しい,ずうずうしい,"impudent, shameless",JLPT JLPT_2
-ずうっと,ずうっと,"all the time, all the way",JLPT JLPT_2
-末っ子,すえっこ,youngest child,JLPT JLPT_2
-スカーフ,スカーフ,scarf,JLPT JLPT_2
-図鑑,ずかん,picture book,JLPT JLPT_2
-隙,すき,"unguarded moment, chance",JLPT JLPT_2
-杉,すぎ,Japanese cedar,JLPT JLPT_2
-好き嫌い,すききらい,"likes and dislikes, taste",JLPT JLPT_2
-好き好き,すきずき,matter of taste,JLPT JLPT_2
-透き通る,すきとおる,to be(come) transparent,JLPT JLPT_2
-隙間,すきま,"crack, gap, opening",JLPT JLPT_2
-～過ぎる,～すぎる,too much ~,JLPT JLPT_2
-スクール,スクール,school,JLPT JLPT_2
-図形,ずけい,figure,JLPT JLPT_2
-鈴,すず,bell,JLPT JLPT_2
-涼む,すずむ,"to cool oneself, to cool off",JLPT JLPT_2
-スタート,スタート,start,JLPT JLPT_2
-スチュワーデス,スチュワーデス,stewardess,JLPT JLPT_2
-すっきり,すっきり,"shapely, clear, neat",JLPT JLPT_2
-ステージ,ステージ,stage; performance,JLPT JLPT_2
-ストッキング,ストッキング,stockings,JLPT JLPT_2
-ストップ,ストップ,stop,JLPT JLPT_2
-素直,すなお,"obedient, meek, docile",JLPT JLPT_2
-頭脳,ずのう,"head, brains, intellect",JLPT JLPT_2
-スピーカー,スピーカー,speaker,JLPT JLPT_2
-図表,ずひょう,"chart, diagram, graph",JLPT JLPT_2
-スマート,スマート,"smart, stylish, slim",JLPT JLPT_2
-住まい,すまい,"dwelling, house",JLPT JLPT_2
-すまない,すまない,sorry (phrase),JLPT JLPT_2
-～済,～ずみ,finished,JLPT JLPT_2
-相撲,すもう,sumo wrestling,JLPT_2 JLPT Intermediate_Japanese_Ln.7 Intermediate_Japanese
-スライド,スライド,slide,JLPT JLPT_2
-ずらす,ずらす,"to put off, to delay",JLPT JLPT_2
-ずらり,ずらり,"in a line, in a row",JLPT JLPT_2
-スリッパ,スリッパ,slippers,JLPT JLPT_2
-狡い,ずるい,"sly, cunning",JLPT JLPT_2
-寸法,すんぽう,"measurement, size, dimension",JLPT JLPT_2
-税関,ぜいかん,customs,JLPT JLPT_2
-製作,せいさく,"manufacture, production",JLPT JLPT_2
-制作,せいさく,"work (e.g., film, book)",JLPT JLPT_2
-清書,せいしょ,clean copy,JLPT JLPT_2
-青少年,せいしょうねん,"youth, young person",JLPT JLPT_2
-整数,せいすう,integer,JLPT JLPT_2
-清掃,せいそう,cleaning,JLPT JLPT_2
-生存,せいぞん,"existence, being, survival",JLPT JLPT_2
-政党,せいとう,(member of) political party,JLPT JLPT_2
-性能,せいのう,"ability, capability",JLPT JLPT_2
-整備,せいび,"maintenance, overhaul",JLPT JLPT_2
-成分,せいぶん,"ingredient, component, composition",JLPT JLPT_2
-性別,せいべつ,"sex, gender",JLPT JLPT_2
-正方形,せいほうけい,square,JLPT JLPT_2
-正門,せいもん,"main gate, main entrance",JLPT JLPT_2
-成立,せいりつ,"formation, establishment, completion",JLPT JLPT_2
-西暦,せいれき,"Christian Era, after (Christ’s) death (A.D.)",JLPT JLPT_2
-背負う,せおう,to be burdened with; to carry on (one's) back or shoulder(s),Intermediate_Japanese_Ln.14 JLPT_2 JLPT Intermediate_Japanese
-～席,～せき,counter for seats,JLPT JLPT_2
-赤道,せきどう,equator,JLPT JLPT_2
-折角,せっかく,"with trouble, at great pains, long-awaited",JLPT JLPT_2
-接近,せっきん,"getting closer, drawing nearer, approaching",JLPT JLPT_2
-接する,せっする,to attend to (someone); to associate with,JLPT_2 JLPT Intermediate_Japanese_Ln.15 Intermediate_Japanese
-せっせと,せっせと,"busily, away",JLPT JLPT_2
-接続,せつぞく,"connection, union, join, link; changing trains",JLPT JLPT_2
-瀬戸物,せともの,"earthenware, crockery, china",JLPT JLPT_2
-ぜひとも,ぜひとも,by all means (with sense of not taking 'no' for an answer),JLPT JLPT_2
-迫る,せまる,"to draw near, to press",JLPT JLPT_2
-ゼミ,ゼミ,seminar,Intermediate_Japanese_Ln.5 JLPT JLPT_2 Intermediate_Japanese
-せめて,せめて,at least,JLPT JLPT_2
-セメント,セメント,cement,JLPT JLPT_2
-台詞,せりふ,"speech, words, one's lines, remarks",JLPT JLPT_2
-栓,せん,"stopper, cork, stopcock",JLPT JLPT_2
-～船,～せん,counter for ships,JLPT JLPT_2
-～戦,～せん,"counter for games, matches",JLPT JLPT_2
-前～,ぜん～,"former, late ~, past ~",JLPT JLPT_2
-～前,～ぜん,before ~,JLPT JLPT_2
-前後,ぜんご,"front and back, before and after",JLPT JLPT_2
-全集,ぜんしゅう,complete works,JLPT JLPT_2
-扇子,せんす,folding fan,JLPT JLPT_2 Genki_Ln.20 Genki
-専制,せんせい,"despotism, autocracy",JLPT JLPT_2
-先々月,せんせんげつ,month before last,JLPT JLPT_2
-先々週,せんせんしゅう,2 weeks before,JLPT JLPT_2
-先祖,せんぞ,ancestor,JLPT JLPT_2
-先端,せんたん,"pointed end, tip",JLPT JLPT_2
-センチ,センチ,centimeter,JLPT JLPT_2
-先頭,せんとう,"head, lead, vanguard",JLPT JLPT_2
-全般,ぜんぱん,"(the) whole, general",JLPT JLPT_2
-扇風機,せんぷうき,electric fan,JLPT JLPT_2
-洗面,せんめん,"wash up (one's face), have a wash",JLPT JLPT_2
-全力,ぜんりょく,"all one's power, whole energy",JLPT JLPT_2
-線路,せんろ,"line, track, roadbed",JLPT JLPT_2
-～沿い,～そい,along,JLPT JLPT_2
-総～,そう～,"gross, general, entire",JLPT JLPT_2
-～艘,～そう,counter for ships,JLPT JLPT_2
-相違,そうい,"difference, discrepancy, variation",JLPT JLPT_2 Intermediate_Japanese Intermediate_Japanese_Ln.11
-そういえば,そういえば,which reminds me ..,JLPT JLPT_2
-雑巾,ぞうきん,"house-cloth, dust cloth",JLPT JLPT_2
-増減,ぞうげん,"increase and decrease, fluctuation",JLPT JLPT_2
-倉庫,そうこ,"storehouse, warehouse",JLPT JLPT_2
-相互,そうご,"mutual, reciprocal",JLPT JLPT_2
-創作,そうさく,"production, creation, work",JLPT JLPT_2
-葬式,そうしき,funeral,JLPT JLPT_2
-造船,ぞうせん,shipbuilding,JLPT JLPT_2
-騒々しい,そうぞうしい,"noisy, boisterous",JLPT JLPT_2
-増大,ぞうだい,"increase, growth",JLPT JLPT_2
-そうっと,そうっと,"softly, cautiously, gently",JLPT JLPT_2
-送別,そうべつ,"farewell, send-off",JLPT JLPT_2
-草履,ぞうり,Japanese sandals (footwear),JLPT JLPT_2
-総理大臣,そうりだいじん,Prime Minister,JLPT JLPT_2
-送料,そうりょう,"postage, carriage",JLPT JLPT_2
-～足,～そく,counter for shoes,JLPT JLPT_2
-属する,ぞくする,"to belong to, to come under",JLPT JLPT_2
-続々,ぞくぞく,"successively, one after another",JLPT JLPT_2
-速達,そくたつ,"express, special delivery",JLPT JLPT_2
-測定,そくてい,measurement,JLPT JLPT_2
-測量,そくりょう,"measurement, surveying",JLPT JLPT_2
-速力,そくりょく,speed,JLPT JLPT_2
-素質,そしつ,"talent, capability",JLPT JLPT_2
-祖先,そせん,ancestor(s),JLPT JLPT_2 Intermediate_Japanese_Ln.8 Intermediate_Japanese
-そそっかしい,そそっかしい,"careless, thoughtless",JLPT JLPT_2
-卒直,そっちょく,"frank, candid, honest",JLPT JLPT_2
-そのころ,そのころ,"in those days, at that time, then",JLPT JLPT_2
-そのため,そのため,"hence, for that reason",JLPT JLPT_2
-その他,そのほか,besides,JLPT JLPT_2
-剃る,そる,to shave,JLPT JLPT_2
-それなのに,それなのに,"though, although",JLPT JLPT_2
-それなら,それなら,"If that's the case..., If so..., That being the case...",JLPT JLPT_2
-それはいけませんね (かん),それはいけませんね (かん),that's not good,JLPT JLPT_2
-逸れる,それる,"to stray (turn) from subject, to go astray",JLPT JLPT_2
-算盤,そろばん,abacus,JLPT JLPT_2
-存じる,ぞんじる,(humble) to know,JLPT JLPT_2
-存ずる,ぞんずる,(humble) to know,JLPT JLPT_2
-損得,そんとく,"loss and gain, advantage and disadvantage",JLPT JLPT_2
-田ぼ,たんぼ,"paddy field, farm",JLPT JLPT_2
-第～,だい～,~th,JLPT JLPT_2
-だいいち (とりわけ),だいいち (とりわけ),"first, foremost,&nbsp;&nbsp;#1",JLPT JLPT_2
-大学院,だいがくいん,graduate school,Genki_Ln.16 JLPT Intermediate_Japanese JLPT_2 Intermediate_Japanese_Ln.1 Genki
-大工,だいく,carpenter,JLPT JLPT_2
-体系,たいけい,"system, organization",JLPT JLPT_2
-太鼓,たいこ,"drum, tambourine",JLPT JLPT_2
-対策,たいさく,"counter-plan, counter-measure",JLPT JLPT_2
-大して,たいして,"(not so) much, (not) very",JLPT JLPT_2
-大小,だいしょう,size,JLPT JLPT_2
-体制,たいせい,"order, system, structure",JLPT JLPT_2
-体積,たいせき,"capacity, volume",JLPT JLPT_2
-大層,たいそう,"very much, greatly",JLPT JLPT_2
-体操,たいそう,"gymnastics, physical exercises, calisthenics",JLPT JLPT_2
-大分,だいぶん,"considerably, greatly, a lot",JLPT JLPT_2
-大木,たいぼく,large tree,JLPT JLPT_2
-代名詞,だいめいし,pronoun,JLPT JLPT_2
-タイア,タイア,"tire, tyre",JLPT JLPT_2
-ダイヤグラム,ダイヤグラム,diagram,JLPT JLPT_2
-ダイヤモンド,ダイヤモンド,diamond,JLPT JLPT_2
-ダイヤル,ダイヤル,dial,JLPT JLPT_2
-対立,たいりつ,"confrontation, opposition, antagonism",JLPT JLPT_2
-田植え,たうえ,rice planting,JLPT JLPT_2
-絶えず,たえず,constantly,JLPT JLPT_2 Intermediate_Japanese_Ln.10 Intermediate_Japanese
-楕円,だえん,ellipse,JLPT JLPT_2
-耕す,たがやす,"to till, to plow, to cultivate",JLPT JLPT_2
-滝,たき,waterfall,JLPT JLPT_2
-蓄える,たくわえる,"to save, to store, to lay in stock",JLPT JLPT_2
-竹,たけ,bamboo,JLPT JLPT_2
-ただいま,ただいま,"Here I am, I'm home!",JLPT JLPT_2
-但し,ただし,"but, however, provided that",JLPT JLPT_2
-立ち止まる,たちどまる,"to stop, to halt, to stand still",JLPT JLPT_2
-たちまち,たちまち,"instantly, suddenly, all at once",JLPT_2 JLPT Intermediate_Japanese_Ln.7 Intermediate_Japanese
-発,はつ,"to depart (e.g., on a plane, train)",JLPT JLPT_2
-脱線,だっせん,"derailment, digression",JLPT JLPT_2
-妥当,だとう,"proper, appropriate",JLPT JLPT_2
-例える,たとえる,"to compare, to liken",JLPT JLPT_2
-頼もしい,たのもしい,"reliable, promising",JLPT JLPT_2
-ダブル,ダブル,double,JLPT_1 JLPT JLPT_2
-ダム,ダム,dam,JLPT JLPT_2
-溜息,ためいき,a sigh,JLPT JLPT_2
-ためらう,ためらう,to be hesitant,JLPT JLPT_2 Intermediate_Japanese_Ln.12 Intermediate_Japanese
-～だらけ,～だらけ,"be full of ~, be filled with ~",JLPT JLPT_2
-だらしない,だらしない,"slovenly, loose, a slut",JLPT JLPT_2
-足る,たる,"to be sufficient, to be enough",JLPT JLPT_2
-短～,たん～,short ~,JLPT JLPT_2
-～団,～だん,"group, corps, party",JLPT JLPT_2
-オーケストラ,オーケストラ,orchestra,JLPT JLPT_2
-おおざっぱ,おおざっぱ,"rough (not precise), broad, sketchy",JLPT JLPT_2
-大通り,おおどおり,main street,JLPT JLPT_2
-オートメーション,オートメーション,automation,JLPT JLPT_2
-大凡,おおよそ,"about, approximately",JLPT JLPT_2
-お帰り,おかえり,"return, welcome",JLPT JLPT_2
-おかけください,おかけください,please sit down,JLPT JLPT_2
-おかげさまで,おかげさまで,"Thanks to god, thanks to you",JLPT JLPT_2
-おかず,おかず,"side dish, accompaniment for rice dishes",JLPT JLPT_2
-おかまいなく,おかまいなく,please don't fuss over me,JLPT JLPT_2
-拝む,おがむ,"to worship, to pray",JLPT JLPT_2
-お代わり,おかわり,"second helping, another cup",JLPT JLPT_2
-補う,おぎなう,to compensate for,JLPT JLPT_2
-お気の毒に,おきのどくに,I'm sorry to hear that…,JLPT JLPT_2
-屋外,おくがい,outdoors,JLPT JLPT_2
-送り仮名,おくりがな,part of word written in kana,JLPT JLPT_2
-お元気で,おげんきで,Take care',JLPT JLPT_2
-怠る,おこたる,"to neglect, to fail",JLPT JLPT_2
-お先に,おさきに,"before, after you",JLPT JLPT_2
-伯父,おじ,(humble) uncle (older than one's parent),JLPT JLPT_2
-叔父,おじ,uncle (younger than one's parent),JLPT JLPT_2
-惜しい,おしい,"regrettable, disappointing",JLPT JLPT_2
-伯父さん,おじさん,"(hon.) middle-aged gentleman, uncle",JLPT JLPT_2
-小父さん,おじさん,"(hon.) middle-aged gentleman, uncle",JLPT JLPT_2
-叔父さん,おじさん,"(hon.) middle-aged gentleman, uncle",JLPT JLPT_2
-お邪魔します,おじゃまします,Excuse me for disturbing you,JLPT JLPT_2
-お世話になりました,おせわになりました,I've been in your care,JLPT JLPT_2
-お大事に,おだいじに,"Take care of yourself, Take care!, Get well soon",JLPT Genki_Ln.12 Intermediate_Japanese JLPT_2 Intermediate_Japanese_Ln.12 Genki
-落着く,おちつく,"to calm down, to settle down",JLPT JLPT_2
-お出掛け,おでかけ,outing,JLPT JLPT_2
-お手伝いさん,おてつだいさん,maid,JLPT JLPT_2
-脅かす,おどかす,"to threaten, to coerce",JLPT JLPT_2
-落し物,おとしもの,lost property,JLPT JLPT_2
-驚かす,おどろかす,"to surprise, to frighten",JLPT JLPT_2
-お願いします,おねがいします,"Please (lit., I request)",JLPT JLPT_2 Intermediate_Japanese_Ln.1 Intermediate_Japanese
-各々,おのおの,"each, every, either",JLPT JLPT_2
-伯母,おば,(humble) aunt (older than one's parent),JLPT JLPT_2
-叔母,おば,aunt (younger than one's parent),JLPT JLPT_2
-小母さん,おばさん,"lady, woman, ma'am",JLPT JLPT_2
-おはよう,おはよう,(abbr.) Good morning,JLPT JLPT_2
-お参り,おまいり,"worship, shrine visit",JLPT JLPT_2
-お待たせしました,おまたせしました,Sorry to have kept you waiting,JLPT JLPT_2
-お待ちください,おまちください,Please wait a moment,JLPT JLPT_2
-おまちどおさま,おまちどおさま,Sorry to have kept you waiting,JLPT JLPT_2
-おめでたい,おめでたい,"happy event, matter for congratulation",JLPT JLPT_2
-思い掛けない,おもいがけない,"unexpected, casual",JLPT JLPT_2
-思い切り,おもいきり,"with all one's strength (heart), resignation, resolution",JLPT JLPT_2
-思い込む,おもいこむ,"to be under impression that, to be convinced that",JLPT JLPT_2
-思いっ切り,おもいっきり,"very, much, fully",JLPT JLPT_2
-重たい,おもたい,"heavy, massive, serious",JLPT JLPT_2
-お休み,おやすみ,"holiday, absence; (exp.) Good night",JLPT JLPT_2
-おやつ,おやつ,"between meal snack, afternoon refreshment",JLPT JLPT_2
-親指,おやゆび,thumb,JLPT JLPT_2
-オルガン,オルガン,organ,JLPT JLPT_2
-恩恵,おんけい,"blessing, benefit",JLPT JLPT_2
-温室,おんしつ,greenhouse,JLPT JLPT_2
-温泉,おんせん,"spa, hot spring",JLPT Intermediate_Japanese JLPT_2 Genki_Ln.9 Intermediate_Japanese_Ln.10 Genki
-温帯,おんたい,temperate zone,JLPT JLPT_2
-御中,おんちゅう,Messrs.,JLPT JLPT_2
-女の人,おんなのひと,woman,Genki_Ln.7 JLPT JLPT_2 Genki
-～日,～か,counter for days,JLPT JLPT_2
-～下,～か,under ~,JLPT JLPT_2
-～化,～か,action of making something,JLPT JLPT_2
-～科,～か,"family, group, course",JLPT JLPT_2
-～歌,～か,song of ~,JLPT JLPT_2
-～画,～が,"picture, painting",JLPT_1 JLPT JLPT_2
-カーブ,カーブ,curve; curve ball (baseball),JLPT JLPT_2
-外～,がい～,"foreign ~, outside ~",JLPT JLPT_2
-～外,～がい,out of ~,JLPT JLPT_2
-開会,かいかい,opening of a meeting,JLPT JLPT_2
-会館,かいかん,"meeting hall, assembly hall",JLPT JLPT_2
-改札,かいさつ,examination of tickets,JLPT JLPT_2
-解散,かいさん,"breakup, dissolution",JLPT JLPT_2
-海水浴,かいすいよく,"sea bathing, seawater bath",JLPT JLPT_2
-回数,かいすう,"number of times, frequency",JLPT JLPT_2
-回数券,かいすうけん,book of tickets,JLPT JLPT_2
-改正,かいせい,"revision, amendment, alteration",JLPT JLPT_2
-快晴,かいせい,good weather,JLPT JLPT_2
-解説,かいせつ,"explanation, commentary",JLPT JLPT_2
-改造,かいぞう,remodeling,JLPT JLPT_2
-開通,かいつう,"opening, open",JLPT JLPT_2
-回転,かいてん,"rotation, turning",JLPT JLPT_2
-解答,かいとう,"answer, solution",JLPT JLPT_2
-回答,かいとう,"reply, answer",JLPT JLPT_2
-外部,がいぶ,"the outside, external",JLPT JLPT_2
-解放,かいほう,"release, liberation, emancipation",JLPT JLPT_2
-開放,かいほう,"open, throw open, liberalization",JLPT JLPT_2
-海洋,かいよう,ocean,JLPT JLPT_2
-概論,がいろん,"introduction, general remark",JLPT JLPT_2
-却って,かえって,"on the contrary, rather",JLPT JLPT_2
-家屋,かおく,"house, building",JLPT JLPT_2
-係わる,かかわる,"to concern oneself in, to be involved in",JLPT JLPT_2
-書留,かきとめ,registered mail,JLPT JLPT_2
-書取,かきとり,dictation,JLPT JLPT_2
-垣根,かきね,hedge,JLPT JLPT_2
-限り,かぎり,"limit(s), as far as possible",JLPT JLPT_2
-各～,かく～,"every ~, each ~",JLPT JLPT_2
-架空,かくう,"imaginary, fiction, fanciful",JLPT JLPT_2
-各自,かくじ,"individual, each",JLPT JLPT_2
-拡充,かくじゅう,expansion,JLPT JLPT_2
-学術,がくじゅつ,"science, learning, scholarship",JLPT JLPT_2
-各地,かくち,various parts of the country,JLPT JLPT_2 Intermediate_Japanese_Ln.10 Intermediate_Japanese
-拡張,かくちょう,"expansion, extension",JLPT JLPT_2
-角度,かくど,angle,JLPT JLPT_2
-学年,がくねん,"year in school, grade in school",JLPT JLPT_2
-格別,かくべつ,exceptional,JLPT JLPT_2
-確率,かくりつ,probability,JLPT JLPT_2
-学力,がくりょく,"scholarship, knowledge",JLPT JLPT_2
-掛け算,かけざん,multiplication,JLPT JLPT_2
-可決,かけつ,"approval, adoption (e.g., motion, bill), passage",JLPT JLPT_2
-火口,かこう,crater (of a volcano),JLPT JLPT_2
-下降,かこう,"decline, descent, fall",JLPT JLPT_2
-火山,かざん,volcano,JLPT JLPT_2 Intermediate_Japanese_Ln.10 Intermediate_Japanese
-かしこまりました,かしこまりました,Certainly,JLPT JLPT_2 Genki_Ln.20 Genki
-貸し出し,かしだし,"lending, loaning",JLPT JLPT_2
-過失,かしつ,"error, mistake, negligence",JLPT JLPT_2
-果実,かじつ,fruit,JLPT JLPT_2
-貸間,かしま,room to let,JLPT JLPT_2
-貸家,かしや,house for rent,JLPT JLPT_2
-箇所,かしょ,"place, point, part",JLPT JLPT_2
-過剰,かじょう,"excess, over-",JLPT JLPT_2
-かじる,かじる,"to chew, to bite (at)",JLPT JLPT_2
-課税,かぜい,taxation,JLPT JLPT_2
-下線,かせん,"underline, underscore",JLPT JLPT_2
-カセット,カセット,cassette (tape),JLPT JLPT_2
-加速,かそく,acceleration,JLPT JLPT_2
-加速度,かそくど,acceleration,JLPT JLPT_2
-塊,かたまり,"lump, mass, cluster",JLPT JLPT_2
-固まる,かたまる,"to harden, to solidify, to become firm",JLPT JLPT_2
-片道,かたみち,one-way (trip),JLPT JLPT_2
-傾く,かたむく,"to incline toward, to slant, to lurch",JLPT JLPT_2
-片寄る,かたよる,"to be one-sided, to incline, to be partial",JLPT JLPT_2
-～がち,～がち,tend to do ~,JLPT JLPT_2
-学科,がっか,"study subject, course of study",JLPT JLPT_2
-学会,がっかい,academic conference,JLPT_2 JLPT Intermediate_Japanese_Ln.15 Intermediate_Japanese
-学級,がっきゅう,class,JLPT JLPT_2
-担ぐ,かつぐ,"to shoulder, to carry on shoulder",JLPT JLPT_2
-括弧,かっこ,"parenthesis, brackets",JLPT JLPT_2
-活字,かつじ,printing type,JLPT JLPT_2
-勝手に,かってに,"arbitrarily,",JLPT JLPT_2
-活力,かつりょく,"vitality, energy",JLPT JLPT_2
-仮名,かな,kana,JLPT JLPT_2
-仮名遣い,かなづかい,"kana orthography, syllabary spelling",JLPT JLPT_2
-加熱,かねつ,heating,JLPT JLPT_2
-兼ねる,かねる,to simultaneously serve two or more functions,JLPT JLPT_2
-カバー,カバー,"cover (e.g., book)",JLPT JLPT_2
-過半数,かはんすう,majority,JLPT JLPT_2
-かび (～がはえる),かび (～がはえる),"mold, mildew",JLPT JLPT_2
-被せる,かぶせる,to cover (with something),JLPT JLPT_2
-釜,かま,"iron pot, kettle",JLPT JLPT_2
-構いません,かまいません,it's all right; one doesn’t mind,Intermediate_Japanese_Ln.4 JLPT JLPT_2 Intermediate_Japanese
-紙屑,かみくず,wastepaper,JLPT JLPT_2
-神様,かみさま,god,JLPT JLPT_2 Genki_Ln.20 Genki
-剃刀,かみそり,razor,JLPT JLPT_2
-ガム,ガム,chewing gum,JLPT JLPT_2
-貨物,かもつ,"cargo, freight",JLPT JLPT_2
-カラー,カラー,"collar, color",JLPT JLPT_2
-からかう,からかう,"to ridicule, to make fun of",JLPT JLPT_2
-空っぽ,からっぽ,"empty, vacant, hollow",JLPT JLPT_2
-かるた,かるた,playing cards (POR: carta),JLPT JLPT_2
-枯れる,かれる,"to wither, to die (plant), to be blasted (plant)",JLPT JLPT_2
-カロリー,カロリー,calorie,JLPT JLPT_2
-可愛がる,かわいがる,"to love, to be affectionate",JLPT JLPT_2
-為替,かわせ,"money order, exchange",JLPT JLPT_2
-瓦,かわら,roof tile,JLPT JLPT_2
-～刊,～かん,"~ issued (magazine, newspaper)",JLPT JLPT_2
-～間,～かん,"between, during",JLPT JLPT_2
-～巻,～かん,volume,JLPT JLPT_2
-～館,～かん,"~ hall, ~ building",JLPT JLPT_2
-～感,～かん,"feeling, sense, impression",JLPT JLPT_2
-換気,かんき,ventilation,JLPT JLPT_2
-感激,かんげき,"deep emotion, impression, inspiration",JLPT JLPT_2
-関西,かんさい,"south-western half of Japan, including Osaka",JLPT JLPT_2
-元日,がんじつ,New Year's Day,JLPT JLPT_2
-鑑賞,かんしょう,appreciation,JLPT JLPT_2
-感ずる,かんずる,"to feel, to sense",JLPT JLPT_2
-間接,かんせつ,"indirect, indirectness",JLPT JLPT_2
-観測,かんそく,observation,JLPT JLPT_2
-寒帯,かんたい,frigid zone,JLPT JLPT_2
-官庁,かんちょう,"government office, authorities",JLPT JLPT_2
-勘違い,かんちがい,"misunderstanding, wrong guess",JLPT JLPT_2
-缶詰,かんづめ,"canning, canned goods,",JLPT JLPT_2
-乾電池,かんでんち,"dry cell, battery",JLPT JLPT_2
-関東,かんとう,"eastern half of Japan, including Tokyo",JLPT JLPT_2
-観念,かんねん,"idea, notion; sense",JLPT JLPT_2
-乾杯,かんぱい,Cheers! (a toast),JLPT_2 JLPT Genki_Ln.8 Genki
-看板,かんばん,"sign, signboard",JLPT JLPT_2
-看病,かんびょう,nursing (a patient),JLPT JLPT_2
-冠,かんむり,"crown, wreath",JLPT JLPT_2
-漢和,かんわ,"Chinese Character-Japanese (e.g., dictionary)",JLPT JLPT_2
-～期,～き,"~age, ~period",JLPT JLPT_2
-～器,～き,"device, equipment",JLPT JLPT_2
-～機,～き,machine,JLPT JLPT_2
-気圧,きあつ,atmospheric pressure,JLPT JLPT_2
-着替え,きがえ,"changing clothes, change of clothes",JLPT JLPT_2
-着替える,きがえる,to change (one's) clothes,JLPT Intermediate_Japanese JLPT_2 Genki Intermediate_Japanese_Ln.10 Genki_Ln.21
-機関車,きかんしゃ,"locomotive, engine",JLPT JLPT_2
-飢饉,ききん,famine,JLPT JLPT_2
-器具,きぐ,instrument,JLPT JLPT_2
-記号,きごう,"symbol, code",JLPT JLPT_2
-刻む,きざむ,"to mince, to carve, to engrave",JLPT JLPT_2
-儀式,ぎしき,"ceremony, rite, ritual",JLPT JLPT_2
-基準,きじゅん,"standard, basis, criteria",JLPT JLPT_2
-規準,きじゅん,"standard, basis, criteria",JLPT JLPT_2
-起床,きしょう,"rising, getting out of bed",JLPT JLPT_2
-着せる,きせる,to put on clothes,JLPT JLPT_2
-基礎,きそ,"foundation, basis",JLPT JLPT_2
-基地,きち,base,JLPT JLPT_2
-きっかけ,きっかけ,"prompt, trigger, cue",JLPT JLPT_2
-ぎっしり,ぎっしり,"tightly, fully",JLPT JLPT_2
-基盤,きばん,"foundation, basis",JLPT JLPT_2
-～気味,～ぎみ,slightly ~,JLPT JLPT_2
-客席,きゃくせき,guest seating,JLPT JLPT_2
-客間,きゃくま,"parlor, guest room",JLPT JLPT_2
-ギャング,ギャング,gang,JLPT JLPT_2
-キャンパス,キャンパス,campus,JLPT JLPT_2
-休業,きゅうぎょう,"closure, shutdown, holiday",JLPT JLPT_2
-休講,きゅうこう,lecture canceled,JLPT JLPT_2
-給与,きゅうよ,salary,JLPT JLPT_2
-休養,きゅうよう,"rest, break, recreation",JLPT JLPT_2
-清い,きよい,"clear, pure, noble",JLPT JLPT_2
-～教,～きょう,religion,JLPT JLPT_2
-～行,～ぎょう,"line, row",JLPT JLPT_2
-～業,～ぎょう,type of business,JLPT JLPT_2
-強化,きょうか,"strengthen, intensify, reinforce",JLPT JLPT_2
-境界,きょうかい,boundary,JLPT JLPT_2
-共産～,きょうさん～,communist ~,JLPT JLPT_2
-行事,ぎょうじ,"event, function",JLPT JLPT_2
-恐縮,きょうしゅく,sorry to trouble,JLPT JLPT_2
-教養,きょうよう,"culture, education, sophistication",JLPT JLPT_2
-行列,ぎょうれつ,"line, procession; matrix (math)",JLPT JLPT_2
-漁業,ぎょぎょう,fishing (industry),JLPT JLPT_2
-曲線,きょくせん,curve,JLPT JLPT_2
-規律,きりつ,"order, rules, law",JLPT JLPT_2
-斬る,きる,"to behead, to murder",JLPT JLPT_2
-～きる,～きる,"nevertheless, to carry through",JLPT JLPT_2
-～切れ,～きれ,out of ~,JLPT JLPT_2
-気を付ける,きをつける,"to be careful, to pay attention, to take care",JLPT JLPT_2
-金魚,きんぎょ,goldfish,JLPT JLPT_2
-区域,くいき,"zone, district, area",JLPT JLPT_2
-空～,くう～,empty ~,JLPT JLPT_2
-偶数,ぐうすう,even number,JLPT JLPT_2
-空想,くうそう,"daydream, fantasy",JLPT JLPT_2
-空中,くうちゅう,"sky, air",JLPT JLPT_2
-クーラー,クーラー,air conditioner,JLPT JLPT_2
-釘,くぎ,nail,JLPT JLPT_2
-区切る,くぎる,"to punctuate, to cut off, to mark off",JLPT JLPT_2
-櫛,くし,comb,JLPT JLPT_2
-くしゃみ,くしゃみ,sneeze,JLPT JLPT_2
-苦情,くじょう,"complaint, grievance, grumble",JLPT JLPT_2
-苦心,くしん,"pain, trouble",JLPT JLPT_2
-屑,くず,"waste, scrap",JLPT JLPT_2
-崩す,くずす,"to destroy, to make change (money)",JLPT JLPT_2
-薬指,くすりゆび,ring finger,JLPT JLPT_2
-崩れる,くずれる,"to collapse, to crumble",JLPT JLPT_2
-砕く,くだく,"to break, to smash",JLPT JLPT_2
-砕ける,くだける,"to break, to be broken",JLPT JLPT_2
-くたびれる,くたびれる,"to get tired, to wear out",JLPT JLPT_2
-くだらない,くだらない,"good-for-nothing, stupid, worthless",JLPT JLPT_2
-～口,～くち,"~ opening; ~ entrance, ~ exit",JLPT JLPT_2
-唇,くちびる,lip,JLPT JLPT_2
-口紅,くちべに,lipstick,JLPT JLPT_2
-くっつく,くっつく,"to adhere to, to keep close to",JLPT JLPT_2
-くっつける,くっつける,to attach,JLPT JLPT_2
-くどい,くどい,"verbose, importunate, heavy (taste)",JLPT JLPT_2
-句読点,くとうてん,punctuation marks,JLPT JLPT_2
-配る,くばる,"to distribute, to deliver",JLPT JLPT_2
-工夫,くふう,"device, artifice, ingenuity",JLPT JLPT_2
-区分,くぶん,"division, section, classification",JLPT JLPT_2
-組合せ,くみあわせ,combination,JLPT JLPT_2
-組み立てる,くみたてる,"to assemble, to set up, to construct",JLPT JLPT_2
-悔やむ,くやむ,"to regret, to mourn",JLPT JLPT_2 Intermediate_Japanese Intermediate_Japanese_Ln.11
-クリーニング,クリーニング,"cleaning, dry cleaning, laundry service",JLPT JLPT_2
-くるむ,くるむ,"to be enveloped by, to wrap up",JLPT JLPT_2
-くれぐれも,くれぐれも,"repeatedly, sincerely, earnestly",JLPT JLPT_2
-～家,～け,"~'s family, the house of ~",JLPT JLPT_2
-～形,～けい,shape of ~,JLPT JLPT_2
-～系,～けい,"~ system, ~ lineage, ~ group",JLPT_1 JLPT JLPT_2
-稽古,けいこ,"practice, training, study",JLPT JLPT_2
-敬語,けいご,"honorific language (lit., respect language)",JLPT Intermediate_Japanese Genki_Ln.19 JLPT_2 Intermediate_Japanese_Ln.13 Genki
-蛍光灯,けいこうとう,fluorescent lamp,JLPT JLPT_2
-形式,けいしき,"form, formality, format",JLPT JLPT_2
-継続,けいぞく,continuation,JLPT JLPT_2
-毛糸,けいと,knitting wool,JLPT JLPT_2
-経度,けいど,longitude,JLPT JLPT_2
-系統,けいとう,"system, genealogy",JLPT JLPT_2
-芸能,げいのう,"public entertainment, performing arts",JLPT JLPT_2
-競馬,けいば,horse racing,JLPT JLPT_2
-警備,けいび,"defense, guard, policing, security",JLPT JLPT_2
-形容詞,けいようし,adjective,JLPT JLPT_2
-形容動詞,けいようどうし,"adjectival noun, quasi-adjective",JLPT JLPT_2
-外科,げか,surgical department,JLPT JLPT_2
-毛皮,けがわ,"fur, skin, pelt",JLPT JLPT_2
-激増,げきぞう,sudden increase,JLPT JLPT_2
-下車,げしゃ,"alighting, getting off",JLPT JLPT_2
-下旬,げじゅん,month (last third of),JLPT JLPT_2
-下水,げすい,"drainage, sewage, ditch, gutter, sewerage",JLPT JLPT_2
-削る,けずる,"to cut down little by little, to take a percentage",JLPT JLPT_2
-桁,けた,"column, beam, digit",JLPT JLPT_2
-下駄,げた,"(Japanese footwear), wooden clogs",JLPT JLPT_2
-血圧,けつあつ,blood pressure,JLPT JLPT_2
-月給,げっきゅう,monthly salary,JLPT JLPT_2
-傑作,けっさく,"masterpiece, best work",JLPT JLPT_2
-月末,げつまつ,end of the month,JLPT JLPT_2
-気配,けはい,"indication, sign, hint",JLPT JLPT_2
-下品,げひん,"vulgar, indecent, coarse",JLPT JLPT_2
-煙い,けむい,smoky,JLPT JLPT_2
-険しい,けわしい,"steep, rugged; severe",JLPT JLPT_2
-～圏,～けん,"bloc, sphere, area",JLPT_1 JLPT JLPT_2
-現～,げん～,"present, incumbent",JLPT JLPT_2
-見学,けんがく,"tour, study by observation",JLPT JLPT_2
-謙虚,けんきょ,"modesty, humble",JLPT JLPT_2
-原稿,げんこう,"manuscript, copy",JLPT JLPT_2
-原産,げんさん,place of origin,JLPT JLPT_2
-原始,げんし,"origin, primeval",JLPT JLPT_2
-研修,けんしゅう,training,JLPT JLPT_2
-厳重,げんじゅう,"strict, severe, firm",JLPT JLPT_2
-謙遜,けんそん,"humble, humility, modesty",JLPT JLPT_2
-県庁,けんちょう,prefectural office,JLPT JLPT_2
-限度,げんど,"limit, bounds",JLPT JLPT_2
-現に,げんに,"actually, really",JLPT JLPT_2
-顕微鏡,けんびきょう,microscope,JLPT JLPT_2
-懸命,けんめい,"eagerness, strenuous",JLPT JLPT_2
-原理,げんり,"principle, theory, fundamental truth",JLPT JLPT_2
-原料,げんりょう,raw materials,JLPT JLPT_2
-小～,こ～,small ~,JLPT JLPT_2
-恋しい,こいしい,"dear, beloved; to miss",JLPT JLPT_2
-高～,こう～,high (level) ~,JLPT JLPT_2
-～校,～こう,counter for school,JLPT JLPT_2
-～港,～こう,~ port,JLPT JLPT_2
-～号,～ごう,counter for magazine; the name of ship,JLPT JLPT_2
-工員,こういん,factory worker,JLPT JLPT_2
-強引,ごういん,"forcible, assertive, pushy",JLPT JLPT_2
-公害,こうがい,"public nuisance, pollution",JLPT JLPT_2
-高級,こうきゅう,high class; first-rate,Intermediate_Japanese_Ln.6 JLPT_2 JLPT Intermediate_Japanese
-公共,こうきょう,"public, community, communal",JLPT JLPT_2
-工芸,こうげい,industrial arts,JLPT JLPT_2
-孝行,こうこう,filial piety,JLPT JLPT_2
-交差,こうさ,cross,JLPT JLPT_2
-講師,こうし,lecturer,JLPT_2 JLPT Intermediate_Japanese_Ln.15 Intermediate_Japanese
-工事,こうじ,construction work,JLPT JLPT_2
-公式,こうしき,"formula, formality, official",JLPT JLPT_2
-口実,こうじつ,excuse,JLPT JLPT_2
-こうして,こうして,"like this, with this",JLPT JLPT_2
-公衆,こうしゅう,the public,JLPT JLPT_2
-香水,こうすい,perfume,JLPT JLPT_2
-功績,こうせき,"achievements, merit",JLPT JLPT_2
-光線,こうせん,"beam, light ray",JLPT JLPT_2
-高層,こうそう,"tall, high rise",JLPT JLPT_2
-構造,こうぞう,"structure, construction",JLPT JLPT_2
-交替,こうたい,"change, relief, alteration",JLPT JLPT_2
-耕地,こうち,arable land,JLPT JLPT_2
-交通機関,こうつうきかん,transportation facilities,JLPT JLPT_2
-校庭,こうてい,school yard,JLPT JLPT_2
-肯定,こうてい,"positive, affirmation",JLPT JLPT_2
-高度,こうど,"altitude, height; advanced",JLPT JLPT_2
-高等,こうとう,"high class, high grade",JLPT JLPT_2
-合同,ごうどう,"combination, incorporation",JLPT JLPT_2
-高等学校,こうとうがっこう,senior high school,JLPT JLPT_2
-公表,こうひょう,"official announcement, proclamation",JLPT JLPT_2
-鉱物,こうぶつ,mineral,JLPT JLPT_2
-公務,こうむ,"official business, public business",JLPT JLPT_2
-項目,こうもく,item,JLPT JLPT_2
-紅葉,こうよう,fall colors (of leaves),Intermediate_Japanese_Ln.4 JLPT JLPT_2 Intermediate_Japanese
-合理,ごうり,rational,JLPT JLPT_2
-交流,こうりゅう,exchange; alternating current,JLPT JLPT_2
-合流,ごうりゅう,"confluence, merge, join",JLPT JLPT_2
-効力,こうりょく,"effect, efficacy",JLPT JLPT_2
-コース,コース,course,JLPT JLPT_2
-コーラス,コーラス,chorus,JLPT JLPT_2
-焦がす,こがす,"to burn, to scorch",JLPT JLPT_2
-～国,～こく,nation of ~,JLPT JLPT_2
-国王,こくおう,king,JLPT JLPT_2
-国立,こくりつ,national,JLPT JLPT_2
-ご苦労様,ごくろうさま,Thank you for your hard work,JLPT JLPT_2
-焦げる,こげる,"to burn, to be burned",JLPT JLPT_2
-凍える,こごえる,"to freeze, to be chilled, to be frozen",JLPT JLPT_2
-心当たり,こころあたり,"having some knowledge of, happening to know",JLPT JLPT_2
-心得る,こころえる,"to understand, to have thorough knowledge",JLPT JLPT_2
-腰掛け,こしかけ,"seat, bench",JLPT JLPT_2
-腰掛ける,こしかける,to sit (down),JLPT JLPT_2
-五十音,ごじゅうおん,the Japanese syllabary,JLPT JLPT_2
-こしらえる,こしらえる,"to make, to manufacture",JLPT JLPT_2
-擦る,こする,"to rub, to chafe, to file, to frost (glass), to strike (match)",JLPT JLPT_2
-個体,こたい,an individual,JLPT JLPT_2
-ごちそうさま,ごちそうさま,Thank you for the meal,JLPT JLPT_2
-こちらこそ,こちらこそ,it is I who should say so,JLPT JLPT_2
-小遣い,こづかい,"pocket money, allowance",JLPT JLPT_2
-コック,コック,"cook; tap, cock",JLPT JLPT_2
-こっそり,こっそり,"stealthily, secretly",JLPT JLPT_2
-古典,こてん,"classics, classic",JLPT JLPT_2
-～毎,～ごと,"every ~, each ~",JLPT JLPT_2
-〜 (まる) ごと,〜 (まる) ごと,"whole ~, all of ~",JLPT JLPT_2
-言付ける,ことづける,to leave a message,JLPT JLPT_2
-言葉遣い,ことばづかい,"speech, expression, wording",JLPT JLPT_2
-こないだ,こないだ,"the other day, lately, recently",JLPT JLPT_2
-御無沙汰,ごぶさた,not writing or contacting for a while,JLPT JLPT_2
-ゴム,ゴム,"gum, rubber",JLPT JLPT_2
-御免,ごめん,"declining (something); pardon, sorry",JLPT JLPT_2
-ごめんください,ごめんください,"May I come in, Is anyone here",JLPT JLPT_2
-小指,こゆび,little finger,JLPT JLPT_2
-堪える,こらえる,"to bear, to endure, to put up with",JLPT JLPT_2
-娯楽,ごらく,"pleasure, amusement, recreation",JLPT JLPT_2
-御覧,ごらん,"(hon.) look, inspection, try",JLPT JLPT_2
-コレクション,コレクション,collection; correction,JLPT JLPT_2
-転がす,ころがす,to roll,JLPT JLPT_2
-転がる,ころがる,"to roll, to tumble",JLPT JLPT_2
-紺,こん,"navy blue, deep blue",JLPT JLPT_2 Intermediate_Japanese_Ln.9 Intermediate_Japanese
-今～,こん～,"this, current",JLPT JLPT_2
-コンクール,コンクール,contest (FRE: concours),JLPT JLPT_2
-コンクリート,コンクリート,concrete,JLPT JLPT_2
-混合,こんごう,"mixing, mixture",JLPT JLPT_2
-コンセント,コンセント,consent; power outlet,JLPT JLPT_2
-献立,こんだて,menu,JLPT JLPT_2
-こんばんは,こんばんは,good evening,JLPT JLPT_2
-サークル,サークル,"circle, sports club (e.g., at a company)",JLPT JLPT_2
-再～,さい～,re ~,JLPT JLPT_2
-最～,さい～,the most ~,JLPT JLPT_2
-在学,ざいがく,(enrolled) in school,JLPT JLPT_2
-再三,さいさん,"again and again, repeatedly",JLPT JLPT_2
-祭日,さいじつ,"national holiday, festival day",JLPT JLPT_2
-催促,さいそく,"demand, urge (action), press for",JLPT JLPT_2
-採点,さいてん,"marking, grading",JLPT JLPT_2
-災難,さいなん,"calamity, misfortune",JLPT JLPT_2
-裁縫,さいほう,sewing,JLPT JLPT_2
-材木,ざいもく,"lumber, timber",JLPT JLPT_2
-サイレン,サイレン,siren,JLPT JLPT_2
-逆さ,さかさ,"reverse, upside down",JLPT JLPT_2
-逆様,さかさま,"reverse, upside down",JLPT JLPT_2
-捜す,さがす,"to search, to seek, to look for",JLPT JLPT_2
-遡る,さかのぼる,"to go back, to date back; ascend",JLPT JLPT_2
-酒場,さかば,"bar, bar-room",JLPT JLPT_2
-一昨昨日,さきおととい,"two days before yesterday, three days ago",JLPT JLPT_2
-先程,さきほど,a little while ago,JLPT JLPT_2
-索引,さくいん,"index, indices",JLPT JLPT_2
-作者,さくしゃ,"author, artist",JLPT JLPT_2
-削除,さくじょ,"elimination, deletion",JLPT JLPT_2
-作成,さくせい,"creation, preparation, to make",JLPT JLPT_2
-作製,さくせい,"manufacture, production",JLPT JLPT_2
-探る,さぐる,"to search, to look for, investigate",JLPT JLPT_2
-囁く,ささやく,"to whisper, to murmur",JLPT JLPT_2
-匙,さじ,spoon,JLPT JLPT_2
-座敷,ざしき,tatami room,JLPT JLPT_2
-差し支え,さしつかえ,"hindrance, impediment",JLPT JLPT_2
-差し引き,さしひき,"deduction, balance",JLPT_1 JLPT JLPT_2
-刺身,さしみ,sliced raw fish,JLPT JLPT_2
-(かさを～) さす,(かさを～) さす,to open; hold (an umbrella),JLPT JLPT_2 MediaMissing
-流石,さすが,"indeed, truly, as one would expect",JLPT JLPT_2
-撮影,さつえい,photographing,JLPT JLPT_2
-雑音,ざつおん,"noise (jarring, grating)",JLPT JLPT_2
-さっさと,さっさと,quickly,JLPT JLPT_2
-早速,さっそく,"at once, immediately, promptly",JLPT JLPT_2
-錆,さび,rust (color),JLPT JLPT_2
-錆びる,さびる,"to rust, to become rusty",JLPT JLPT_2
-座布団,ざぶとん,cushion (Japanese),JLPT JLPT_2
-妨げる,さまたげる,"to disturb, to prevent",JLPT JLPT_2
-さようなら,さようなら,good-bye,JLPT JLPT_2
-サラリーマン,サラリーマン,salaryman; company employee,Genki_Ln.17 JLPT JLPT_2 Genki
-騒がしい,さわがしい,noisy,JLPT JLPT_2
-さわやか,さわやか,"fresh, refreshing",JLPT JLPT_2
-～山,～さん,the name of mountain,JLPT JLPT_2
-～産,～さん,made in ~,JLPT JLPT_2
-三角,さんかく,"triangle, triangular",JLPT JLPT_2
-算数,さんすう,arithmetic,JLPT JLPT_2
-産地,さんち,producing area,JLPT JLPT_2
-サンプル,サンプル,sample,JLPT JLPT_2
-山林,さんりん,mountain forest,JLPT JLPT_2
-～史,～し,history of ~,JLPT JLPT_2
-～紙,～し,"newspaper, type of paper",JLPT JLPT_2
-～寺,～じ,the name of temple,JLPT JLPT_2
-仕上がる,しあがる,to be finished,JLPT JLPT_2
-明明後日,しあさって,two days after tomorrow,JLPT JLPT_2
-シーズン,シーズン,season (sporting),JLPT JLPT_2
-シーツ,シーツ,sheet,JLPT JLPT_2
-寺院,じいん,temple,JLPT JLPT_2
-しいんと (する),しいんと (する),"silent (as the grave), (deathly) quiet",JLPT JLPT_2
-自衛,じえい,self-defense,JLPT JLPT_2
-塩辛い,しおからい,salty (taste),JLPT JLPT_2
-司会,しかい,"host, chairperson",JLPT JLPT_2
-四角い,しかくい,square,JLPT JLPT_2
-仕方がない,しかたがない,"it can't be helped, it's inevitable",JLPT JLPT_2
-～時間目,～じかんめ,"~th hour, ~th period",JLPT JLPT_2
-時間割,じかんわり,"timetable, schedule",JLPT JLPT_2
-〜(日本) 式,～(にほん) しき,"custom,",JLPT JLPT_2 MediaMissing
-敷地,しきち,site,JLPT JLPT_2
-敷く,しく,"to spread out, to lay out",JLPT JLPT_2
-茂る,しげる,to grow thick,JLPT JLPT_2
-持参,じさん,"bringing, taking, carrying",JLPT JLPT_2
-磁石,じしゃく,magnet,JLPT JLPT_2
-四捨五入,ししゃごにゅう,rounding up (fractions),JLPT JLPT_2
-始終,しじゅう,"continuously, always, constantly",JLPT JLPT_2
-自習,じしゅう,self-study,JLPT JLPT_2 Intermediate_Japanese_Ln.13 Intermediate_Japanese
-静まる,しずまる,"to quieten down, to calm down",JLPT JLPT_2
-姿勢,しせい,attitude; posture,JLPT JLPT_2
-自然科学,しぜんかがく,natural science,JLPT JLPT_2
-時速,じそく,speed (per hour),JLPT JLPT_2
-子孫,しそん,"descendant, offspring",JLPT JLPT_2
-死体,したい,corpse,JLPT JLPT_2
-下書き,したがき,"rough copy, draft",JLPT JLPT_2
-自宅,じたく,one's own home (same as 自分の家 (じぶんのいえ)),Intermediate_Japanese_Ln.5 JLPT JLPT_2 Intermediate_Japanese
-下町,したまち,old parts of town,JLPT JLPT_2
-自治,じち,"self-government, autonomy",JLPT JLPT_2
-室～,しつ～,room,JLPT JLPT_2
-～室,～しつ,counter for room,JLPT JLPT_2
-～日,～じつ,day,JLPT JLPT_2
-実感,じっかん,"feelings, realization",JLPT JLPT_2
-湿気,しっき,"moisture, humidity, dampness",JLPT JLPT_2
-しつこい,しつこい,"insistent, obstinate",JLPT JLPT_2
-実習,じっしゅう,"practice, training",JLPT JLPT_2
-実績,じっせき,"achievements, actual results",JLPT JLPT_2
-執筆,しっぴつ,writing,JLPT JLPT_2
-実物,じつぶつ,an actual thing,Intermediate_Japanese_Ln.6 JLPT_2 JLPT Intermediate_Japanese
-しっぽ,しっぽ,tail (animal),JLPT JLPT_2
-実用,じつよう,"practical use, utility",JLPT JLPT_2
-しつれいしました (かん),しつれいしました (かん),"Excuse me., I'm sorry.",JLPT JLPT_2
-実例,じつれい,"example, instance",JLPT JLPT_2
-失恋,しつれん,"broken heart, unrequited love",JLPT JLPT_2
-指定,してい,"designation, specification, assignment",JLPT JLPT_2
-私鉄,してつ,private railway,JLPT JLPT_2
-縛る,しばる,"to tie, to bind",JLPT JLPT_2
-地盤,じばん,(the) ground,JLPT JLPT_2
-しびれる,しびれる,to become numb,JLPT JLPT_2
-紙幣,しへい,"paper money, notes, bills",JLPT JLPT_2
-しぼむ,しぼむ,"to wither, to shrivel",JLPT JLPT_2
-絞る,しぼる,"to press, to wring, to squeeze",JLPT JLPT_2
-縞,しま,stripe,JLPT JLPT_2
-～おしまい (おわり),～おしまい (おわり),end up ~,JLPT JLPT_2
-しみじみ,しみじみ,"keenly, deeply, heartily",JLPT JLPT_2
-氏名,しめい,full name,JLPT JLPT_2
-締切,しめきり,deadline,JLPT JLPT_2 Intermediate_Japanese Intermediate_Japanese_Ln.3
-締め切る,しめきる,"to close, cancel",JLPT JLPT_2
-しめた (かん),しめた (かん),"I've got it, all right, fine",JLPT JLPT_2
-地面,じめん,"ground, earth's surface",JLPT JLPT_2
-～車,～しゃ,~ car,JLPT JLPT_2
-～者,～しゃ,person,JLPT JLPT_2
-～社,～しゃ,counter for company,JLPT JLPT_2
-ジャーナリスト,ジャーナリスト,journalist,JLPT JLPT_2
-社会科学,しゃかいかがく,social science,JLPT JLPT_2
-しゃがむ,しゃがむ,to squat,JLPT JLPT_2
-蛇口,じゃぐち,"faucet, tap",JLPT JLPT_2
-弱点,じゃくてん,"weak point, weakness",JLPT JLPT_2
-車庫,しゃこ,"garage, car shed",JLPT JLPT_2
-車掌,しゃしょう,(train) conductor,JLPT JLPT_2
-写生,しゃせい,"sketching, drawing from nature",JLPT JLPT_2
-社説,しゃせつ,editorial,JLPT JLPT_2
-しゃっくり,しゃっくり,"hiccough, hiccup",JLPT JLPT_2
-シャッター,シャッター,shutter,JLPT JLPT_2
-しゃぶる,しゃぶる,"to suck, to chew",JLPT JLPT_2
-車輪,しゃりん,(car) wheel,JLPT JLPT_2
-洒落,しゃれ,"joke, pun, witticism",JLPT JLPT_2
-じゃんけん,じゃんけん,rock-scissors-paper game,JLPT JLPT_2
-～手,～しゅ,"~ player, person who does ~",JLPT JLPT_2
-～酒,～しゅ,kind of alcohol,JLPT JLPT_2
-～集,～しゅう,collection of ~,JLPT JLPT_2
-重～,じゅう～,heavy ~,JLPT JLPT_2
-集会,しゅうかい,"meeting, assembly",JLPT JLPT_2
-集金,しゅうきん,money collection,JLPT JLPT_2
-集合,しゅうごう,"gathering, assembly",JLPT JLPT_2
-習字,しゅうじ,penmanship,JLPT JLPT_2
-修繕,しゅうぜん,"repair, mending",JLPT JLPT_2
-じゅうたん (カーペット),じゅうたん (カーペット),carpet,JLPT JLPT_2
-終点,しゅうてん,"terminus, last stop (e.g train)",JLPT JLPT_2
-重点,じゅうてん,"important point, lay stress on, emphasis",JLPT JLPT_2
-リズム,リズム,rhythm,JLPT JLPT_2
-リットル,リットル,liter,JLPT JLPT_2
-リボン,リボン,ribbon,JLPT JLPT_2
-略す,りゃくす,to abbreviate,JLPT JLPT_2
-～流,～りゅう,"fashion, manner, way",JLPT JLPT_2
-流域,りゅういき,(river) basin,JLPT JLPT_2
-両～,りょう～,both ~,JLPT JLPT_2
-～料,～りょう,"fare, charge",JLPT JLPT_2
-～領,～りょう,territory,JLPT JLPT_2
-両側,りょうがわ,both sides,JLPT JLPT_2
-漁師,りょうし,fisherman,JLPT JLPT_2
-領事,りょうじ,consul,JLPT JLPT_2
-領収,りょうしゅう,"receipt, voucher",JLPT JLPT_2
-～力,～りょく,power of ~,JLPT JLPT_2
-臨時,りんじ,"temporary, special, extraordinary",JLPT JLPT_2
-留守番,るすばん,"care-taking, caretaker, house-watching",JLPT JLPT_2 Genki_Ln.23 Genki
-零点,れいてん,"zero, no marks",JLPT JLPT_2
-冷凍,れいとう,"freezing, cold storage, refrigeration",JLPT JLPT_2
-レインコート,レインコート,raincoat,JLPT JLPT_2
-レクリェーション,レクリェーション,recreation,JLPT JLPT_2
-レジャー,レジャー,leisure,JLPT JLPT_2
-列島,れっとう,chain of islands,JLPT JLPT_2
-リポート,リポート,"report, paper",JLPT JLPT_2
-煉瓦,れんが,brick,JLPT JLPT_2
-連合,れんごう,"union, alliance",JLPT JLPT_2
-レンズ,レンズ,lens,JLPT JLPT_2
-ろうそく,ろうそく,candle,JLPT_2 JLPT Genki_Ln.18 Genki
-ローマ字,ローマじ,"romanization, Roman letters (alphabet)",JLPT_2 JLPT Intermediate_Japanese_Ln.15 Intermediate_Japanese
-録音,ろくおん,(audio) recording,JLPT JLPT_2
-ロッカー,ロッカー,locker,JLPT JLPT_2
-ロビー,ロビー,lobby,JLPT JLPT_2
-～論,～ろん,theory,JLPT JLPT_2
-論ずる,ろんずる,"to argue, to discuss",JLPT JLPT_2
-和～,わ～,Japanese style,JLPT JLPT_2
-～羽,～わ,counter for rabbits; birds,JLPT JLPT_2
-和英,わえい,Japanese-English,JLPT JLPT_2
-我～,わが～,our ~,JLPT JLPT_2
-若々しい,わかわかしい,"youthful, young",JLPT JLPT_2
-詫びる,わびる,to apologize,JLPT JLPT_2
-和服,わふく,Japanese clothes,JLPT JLPT_2
-割合に,わりあいに,"relatively, comparatively",JLPT JLPT_2
-割算,わりざん,division (math),JLPT JLPT_2
-割と,わりと,"relatively, comparatively",JLPT JLPT_2
-割引,わりびき,discount,JLPT JLPT_2
-ワンピース,ワンピース,one-piece dress,JLPT JLPT_2
-アイデア; アイディア,アイデア; アイディア,idea,JLPT JLPT_2
-あいまい,あいまい,"vague, ambiguous",JLPT JLPT_2
-扇ぐ,あおぐ,"to fan, to flap",JLPT JLPT_2
-青白い,あおじろい,pale,JLPT JLPT_2
-呆れる,あきれる,"to be shocked, to be appalled",JLPT JLPT_2
-アクセント,アクセント,accent,JLPT JLPT_2
-あくび,あくび,yawn,JLPT JLPT_2
-飽くまで,あくまで,"to the end, to the last, stubbornly",JLPT JLPT_2
-明くる～,あくる～,"next, following",JLPT JLPT_2
-明け方,あけがた,dawn,JLPT JLPT_2
-憧れる,あこがれる,"to long for, to yearn after",JLPT JLPT_2
-朝寝坊,あさねぼう,"oversleeping, late riser",JLPT JLPT_2
-足跡,あしあと,footprint,JLPT JLPT_2
-足元,あしもと,at one's feet,JLPT JLPT_2
-味わう,あじわう,"to taste, to savor",JLPT JLPT_2
-あちらこちら,あちらこちら,here and there,JLPT JLPT_2
-厚かましい,あつかましい,"impudent, shameless,",JLPT JLPT_2
-圧縮,あっしゅく,"compression, condensation, pressure",JLPT JLPT_2
-宛名,あてな,"address, direction",JLPT JLPT_2
-当てはまる,あてはまる,"to be applicable, to come under (a category)",JLPT JLPT_2
-当てはめる,あてはめる,"to apply, to adapt",JLPT JLPT_2
-暴れる,あばれる,"to act violently, to rage",JLPT JLPT_2
-あぶる,あぶる,"to scorch, to roast",JLPT JLPT_2
-あふれる,あふれる,"to flood, to overflow",JLPT JLPT_2
-雨戸,あまど,sliding storm door,JLPT JLPT_2
-甘やかす,あまやかす,"to pamper, to spoil",JLPT JLPT_2
-余る,あまる,"to be left over, to be in excess",JLPT JLPT_2
-編み物,あみもの,knitting,JLPT JLPT_2
-編む,あむ,to knit,Genki Genki_Ln.13 JLPT JLPT_2
-危うい,あやうい,"dangerous, critical",JLPT JLPT_2
-怪しい,あやしい,"suspicious, dubious, doubtful",JLPT JLPT_2
-荒い,あらい,"rough, rude, wild",JLPT JLPT_2
-粗い,あらい,"coarse, rough",JLPT JLPT_2
-粗筋,あらすじ,"outline, synopsis",JLPT JLPT_2
-改めて,あらためて,"another time, again",JLPT JLPT_2
-改める,あらためる,"to change, to reform, to revise",JLPT JLPT_2
-有難い,ありがたい,"grateful, thankful, appreciated",JLPT JLPT_2
-あれこれ,あれこれ,"one thing or another, this and that",JLPT JLPT_2
-荒れる,あれる,"to be stormy, to be rough, to be ruined",JLPT JLPT_2
-慌ただしい,あわただしい,"busy, hurried",JLPT JLPT_2
-安易,あんい,easy-going,JLPT JLPT_2
-アンテナ,アンテナ,antenna,JLPT JLPT_2
-～位,～い,~th place,JLPT JLPT_2
-言い出す,いいだす,"to start talking, to suggest",JLPT JLPT_2
-言い付ける,いいつける,"to tell, to order",JLPT JLPT_2
-意義,いぎ,"meaning, significance",JLPT JLPT_2
-生き生き,いきいき,"vividly, lively",JLPT JLPT_2
-いきなり,いきなり,all of a sudden,Intermediate_Japanese Intermediate_Japanese_Ln.13 JLPT JLPT_2
-幾～,いく～,several ~,JLPT JLPT_2
-育児,いくじ,"childcare, nursing",Intermediate_Japanese Intermediate_Japanese_Ln.14 JLPT JLPT_2
-幾分,いくぶん,somewhat,JLPT JLPT_2
-生け花,いけばな,flower arrangement,JLPT JLPT_2
-以後,いご,after this; from now on; hereafter,JLPT JLPT_2 Intermediate_Japanese_Ln.8 Intermediate_Japanese
-以降,いこう,"on and after, hereafter",JLPT JLPT_2
-イコール,イコール,equal,JLPT JLPT_2
-勇ましい,いさましい,"brave, valiant",JLPT JLPT_2
-衣食住,いしょくじゅう,"food, clothing and shelter",JLPT JLPT_2
-～いち (にほんいち),～いち (にほんいち),No. 1 ~ (in),JLPT JLPT_2
-いちいち,いちいち,"one by one, separately",JLPT JLPT_2
-一応,いちおう,"tentatively, for the time being",JLPT JLPT_2
-一段と,いちだんと,"by far, greater",JLPT_2 JLPT Intermediate_Japanese_Ln.15 Intermediate_Japanese
-一流,いちりゅう,"first class, leading",JLPT JLPT_2
-一昨日,いっさくじつ,day before yesterday,JLPT JLPT_2
-一昨年,いっさくねん,year before last,JLPT JLPT_2
-一斉,いっせい,"simultaneous, all at once",JLPT JLPT_2
-一旦,いったん,"once, for a moment",JLPT JLPT_2
-一定,いってい,"fixed, settled, regular",JLPT JLPT_2
-行っていらっしゃい,いっていらっしゃい,"have a nice day, see you",JLPT JLPT_2
-行ってらっしゃい,いってらっしゃい,"have a nice day, see you",JLPT JLPT_2
-いってまいります,いってまいります,"(Lit.) I'll go and come back, 'I'm going, see you later'",JLPT JLPT_2
-いってきます,いってきます,"(Lit.) I'll go and come back, 'I'm going, see you later'",JLPT JLPT_2
-移転,いてん,"moving, transfer",JLPT JLPT_2
-井戸,いど,water well,JLPT JLPT_2
-緯度,いど,latitude (navigation),JLPT JLPT_2
-威張る,いばる,"to be proud, to swagger",JLPT JLPT_2
-嫌がる,いやがる,"reluctant, to dislike",JLPT JLPT_2
-いよいよ,いよいよ,"more and more, increasingly, at last",JLPT JLPT_2
-煎る,いる,to roast,JLPT JLPT_2
-炒る,いる,"to parch, to roast",JLPT JLPT_2
-入れ物,いれもの,"container, case",JLPT JLPT_2
-インキ,インキ,ink,JLPT JLPT_2
-引力,いんりょく,gravity,JLPT JLPT_2
-ウーマン,ウーマン,woman,JLPT JLPT_2
-ウール,ウール,wool,JLPT JLPT_2
-ウエートレス,ウエートレス,waitress,JLPT JLPT_2
-植木,うえき,"garden shrubs, trees, potted plant",JLPT JLPT_2
-飢える,うえる,to starve,JLPT JLPT_2
-浮ぶ,うかぶ,"to float, to rise to surface, to come to mind",JLPT JLPT_2
-浮かべる,うかべる,to float; to express,JLPT JLPT_2
-浮く,うく,to float,JLPT JLPT_2
-承る,うけたまわる,"(humble) to hear, to be told, to know",JLPT JLPT_2
-受取,うけとり,receipt,JLPT JLPT_2
-受け持つ,うけもつ,to take (be in) charge of,JLPT JLPT_2
-薄暗い,うすぐらい,"dim, gloomy",JLPT JLPT_2
-薄める,うすめる,"to dilute, to water down",JLPT JLPT_2
-打合せ,うちあわせ,"business meeting, previous arrangement",JLPT JLPT_2
-打ち消す,うちけす,"to deny, to negate",JLPT JLPT_2
-うどん,うどん,udon noodles (Japanese traditional noodles),Intermediate_Japanese_Ln.6 JLPT_2 JLPT Intermediate_Japanese
-うなずく,うなずく,to nod,JLPT JLPT_2
-敬う,うやまう,"to show respect, to honor",JLPT JLPT_2
-裏返す,うらがえす,"to turn inside out, to turn (something) over",JLPT JLPT_2
-裏口,うらぐち,"backdoor, rear entrance",JLPT JLPT_2
-占う,うらなう,"to predict, to divine",JLPT JLPT_2
-恨み,うらみ,resentment,JLPT JLPT_2
-恨む,うらむ,"to curse, to feel bitter",JLPT JLPT_2
-羨む,うらやむ,to envy,JLPT JLPT_2
-売上,うりあげ,"amount sold, proceeds",JLPT JLPT_2
-売り切れ,うりきれ,sold-out,JLPT JLPT_2
-売り切れる,うりきれる,to be sold out,JLPT JLPT_2
-売行き,うれゆき,sales,JLPT JLPT_2
-うろうろ,うろうろ,"loitering, aimless wandering",JLPT JLPT_2
-上～,うわ～,upper ~,JLPT JLPT_2
-運河,うんが,"canal, waterway",JLPT JLPT_2
-うんと,うんと,"a great deal, very much",JLPT JLPT_2
-英文,えいぶん,sentence in English,JLPT JLPT_2
-英和,えいわ,"English-Japanese (e.g., dictionary)",JLPT JLPT_2
-ええと,ええと,"let me see, well, er...",JLPT JLPT_2
-液体,えきたい,"liquid, fluid",JLPT JLPT_2
-エチケット,エチケット,etiquette,JLPT JLPT_2
-絵の具,えのぐ,"colors, paints",JLPT JLPT_2
-エプロン,エプロン,apron,JLPT JLPT_2
-偉い,えらい,"great, celebrated, remarkable,",JLPT JLPT_2
-～園,～えん,~ garden (especially man made),JLPT JLPT_2
-宴会,えんかい,"party, banquet",JLPT JLPT_2
-園芸,えんげい,"horticulture, gardening",JLPT JLPT_2
-演劇,えんげき,play (theatrical),JLPT JLPT_2
-円周,えんしゅう,circumference,JLPT JLPT_2
-遠足,えんそく,"trip, hike, picnic",JLPT JLPT_2
-延長,えんちょう,"extension, prolongation",JLPT JLPT_2
-煙突,えんとつ,chimney,JLPT JLPT_2
-御～,おん～,honorific ~,JLPT JLPT_2
-追いかける,おいかける,to chase or run after someone,JLPT JLPT_2
-追い越す,おいこす,"to pass (e.g., car), to outdistance, to outstrip",JLPT JLPT_2
-オイル,オイル,oil,JLPT JLPT_2
-王女,おうじょ,princess,JLPT JLPT_2
-応ずる,おうずる,"to respond, to comply with",JLPT JLPT_2
-応接,おうせつ,reception,JLPT JLPT_2
-応対,おうたい,"receiving, dealing with",JLPT JLPT_2
-往復,おうふく,"(col) round trip, coming and going, return ticket",JLPT JLPT_2
-欧米,おうべい,"Europe and America, the West",JLPT_2 JLPT Intermediate_Japanese_Ln.7 Intermediate_Japanese
-応用,おうよう,"application, put to practical use",JLPT JLPT_2
-電波,でんぱ,electro-magnetic wave,JLPT JLPT_2
-テンポ,テンポ,tempo,JLPT JLPT_2
-電流,でんりゅう,electric current,JLPT JLPT_2
-電力,でんりょく,electric power,JLPT JLPT_2
-問い合わせ,といあわせ,inquiry,JLPT JLPT_2
-～頭,～とう,counter for animals,JLPT JLPT_2
-～等,～とう,"level, place",JLPT JLPT_2
-～島,～とう,kind of islands,JLPT JLPT_2
-銅,どう,copper,JLPT JLPT_2
-同～,どう～,same ~,JLPT JLPT_2
-～道,～どう,"kind of path, road",JLPT JLPT_2
-どういたしまして (かん),どういたしまして (かん),"you are welcome, don't mention it",JLPT JLPT_2
-統一,とういつ,"unity, consolidation, uniformity",JLPT JLPT_2
-同格,どうかく,"the same rank, equality, apposition",JLPT JLPT_2
-峠,とうげ,"ridge, (mountain) pass, difficult part",JLPT JLPT_2
-統計,とうけい,"scattering, a scatter, dispersion",JLPT JLPT_2
-動作,どうさ,"action, movements, motions",JLPT JLPT_2
-東西,とうざい,"East and West, whole country",JLPT JLPT_2
-当日,とうじつ,"appointed day, very day",JLPT JLPT_2
-投書,とうしょ,"letter to the editor, letter from a reader, contribution",JLPT_2 JLPT Intermediate_Japanese_Ln.15 Intermediate_Japanese
-登場,とうじょう,entry (on stage),JLPT JLPT_2
-どうせ,どうせ,"anyhow, in any case, at any rate",JLPT JLPT_2
-灯台,とうだい,lighthouse,JLPT JLPT_2
-盗難,とうなん,"theft, robbery",JLPT JLPT_2
-当番,とうばん,being on duty,JLPT JLPT_2
-等分,とうぶん,division into equal parts,JLPT JLPT_2
-透明,とうめい,"transparency, cleanness",JLPT JLPT_2
-灯油,とうゆ,"lamp oil, kerosene",JLPT JLPT_2
-童話,どうわ,fairy tale,JLPT JLPT_2
-～通り,～とおり,"in accordance with ~; following ~; ~ street, ~ avenue",JLPT JLPT_2
-通り掛かる,とおりかかる,to happen to pass by,JLPT JLPT_2
-溶かす,とかす,"to melt, to dissolve",JLPT JLPT_2
-尖る,とがる,"to taper to a point, to become sharp",JLPT JLPT_2
-どきどき,どきどき,"throb, beat (fast)",JLPT JLPT_2
-特殊,とくしゅ,"special, unique",JLPT JLPT_2
-特色,とくしょく,"characteristic, feature",JLPT JLPT_2
-特定,とくてい,"specific, special, particular",JLPT JLPT_2
-特売,とくばい,special sale,JLPT JLPT_2
-溶け込む,とけこむ,to melt into; to become a part of,JLPT JLPT_2 Intermediate_Japanese Intermediate_Japanese_Ln.11
-退ける,どける,"to dislodge, to put something out of the way",JLPT JLPT_2
-床の間,とこのま,alcove,JLPT JLPT_2
-～ところ,～ところ,about to do ~,JLPT JLPT_2
-所々,ところどころ,"here and there, some parts (of something)",JLPT JLPT_2
-都心,としん,heart (of city),JLPT JLPT_2
-戸棚,とだな,"cupboard, cabinet",JLPT JLPT_2
-とっくに,とっくに,"long ago, already, a long time ago",JLPT JLPT_2
-どっと,どっと,suddenly,JLPT JLPT_2
-整う,ととのう,"to be prepared, to be in order, to be arranged",JLPT JLPT_2
-留まる,とどまる,"to be fixed; to abide, to stay (in the one place)",JLPT JLPT_2
-怒鳴る,どなる,"to shout, to yell",JLPT JLPT_2
-殿,どの,Mister (mostly in addressing someone on an envelope),JLPT JLPT_2
-飛び込む,とびこむ,"to jump in, to leap in, to plunge into",JLPT JLPT_2
-留まる,とまる,"to be fixed; to abide, to stay (in the one place)",JLPT JLPT_2
-ともかく,ともかく,"anyhow, at any rate, anyway",JLPT JLPT_2
-捕える,とらえる,"to seize, to capture, to arrest",JLPT JLPT_2
-取り入れる,とりいれる,"to harvest, to take in, to adopt",JLPT JLPT_2
-取り消す,とりけす,to cancel,JLPT JLPT_2
-取り出す,とりだす,"to take out, to pick out",JLPT JLPT_2
-採る,とる,"to adopt (measure, proposal); to pick (fruit)",JLPT JLPT_2
-捕る,とる,"to take, to catch (fish)",JLPT JLPT_2
-丼,どんぶり,"porcelain bowl, bowl of rice with food on top",JLPT JLPT_2
-～内,～ない,inside ~,JLPT JLPT_2
-内科,ないか,"internist clinic, internal medicine",JLPT JLPT_2
-内線,ないせん,phone extension,JLPT JLPT_2
-ナイロン,ナイロン,nylon,JLPT JLPT_2
-長～,なが～,long ~,JLPT JLPT_2
-仲直り,なかなおり,"reconciliation, make peace with",JLPT JLPT_2
-長引く,ながびく,"to be prolonged, to drag on",JLPT JLPT_2
-中指,なかゆび,middle finger,JLPT JLPT_2
-仲良し,なかよし,"intimate friend, bosom buddy",JLPT JLPT_2
-慰める,なぐさめる,"to comfort, to console",JLPT JLPT_2
-為す,なす,"to accomplish, to do",JLPT JLPT_2
-謎謎,なぞなぞ,riddle,JLPT JLPT_2
-傾らか,なだらか,"gradual, gentle",JLPT JLPT_2
-懐かしい,なつかしい,"dear, desired, missed",JLPT JLPT_2
-撫でる,なでる,"to brush gently, to stroke",JLPT JLPT_2
-斜め,ななめ,"diagonal, oblique",JLPT JLPT_2
-なにしろ,なにしろ,"at any rate, in any case",JLPT JLPT_2
-何々,なになに,"such and such, What?",JLPT JLPT_2
-何分,なにぶん,"by all means, please",JLPT JLPT_2
-生意気,なまいき,"impertinent, impudent",JLPT JLPT_2
-並木,なみき,"roadside tree, row of trees",JLPT JLPT_2
-倣う,ならう,"to imitate, to follow, to emulate",JLPT JLPT_2
-南極,なんきょく,"south pole, Antarctic",JLPT JLPT_2
-なんとなく,なんとなく,"somehow or other, for some reason or another",JLPT JLPT_2
-なんとも,なんとも,"nothing (with neg. verb), quite, not a bit",JLPT JLPT_2
-ナンバー,ナンバー,number,JLPT JLPT_2
-南米,なんべい,South America,JLPT_2 JLPT Intermediate_Japanese_Ln.15 Intermediate_Japanese
-南北,なんぼく,south and north,JLPT JLPT_2
-匂う,におう,"to be fragrant, to smell",JLPT JLPT_2
-逃がす,にがす,"to let loose, to set free, to let escape",JLPT JLPT_2
-憎い,にくい,"hateful, abominable, detestable",JLPT JLPT_2
-～難い,～がたい,hard (difficult) to do ~,JLPT_1 JLPT JLPT_2
-憎む,にくむ,"to hate, to detest",JLPT JLPT_2
-憎らしい,にくらしい,"odious, hateful",JLPT JLPT_2
-にこにこ,にこにこ,"smile sweetly, smiley",JLPT JLPT_2
-濁る,にごる,"to become muddy, to get cloudy",JLPT JLPT_2
-虹,にじ,rainbow,JLPT JLPT_2
-日時,にちじ,date and time,JLPT JLPT_2
-日用品,にちようひん,daily necessities,JLPT JLPT_2
-日課,にっか,"daily work, daily routine",JLPT JLPT_2
-日程,にってい,schedule,JLPT JLPT_2
-鈍い,にぶい,"dull (e.g., a knife), thickheaded, slow (opposite of fast), stupid",JLPT JLPT_2
-入社,にゅうしゃ,entry to a company,JLPT JLPT_2
-女房,にょうぼう,wife,JLPT JLPT_2
-睨む,にらむ,"to glare at, to stare; to keep an eye on",JLPT JLPT_2
-俄,にわか,"sudden, abrupt, unexpected",JLPT JLPT_2
-縫う,ぬう,to sew,JLPT JLPT_2
-ねじ,ねじ,(a) screw,JLPT JLPT_2
-捩る,ねじる,to twist,JLPT JLPT_2
-ネックレス,ネックレス,necklace,JLPT JLPT_2
-熱する,ねっする,to heat,JLPT JLPT_2
-寝間着,ねまき,"sleep-wear, pajamas",JLPT JLPT_2
-寝巻,ねまき,"sleep-wear, pajamas",JLPT JLPT_2
-狙い,ねらい,aim,JLPT JLPT_2
-狙う,ねらう,to aim at,JLPT JLPT_2
-～年生,～ねんせい,counter for school year,JLPT JLPT_2
-年度,ねんど,"year, fiscal year",JLPT JLPT_2
-農産物,のうさんぶつ,agricultural produce,JLPT JLPT_2
-農村,のうそん,agricultural community,JLPT JLPT_2
-濃度,のうど,"concentration, density",JLPT JLPT_2
-農薬,のうやく,agricultural chemicals,JLPT JLPT_2
-能率,のうりつ,efficiency,JLPT JLPT_2
-のこぎり,のこぎり,saw,JLPT JLPT_2
-残らず,のこらず,"completely, without exception",JLPT JLPT_2
-上り,のぼり,"up-train (going to Tokyo), ascent",JLPT JLPT_2
-糊,のり,"glue, paste, starch",JLPT JLPT_2
-乗換,のりかえ,"a transfer (e.g., trains, buses)",JLPT JLPT_2
-乗り越し,のりこし,riding past (one's station),JLPT JLPT_2
-鈍い,のろい,"dull (e.g., a knife), slow (opposite of fast), stupid",JLPT JLPT_2
-のろのろ,のろのろ,"slowly, sluggishly",JLPT JLPT_2
-呑気,のんき,"carefree, optimistic, careless",JLPT JLPT_2
-はい (かん),はい (かん),yes,JLPT JLPT_2
-灰色,はいいろ,"grey, ashen",JLPT JLPT_2
-俳句,はいく,haiku poetry,JLPT JLPT_2
-売店,ばいてん,"shop, stand",JLPT JLPT_2
-バイバイ,バイバイ,bye bye,JLPT JLPT_2
-売買,ばいばい,"trade, buying and selling",JLPT JLPT_2
-這う,はう,"to creep, to crawl",JLPT JLPT_2
-剥す,はがす,"to tear off, to peel off, to rip off",JLPT JLPT_2
-ばからしい,ばからしい,absurd,JLPT JLPT_2
-秤,はかり,"scales, weighing machine",JLPT JLPT_2
-吐き気,はきけ,"nausea, sickness in the stomach",JLPT JLPT_2
-はきはき,はきはき,clearly,JLPT JLPT_2
-～泊,～はく,"counter for staying (e.g., 2 nights)",JLPT JLPT_2
-歯車,はぐるま,"gear, cog-wheel",JLPT JLPT_2
-バケツ,バケツ,"bucket, pail",JLPT JLPT_2
-挟まる,はさまる,"to get between, to be caught in",JLPT JLPT_2
-挟む,はさむ,to pinch; to hold between; to insert,JLPT JLPT_2
-梯子,はしご,"ladder, stairs",JLPT JLPT_2
-始めに,はじめに,"to begin with, first of all",JLPT JLPT_2
-初めに,はじめに,"to begin with, first of all",JLPT JLPT_2
-はじめまして,はじめまして,"How do you do, I am glad to meet you",JLPT JLPT_2
-斜,はす,diagonal,JLPT JLPT_2
-パターン,パターン,pattern,JLPT JLPT_2
-肌着,はだぎ,underwear,JLPT JLPT_2
-果して,はたして,"as was expected, really",JLPT JLPT_2
-鉢,はち,"a bowl, a pot",JLPT JLPT_2
-～発,～はつ,counter for bullets,JLPT JLPT_2
-×,ばつ,cross,JLPT JLPT_2
-発揮,はっき,"exhibition, demonstration, display",JLPT JLPT_2
-バック,バック,back,JLPT JLPT_2
-発想,はっそう,idea; way of thinking (same as 考え方 (かんがえかた)),JLPT_2 JLPT Intermediate_Japanese_Ln.15 Intermediate_Japanese
-発電,はつでん,"generation (e.g., power)",JLPT JLPT_2
-発売,はつばい,sale,JLPT JLPT_2
-話合い,はなしあい,"discussion, talk",JLPT JLPT_2
-話し掛ける,はなしかける,"to accost a person, to talk (to someone)",JLPT JLPT_2
-話中,はなしちゅう,"while talking, the line is busy",JLPT JLPT_2
-甚だしい,はなはだしい,"extreme, excessive, terrible",JLPT JLPT_2
-花火,はなび,fireworks,JLPT JLPT_2
-花嫁,はなよめ,bride,JLPT JLPT_2
-ばね,ばね,"spring (e.g., coil, leaf)",JLPT JLPT_2
-跳ねる,はねる,"to jump, to leap",JLPT JLPT_2
-破片,はへん,"fragment, broken piece",JLPT JLPT_2
-歯磨き,はみがき,"toothbrushing, toothpaste",JLPT JLPT_2
-はめる,はめる,"(col) to get in, to insert, to put on",JLPT JLPT_2
-早口,はやくち,fast-talking,JLPT JLPT_2
-払い込む,はらいこむ,"to deposit, to pay in",JLPT JLPT_2
-払い戻す,はらいもどす,"to repay, to pay back",JLPT JLPT_2
-針金,はりがね,wire,JLPT JLPT_2
-張り切る,はりきる,"to be in high spirits, to be full of vigor",JLPT JLPT_2
-反～,はん～,"anti ~, counter ~",JLPT JLPT_2
-反映,はんえい,"reflection, influence",JLPT JLPT_2
-半径,はんけい,radius,JLPT JLPT_2
-判子,はんこ,seal (used for signature),JLPT JLPT_2
-万歳,ばんざい,"banzai, Long live ~!",JLPT JLPT_2
-判事,はんじ,"judge, justice",JLPT JLPT_2
-番地,ばんち,"house number, address",JLPT JLPT_2
-パンツ,パンツ,underpants,JLPT_2 JLPT Genki_Ln.10 Genki
-バンド,バンド,band,JLPT JLPT_2
-半島,はんとう,peninsula,JLPT JLPT_2
-ハンドル,ハンドル,"handle, steering wheel",JLPT JLPT_2
-～番目,～ばんめ,~th,JLPT JLPT_2
-非～,ひ～,"anti~, counter~, an~, non~",JLPT_1 JLPT JLPT_2
-～費,～ひ,cost of ~,JLPT JLPT_2
-日当たり,ひあたり,"exposure to the sun, sunny place",JLPT JLPT_2
-日帰り,ひがえり,day trip,JLPT JLPT_2
-比較的,ひかくてき,comparatively; relatively,Intermediate_Japanese_Ln.5 JLPT JLPT_2 Intermediate_Japanese
-日陰,ひかげ,shadow,JLPT JLPT_2
-ぴかぴか,ぴかぴか,"glitter, sparkle",JLPT JLPT_2
-引受る,ひきうける,"to undertake, to take up, to take over",JLPT JLPT_2
-引き返す,ひきかえす,"to turn back, to go back, reverse",JLPT JLPT_2
-引算,ひきざん,subtraction,JLPT JLPT_2
-引き出す,ひきだす,"to pull out, to take out, to withdraw",JLPT JLPT_2
-引き止める,ひきとめる,"to keep back, to prevent, to hold back",JLPT JLPT_2
-卑怯,ひきょう,"cowardice, meanness, unfairness",JLPT JLPT_2
-引分け,ひきわけ,"a draw (in competition), tie game",JLPT JLPT_2
-陽射,ひざし,"sunlight, rays of the sun",JLPT JLPT_2
-肘,ひじ,elbow,JLPT JLPT_2
-ピストル,ピストル,pistol,JLPT JLPT_2
-ビタミン,ビタミン,vitamin,JLPT JLPT_2
-ぴたり,ぴたり,exactly; close-fitting,JLPT JLPT_2
-引っ掛かる,ひっかかる,"to be caught in, to be stuck in",JLPT JLPT_2
-筆記,ひっき,"note taking, writing",JLPT JLPT_2
-引っ繰り返す,ひっくりかえす,"to turn over, to overturn, to knock over",JLPT JLPT_2
-引っ繰り返る,ひっくりかえる,"to be overturned, to be upset, to topple over, to be reversed",JLPT JLPT_2
-引っ込む,ひっこむ,"to draw back, to sink, to cave in",JLPT JLPT_2
-筆者,ひっしゃ,"writer, author",JLPT JLPT_2
-必需品,ひつじゅひん,"necessities, essential",JLPT JLPT_2
-一～,ひと～,one ~,JLPT JLPT_2
-人差指,ひとさしゆび,index finger,JLPT JLPT_2
-一通り,ひととおり,"general, briefly",JLPT JLPT_2
-人通り,ひとどおり,pedestrian traffic,JLPT JLPT_2
-ひとまず,ひとまず,"for the present, once, for the time being",JLPT JLPT_2
-瞳,ひとみ,pupil (of eye),JLPT JLPT_2
-一休み,ひとやすみ,a rest,JLPT JLPT_2
-独り言,ひとりごと,"a soliloquy, a monologue, speaking to oneself",JLPT JLPT_2
-ひとりでに,ひとりでに,"by itself, automatically, naturally",JLPT JLPT_2
-ビニール,ビニール,vinyl,JLPT JLPT_2
-皮肉,ひにく,"cynicism, sarcasm",JLPT JLPT_2
-日日,ひにち,date,JLPT JLPT_2
-捻る,ひねる,"to twist, to turn",JLPT JLPT_2
-日の入り,ひのいり,sunset,JLPT JLPT_2
-日の出,ひので,sunrise,JLPT JLPT_2
-響き,ひびき,"echo, sound",JLPT JLPT_2
-響く,ひびく,to resound; to affect,JLPT JLPT_2
-皮膚,ひふ,skin,JLPT JLPT_2
-ひゃっかじてん,ひゃっかじてん,encyclopedia,JLPT JLPT_2
-美容,びよう,beauty of figure or form,JLPT JLPT_2
-～病,～びょう,kind of disease,JLPT JLPT_2
-表紙,ひょうし,"front cover, binding",JLPT JLPT_2
-標識,ひょうしき,"sign, mark",JLPT JLPT_2
-標準,ひょうじゅん,"standard, level",JLPT JLPT_2
-標本,ひょうほん,"example, specimen",JLPT JLPT_2
-評論,ひょうろん,"criticism, critique",JLPT JLPT_2
-ビルディング,ビルディング,building,JLPT JLPT_2
-昼寝,ひるね,"nap (at home), siesta",JLPT JLPT_2
-広さ,ひろさ,extent,JLPT JLPT_2
-広場,ひろば,plaza,JLPT JLPT_2
-広々,ひろびろ,"extensive, spacious",JLPT JLPT_2
-ピンク,ピンク,pink,JLPT JLPT_2
-便箋,びんせん,"writing paper, stationery",JLPT JLPT_2
-瓶詰,びんづめ,"bottling, bottled",JLPT JLPT_2
-～部,～ぶ,~ part,JLPT JLPT_2
-ファスナー,ファスナー,"fastener, zipper",JLPT JLPT_2
-～風,～ふう,~ style,JLPT JLPT_2
-風船,ふうせん,balloon,JLPT JLPT_2
-不運,ふうん,"unlucky, misfortune, bad luck",JLPT JLPT_2
-不規則,ふきそく,"irregularity, unsteadiness",JLPT JLPT_2
-普及,ふきゅう,"diffusion, spread",JLPT JLPT_2
-付近,ふきん,"neighborhood, vicinity",JLPT JLPT_2
-副～,ふく～,vice ~,JLPT JLPT_2
-副詞,ふくし,adverb,JLPT JLPT_2
-複写,ふくしゃ,"copy, duplicate",JLPT JLPT_2
-複数,ふくすう,"plural, multiple",JLPT JLPT_2
-膨らます,ふくらます,"to swell, to expand, to inflate",JLPT JLPT_2
-膨らむ,ふくらむ,"to expand, to swell (out), to become inflated",JLPT JLPT_2
-不潔,ふけつ,"unclean, dirty",JLPT JLPT_2
-更ける,ふける,"to get late, to wear on",JLPT JLPT_2
-符号,ふごう,"sign, mark, symbol",JLPT JLPT_2
-夫妻,ふさい,"man and wife, married couple",JLPT JLPT_2
-塞がる,ふさがる,"to be plugged up, to be shut up",JLPT JLPT_2
-塞ぐ,ふさぐ,"to stuff, to close up, to block (up)",JLPT JLPT_2
-ふざける,ふざける,"to romp, to gambol, to frolic",JLPT JLPT_2
-無沙汰,ぶさた,neglecting to stay in contact,JLPT JLPT_2
-武士,ぶし,"warrior, samurai",JLPT JLPT_2
-部首,ぶしゅ,radical (of a kanji character),JLPT JLPT_2
-襖,ふすま,sliding screen,JLPT JLPT_2
-附属,ふぞく,"attached, belonging, affiliated",JLPT JLPT_2
-蓋,ふた,"cover, lid, cap",JLPT JLPT_2
-物騒,ぶっそう,"dangerous, disturbed, insecure",JLPT JLPT_2
-ぶつぶつ,ぶつぶつ,"grumbling, complaining in a small voice",JLPT JLPT_2
-船便,ふなびん,surface mail (ship),JLPT JLPT_2
-部品,ぶひん,"parts, accessories",JLPT JLPT_2
-吹雪,ふぶき,snow storm,JLPT JLPT_2
-父母,ふぼ,"father and mother, parents",JLPT JLPT_2
-踏切,ふみきり,"railway crossing, level crossing, starting line, scratch, crossover",JLPT JLPT_2
-麓,ふもと,"the foot, the bottom, the base (of a mountain)",JLPT JLPT_2
-フライパン,フライパン,"fry pan, frying pan",JLPT JLPT_2
-ブラウス,ブラウス,blouse,JLPT JLPT_2
-ぶらさげる,ぶらさげる,"to hang, to suspend, to swing",JLPT JLPT_2
-ブラシ,ブラシ,brush,JLPT JLPT_2
-プラットホーム,プラットホーム,platform,JLPT JLPT_2
-～振り,～ぶり,after an interval of ~,JLPT JLPT_2
-フリー,フリー,free,JLPT JLPT_2
-振り仮名,ふりがな,pronunciation key,JLPT JLPT_2
-振り向く,ふりむく,"to turn one's face, to turn around",JLPT JLPT_2
-プリント,プリント,"print, handout",JLPT JLPT_2
-古～,ふる～,old ~,JLPT JLPT_2
-故郷,ふるさと,"home town, birthplace",JLPT JLPT_2
-古里,ふるさと,"home town, birthplace",JLPT JLPT_2
-振舞う,ふるまう,"to behave, to conduct",JLPT JLPT_2
-ブローチ,ブローチ,brooch,JLPT JLPT_2
-プログラム,プログラム,program,JLPT JLPT_2
-風呂敷,ふろしき,"wrapping cloth, cloth wrapper",JLPT JLPT_2
-ふわふわ,ふわふわ,"light, soft",JLPT JLPT_2
-噴火,ふんか,eruption,JLPT JLPT_2
-分解,ぶんかい,"analysis, disassembly",JLPT JLPT_2
-文芸,ぶんげい,"literature, art and literature",JLPT JLPT_2
-文献,ぶんけん,"literature, books (reference)",JLPT JLPT_2
-噴水,ふんすい,water fountain,JLPT JLPT_2
-分数,ぶんすう,fraction (in math),JLPT JLPT_2
-文体,ぶんたい,literary style,JLPT JLPT_2
-分布,ぶんぷ,distribution,JLPT JLPT_2
-文房具,ぶんぼうぐ,stationery,JLPT JLPT_2
-文脈,ぶんみゃく,context,JLPT JLPT_2
-分量,ぶんりょう,"amount, quantity",JLPT JLPT_2
-分類,ぶんるい,classification,JLPT JLPT_2
-閉会,へいかい,closure,JLPT JLPT_2
-平気,へいき,"coolness, calmness, unconcern",JLPT JLPT_2
-並行,へいこう,"(going) side by side, concurrent, at the same time",JLPT_1 JLPT JLPT_2
-平日,へいじつ,weekday,JLPT JLPT_2
-兵隊,へいたい,soldier,JLPT JLPT_2
-平凡,へいぼん,"common, ordinary",JLPT JLPT_2
-平野,へいや,"plain, open field",JLPT JLPT_2
-凹む,へこむ,"to be dented, to be indented",JLPT JLPT_2
-へそ,へそ,"navel, belly-button",JLPT JLPT_2
-隔てる,へだてる,to be shut out,JLPT JLPT_2
-別荘,べっそう,villa; vacation home; summer cottage,JLPT Intermediate_Japanese Genki_Ln.23 JLPT_2 Intermediate_Japanese_Ln.13 Genki
-別々,べつべつ,"separately, individually",JLPT JLPT_2
-ベテラン,ベテラン,veteran,JLPT JLPT_2
-ヘリコプター,ヘリコプター,helicopter,JLPT JLPT_2
-～遍,～へん,time,JLPT JLPT_2
-～弁,～べん,"speech, dialect",JLPT JLPT_2
-編集,へんしゅう,"editing, compilation, editorial (e.g., committee)",JLPT JLPT_2 Intermediate_Japanese_Ln.8 Intermediate_Japanese
-便所,べんじょ,"toilet, lavatory",JLPT JLPT_2
-ペンチ,ペンチ,pliers (lit: pinchers),JLPT JLPT_2
-～歩,～ほ,"step, pace",JLPT JLPT_2
-～ぽい,～ぽい,~ish,JLPT JLPT_2
-～ほう (ひかく),～ほう (ひかく),(in comparison),JLPT JLPT_2
-防～,ぼう～,~ prevention,JLPT JLPT_2
-望遠鏡,ぼうえんきょう,telescope,JLPT JLPT_2
-方角,ほうがく,"direction, way",JLPT JLPT_2
-箒,ほうき,broom,JLPT JLPT_2
-方言,ほうげん,dialect,JLPT JLPT_2
-坊さん,ぼうさん,"Buddhist priest, monk",JLPT JLPT_2
-防止,ぼうし,"prevention, check",JLPT JLPT_2
-方針,ほうしん,"objective, plan, policy",JLPT JLPT_2
-法則,ほうそく,"law, rule",JLPT JLPT_2
-包帯,ほうたい,bandage,JLPT JLPT_2
-膨大,ぼうだい,"enormous, extensive",JLPT JLPT_2
-包丁,ほうちょう,"kitchen knife, carving knife",JLPT JLPT_2
-方程式,ほうていしき,equation,JLPT JLPT_2
-防犯,ぼうはん,prevention of crime,JLPT JLPT_2
-方面,ほうめん,direction; area,JLPT JLPT_2 Intermediate_Japanese_Ln.8 Intermediate_Japanese
-坊や,ぼうや,boy,JLPT JLPT_2
-放る,ほうる,to let go,JLPT JLPT_2
-ボーナス,ボーナス,bonus,JLPT JLPT_2 Genki_Ln.23 Genki
-朗らか,ほがらか,"bright, cheerful, melodious",JLPT JLPT_2
-牧場,ぼくじょう,farm (livestock); pasture land,JLPT JLPT_2
-牧畜,ぼくちく,stock-farming,JLPT JLPT_2
-保健,ほけん,"health preservation, hygiene, sanitation",JLPT JLPT_2
-募集,ぼしゅう,recruitment,JLPT JLPT_2 Genki_Ln.13 Genki
-干す,ほす,"to air, to dry, to drink up",JLPT JLPT_2
-ポスター,ポスター,poster,JLPT_2 JLPT Genki_Ln.21 Genki
-北極,ほっきょく,North Pole,JLPT JLPT_2
-坊っちゃん,ぼっちゃん,son (of others),JLPT JLPT_2
-解く,ほどく,to unfasten,JLPT JLPT_2
-掘る,ほる,"to dig, to excavate",JLPT JLPT_2
-彫る,ほる,"to carve, to chisel",JLPT JLPT_2
-ぼろ,ぼろ,"rag, tattered clothes",JLPT JLPT_2
-盆,ぼん,Festival of the Dead; tray,JLPT JLPT_2
-盆地,ぼんち,"basin (e.g., between mountains)",JLPT JLPT_2
-ほんの～,ほんの～,"mere, just",JLPT JLPT_2
-本部,ほんぶ,headquarters,JLPT JLPT_2
-本来,ほんらい,"essentially, naturally, by nature",JLPT JLPT_2
-まあまあ,まあまあ,okay; so-so; decent,JLPT JLPT_2 Genki_Ln.11 Genki
-毎～,まい～,every ~,JLPT JLPT_2
-枚数,まいすう,the number of flat things,JLPT JLPT_2
-毎度,まいど,"each time, common service-sector greeting",JLPT JLPT_2
-枕,まくら,pillow,JLPT JLPT_2
-曲げる,まげる,"to bend, to crook, to lean",JLPT JLPT_2
-まごまご,まごまご,"confused, be at a loss",JLPT JLPT_2
-摩擦,まさつ,friction; rubbing; chafe,JLPT_2 JLPT Intermediate_Japanese_Ln.15 Intermediate_Japanese
-マスク,マスク,mask,JLPT JLPT_2
-またぐ,またぐ,to straddle,JLPT JLPT_2
-待合室,まちあいしつ,waiting room,JLPT JLPT_2
-待ち合わせる,まちあわせる,"to rendezvous, to meet at a prearranged place and time",JLPT JLPT_2
-街角,まちかど,street corner,JLPT JLPT_2
-真っ暗,まっくら,total darkness,JLPT JLPT_2
-真っ黒,まっくろ,pitch black,JLPT JLPT_2
-真っ青,まっさお,"deep blue, ghastly pale",JLPT JLPT_2
-真っ先,まっさき,"foremost, beginning",JLPT JLPT_2
-真っ白,まっしろ,pure white,JLPT JLPT_2
-祭る,まつる,"to deify, to enshrine",JLPT JLPT_2
-窓口,まどぐち,(ticket) window,JLPT JLPT_2 Intermediate_Japanese_Ln.10 Intermediate_Japanese
-真似る,まねる,"to mimic, to imitate",JLPT JLPT_2
-まぶた,まぶた,eyelids,JLPT JLPT_2
-マフラー,マフラー,a winter scarf,JLPT_2 JLPT Genki_Ln.14 Genki
-間も無く,まもなく,"soon, in a short time",JLPT JLPT_2
-マラソン,マラソン,marathon,JLPT JLPT_2
-稀,まれ,"rare, seldom",JLPT JLPT_2
-回り道,まわりみち,detour,JLPT JLPT_2
-満員,まんいん,"full house, no vacancy, sold out",JLPT JLPT_2
-マンション,マンション,"multistory apartment house, condominium",JLPT_2 JLPT Genki_Ln.14 Genki
-満点,まんてん,perfect score,JLPT JLPT_2
-未～,み～,not yet ~,JLPT JLPT_2
-見上げる,みあげる,"to look up at, to admire",JLPT JLPT_2
-見送る,みおくる,to see off; to escort; to let pass,JLPT JLPT_2
-見下ろす,みおろす,"to overlook, to look down on something",JLPT JLPT_2
-見掛け,みかけ,outward appearance,JLPT JLPT_2
-三日月,みかづき,crescent moon,JLPT JLPT_2
-岬,みさき,cape (on coast),JLPT JLPT_2
-みじめ,みじめ,"sad, pitiful, wretched",JLPT JLPT_2
-ミシン,ミシン,sewing machine,JLPT JLPT_2
-自ら,みずから,"for one's self, personally",JLPT JLPT_2
-水着,みずぎ,bathing suit (woman's),JLPT JLPT_2
-店屋,みせや,"store, shop",JLPT JLPT_2
-～みたい,～みたい,looks like ~,JLPT JLPT_2
-見出し,みだし,"heading, index",JLPT JLPT_2
-道順,みちじゅん,"itinerary, route",JLPT JLPT_2
-みっともない,みっともない,"shameful, indecent",JLPT JLPT_2 Intermediate_Japanese Intermediate_Japanese_Ln.11
-見詰める,みつめる,"to stare at, to gaze at",JLPT JLPT_2
-見直す,みなおす,"to look over again, to review",JLPT JLPT_2
-見慣れる,みなれる,"to become used to seeing, to be familiar with",JLPT JLPT_2
-醜い,みにくい,ugly,JLPT JLPT_2 Intermediate_Japanese_Ln.10 Intermediate_Japanese
-実る,みのる,"to bear fruit, to ripen",JLPT JLPT_2
-身分,みぶん,"position, status",JLPT JLPT_2
-見本,みほん,sample,JLPT JLPT_2
-見舞う,みまう,"to ask after (health), to visit",JLPT JLPT_2
-未満,みまん,"less than, insufficient",JLPT JLPT_2
-名字,みょうじ,"surname, family name",JLPT JLPT_2
-ミリ (メートル),ミリ (メートル),milli-,JLPT JLPT_2
-民間,みんかん,"private, civilian",JLPT JLPT_2
-民主～,みんしゅ～,democratic,JLPT JLPT_2
-民謡,みんよう,"folk song, popular song",JLPT JLPT_2
-～向け,～むけ,for ~,JLPT JLPT_2
-無限,むげん,infinite,JLPT JLPT_2
-無地,むじ,plain,JLPT JLPT_2
-矛盾,むじゅん,"contradiction, inconsistency",JLPT JLPT_2
-無数,むすう,"countless number, infinite number",JLPT JLPT_2
-紫,むらさき,"purple color, violet",JLPT JLPT_2
-群れ,むれ,"crowd, flock, herd",JLPT JLPT_2
-姪,めい,niece,JLPT JLPT_2 Intermediate_Japanese_Ln.8 Intermediate_Japanese
-名～,めい～,famous ~,JLPT JLPT_2
-～名,～めい,counter for people,JLPT JLPT_2
-名作,めいさく,masterpiece,JLPT JLPT_2
-名所,めいしょ,famous place,JLPT JLPT_2
-命ずる,めいずる,"to command, to appoint",JLPT JLPT_2
-迷信,めいしん,superstition,JLPT JLPT_2
-名物,めいぶつ,"famous product, special product, speciality",JLPT JLPT_2
-銘々,めいめい,"each, individual",JLPT JLPT_2
-恵まれる,めぐまれる,"to be blessed with, to be rich in",JLPT JLPT_2
-巡る,めぐる,to go around,JLPT JLPT_2
-目指す,めざす,"to aim at, to have an eye on",JLPT JLPT_2
-目覚し,めざまし,alarm-clock,JLPT JLPT_2
-目下,めした,"at present, now",JLPT JLPT_2
-目印,めじるし,"mark, sign, landmark",JLPT JLPT_2
-目立つ,めだつ,"to be conspicuous, to stand out",JLPT JLPT_2
-めちゃくちゃ,めちゃくちゃ,"absurd, messed up, wrecked",JLPT JLPT_2
-めっきり,めっきり,remarkably,JLPT JLPT_2
-めでたい,めでたい,"happy, propitious, joyous",JLPT JLPT_2
-メニュー,メニュー,menu,JLPT Intermediate_Japanese JLPT_2 Intermediate_Japanese_Ln.6 Genki_Ln.2 Genki
-めまい,めまい,"dizziness, giddiness",JLPT JLPT_2
-目安,めやす,"criterion, aim",JLPT JLPT_2
-免税,めんぜい,tax exemption,JLPT JLPT_2
-面積,めんせき,area,JLPT JLPT_2
-面倒臭い,めんどうくさい,"bother to do, tiresome",JLPT JLPT_2
-儲かる,もうかる,"to be profitable, to yield a profit",JLPT JLPT_2
-儲ける,もうける,"to earn, to have (bear, beget) a child",JLPT JLPT_2
-申し訳ない,もうしわけない,"inexcusable, I am sorry",JLPT JLPT_2
-モーター,モーター,motor,JLPT JLPT_2
-木材,もくざい,"lumber, timber, wood",JLPT JLPT_2
-目次,もくじ,table of contents,JLPT JLPT_2
-潜る,もぐる,"to dive, to pass through; to evade, to hide",JLPT JLPT_2
-もしかしたら,もしかしたら,"perhaps, maybe, by some chance",JLPT JLPT_2
-もたれる,もたれる,"to lean against, to lean on",JLPT JLPT_2
-モダン,モダン,modern,JLPT JLPT_2
-餅,もち,sticky rice cake,JLPT JLPT_2
-～もち,～もち,person who has ~,JLPT JLPT_2
-モデル,モデル,a fashion model,JLPT JLPT_2 Intermediate_Japanese_Ln.8 Intermediate_Japanese
-元々,もともと,"originally, by nature, from the start",JLPT JLPT_2
-物置,ものおき,storage room,JLPT JLPT_2
-物語る,ものがたる,"to tell, to indicate",JLPT JLPT_2
-物差し,ものさし,"ruler, measure",JLPT JLPT_2
-物凄い,ものすごい,"earth-shattering, staggering, to a very great extent",JLPT JLPT_2
-モノレール,モノレール,monorail,JLPT JLPT_2
-紅葉,もみじ,(Japanese) maple,JLPT JLPT_2
-揉む,もむ,"to rub, to crumple (up), to wrinkle",JLPT JLPT_2
-催し,もよおし,"event, festivities, function",JLPT JLPT_2
-盛る,もる,to serve (food); to fill up; to prescribe,JLPT JLPT_2
-～問,～もん,counter for questions,JLPT JLPT_2
-問答,もんどう,"questions and answers, dialogue",JLPT JLPT_2
-～夜,～や,counter for nights,JLPT JLPT_2
-やかましい,やかましい,"to be fussy, to be overly critical",JLPT JLPT_2 Intermediate_Japanese Intermediate_Japanese_Ln.11
-夜間,やかん,"at night, nighttime",JLPT JLPT_2
-やかん,やかん,kettle,JLPT JLPT_2
-役者,やくしゃ,actor,JLPT JLPT_2
-役所,やくしょ,"government office, public office",JLPT JLPT_2
-役人,やくにん,government official,JLPT JLPT_2
-薬品,やくひん,"medicine(s), chemical(s)",JLPT JLPT_2
-役目,やくめ,"duty, business",JLPT JLPT_2
-火傷,やけど,"burn, scald",JLPT JLPT_2
-夜行,やこう,"night train, night travel",JLPT JLPT_2
-矢印,やじるし,directing arrow,JLPT JLPT_2
-やたらに,やたらに,"randomly, recklessly, blindly",JLPT JLPT_2
-薬局,やっきょく,"pharmacy, drugstore",JLPT JLPT_2
-やっつける,やっつける,"to attack (an enemy), to beat, to finish off",JLPT JLPT_2
-家主,やぬし,landlord,JLPT JLPT_2
-やっぱり,やっぱり,"after all, anyway",Genki_Ln.17 JLPT JLPT_2 Genki
-破く,やぶく,to tear,JLPT JLPT_2
-やむをえない,やむをえない,"cannot be helped, unavoidable",JLPT JLPT_2
-軟らかい,やわらかい,"soft, tender, limp",JLPT JLPT_2
-遊園地,ゆうえんち,amusement park,JLPT JLPT_2
-夕刊,ゆうかん,evening paper,JLPT JLPT_2
-郵送,ゆうそう,mailing,JLPT JLPT_2
-夕立,ゆうだち,(sudden) evening shower (rain),JLPT JLPT_2
-夕日,ゆうひ,"(in) the evening sun, setting sun",JLPT JLPT_2
-悠々,ゆうゆう,"quiet, calm, leisurely",JLPT JLPT_2
-有料,ゆうりょう,"admission-paid, toll",JLPT JLPT_2
-浴衣,ゆかた,"bathrobe, informal summer kimono",JLPT JLPT_2 Intermediate_Japanese_Ln.10 Intermediate_Japanese
-行方,ゆくえ,one's whereabouts,JLPT JLPT_2
-湯気,ゆげ,steam,JLPT JLPT_2
-輸血,ゆけつ,blood transfusion,JLPT JLPT_2
-輸送,ゆそう,"transport, transportation",JLPT JLPT_2
-油断,ゆだん,"negligence, unpreparedness",JLPT JLPT_2
-湯飲み,ゆのみ,teacup,JLPT JLPT_2
-緩い,ゆるい,"loose, lenient, slow",JLPT JLPT_2
-溶岩,ようがん,lava,JLPT JLPT_2
-用語,ようご,"term, terminology",JLPT JLPT_2 Intermediate_Japanese_Ln.2 Intermediate_Japanese
-要旨,ようし,"gist, essentials, summary",JLPT JLPT_2
-幼児,ようじ,"infant, baby, child",JLPT JLPT_2
-容積,ようせき,"capacity, volume",JLPT JLPT_2
-幼稚,ようち,"infancy, childish, infantile",JLPT JLPT_2
-幼稚園,ようちえん,kindergarten,JLPT_2 JLPT Intermediate_Japanese_Ln.15 Intermediate_Japanese
-用途,ようと,"use, usefulness",JLPT JLPT_2
-洋品店,ようひんてん,clothes store,JLPT JLPT_2
-養分,ようぶん,"nourishment, nutrient",JLPT JLPT_2
-羊毛,ようもう,wool,JLPT JLPT_2
-漸く,ようやく,"at last, finally, hardly",JLPT JLPT_2
-要領,ようりょう,"gist, essentials, outline",JLPT JLPT_2
-翌～,よく～,next ~,JLPT JLPT_2
-欲張り,よくばり,greedy,JLPT JLPT_2
-余計,よけい,"too much, unnecessary, abundance, surplus, excess, superfluity",JLPT JLPT_2
-よこす,よこす,"to send, to forward; to hand over (e.g., money)",JLPT JLPT_2
-余所,よそ,"another place, somewhere else, strange parts",JLPT JLPT_2
-四つ角,よつかど,"four corners, crossroads",JLPT JLPT_2
-酔っ払い,よっぱらい,drunkard,JLPT JLPT_2
-予備,よび,"preparation, spare",JLPT JLPT_2
-呼び掛ける,よびかける,"to call out to, to accost, to address (crowd), to appeal",JLPT JLPT_2
-呼び出す,よびだす,"to summon, to call (e.g., phone)",JLPT JLPT_2
-蘇る,よみがえる,"to be resurrected, to be revived",JLPT JLPT_2
-慶ぶ,よろこぶ,"to be delighted, to be glad",JLPT JLPT_2
-～等,～ら,plural persons,JLPT JLPT_2
-来日,らいにち,"coming to Japan, visit to Japan",JLPT JLPT_2
-落第,らくだい,"failure, dropping out of a class",JLPT JLPT_2
-ラッシュアワー,ラッシュアワー,rush hour,JLPT JLPT_2 Intermediate_Japanese_Ln.10 Intermediate_Japanese
-欄,らん,"column of text (e.g., as in a newspaper)",JLPT JLPT_2
-ランチ,ランチ,lunch,JLPT JLPT_2
-ランニング,ランニング,running; tank top,JLPT JLPT_2
-乱暴,らんぼう,"rude, violent, rough",JLPT JLPT_2
-理科,りか,science,JLPT JLPT_2
-利害,りがい,"advantages and disadvantages, interest",JLPT JLPT_2
-段階,だんかい,"gradation, grade, stage",JLPT JLPT_2
-短期,たんき,short term,JLPT JLPT_2
-炭鉱,たんこう,"coal mine, coal pit",JLPT JLPT_2
-短所,たんしょ,"defect, weak point; disadvantage",JLPT JLPT_2
-たんす,たんす,chest of drawers,JLPT JLPT_2
-淡水,たんすい,fresh water,JLPT JLPT_2
-断水,だんすい,water outage,JLPT JLPT_2
-単数,たんすう,singular (number),JLPT JLPT_2
-団地,だんち,housing complex,JLPT JLPT_2
-断定,だんてい,"conclusion, decision",JLPT JLPT_2
-短編,たんぺん,"short (e.g., story, film)",JLPT JLPT_2
-誓う,ちかう,"to swear, to vow",JLPT JLPT_2
-地下水,ちかすい,underground water,JLPT JLPT_2
-近々,ちかぢか,"soon, before long",JLPT JLPT_2
-近付ける,ちかづける,"to bring near, to put close, to let come near",JLPT JLPT_2
-近寄る,ちかよる,"to approach, to draw near",JLPT JLPT_2
-力強い,ちからづよい,"powerful, strong, vigorous",JLPT JLPT_2
-ちぎる,ちぎる,"to cut up fine, to pick (fruit)",JLPT JLPT_2
-地質,ちしつ,geological features,JLPT JLPT_2
-知人,ちじん,"friend, acquaintance",JLPT JLPT_2 Intermediate_Japanese_Ln.1 Intermediate_Japanese
-地帯,ちたい,"area, zone",JLPT JLPT_2
-縮む,ちぢむ,"to shrink, to be contracted",JLPT JLPT_2
-縮める,ちぢめる,"to shorten, to reduce, to shrink",JLPT JLPT_2
-縮れる,ちぢれる,"to be wavy, to be curled",JLPT JLPT_2
-チップ,チップ,"gratuity, tip; chip",Intermediate_Japanese_Ln.6 JLPT_2 JLPT Intermediate_Japanese
-地点,ちてん,"site, point on a map",JLPT JLPT_2
-地名,ちめい,place name,JLPT JLPT_2
-茶色い,ちゃいろい,brown,JLPT JLPT_2
-～着,～ちゃく,counter for clothes; finishing place,JLPT JLPT_2
-着々,ちゃくちゃく,steadily,JLPT JLPT_2
-中間,ちゅうかん,"middle, midway, interim",JLPT JLPT_2
-中旬,ちゅうじゅん,second third of a month,JLPT JLPT_2
-抽象,ちゅうしょう,abstract,JLPT JLPT_2
-中世,ちゅうせい,"Middle Ages, medieval times",JLPT JLPT_2
-中性,ちゅうせい,"neuter gender, neutral",JLPT JLPT_2
-中途,ちゅうと,"in the middle, half-way",JLPT JLPT_2
-中年,ちゅうねん,middle-aged,JLPT JLPT_2 Intermediate_Japanese_Ln.1 Intermediate_Japanese
-長～,ちょう～,long ~,JLPT JLPT_2
-～庁,～ちょう,"office, agency",JLPT JLPT_2
-～兆,～ちょう,trillion,JLPT JLPT_2
-～長,～ちょう,"leader, head",JLPT JLPT_2
-～帳,～ちょう,"~ book, notebook",JLPT JLPT_2
-超過,ちょうか,"excess, being more than",JLPT JLPT_2
-彫刻,ちょうこく,"carving, engraving, sculpture",JLPT JLPT_2
-長所,ちょうしょ,"strong point, merit; advantage",JLPT JLPT_2
-長女,ちょうじょ,eldest daughter,JLPT JLPT_2
-調整,ちょうせい,"regulation, adjustment, tuning",JLPT JLPT_2
-調節,ちょうせつ,"regulation, adjustment, control",JLPT JLPT_2
-長短,ちょうたん,"length, long and short, +-",JLPT JLPT_2
-頂点,ちょうてん,"top, summit",JLPT JLPT_2
-長男,ちょうなん,eldest son,JLPT JLPT_2
-長方形,ちょうほうけい,"rectangle, oblong",JLPT JLPT_2
-調味料,ちょうみりょう,"condiment, seasoning",JLPT JLPT_2
-～丁目,～ちょうめ,"~ district (of a town; city, block)",JLPT JLPT_2
-チョーク,チョーク,chalk,JLPT JLPT_2
-直後,ちょくご,immediately following,JLPT JLPT_2
-直線,ちょくせん,straight line,JLPT JLPT_2
-直前,ちょくぜん,just before,JLPT JLPT_2
-直通,ちょくつう,direct connection,JLPT JLPT_2
-直流,ちょくりゅう,direct current,JLPT JLPT_2
-貯蔵,ちょぞう,"storage, preservation",JLPT JLPT_2
-直角,ちょっかく,right angle,JLPT JLPT_2
-直径,ちょっけい,diameter,JLPT JLPT_2
-散らかす,ちらかす,"to scatter around, to leave untidy",JLPT JLPT_2
-散らかる,ちらかる,to be in disorder,JLPT JLPT_2
-塵紙,ちりがみ,"tissue paper, toilet paper",JLPT JLPT_2
-追加,ついか,"addition, supplement, appendix",JLPT JLPT_2
-ついで,ついで,"opportunity, occasion",JLPT JLPT_2
-～通,～つう,counter for letters,JLPT JLPT_2
-通ずる,つうずる,"to lead, to run, to open",JLPT JLPT_2
-通知,つうち,"notice, notification",JLPT JLPT_2
-通帳,つうちょう,bankbook,JLPT JLPT_2
-通用,つうよう,"popular use, circulation",JLPT JLPT_2
-通路,つうろ,"passage, pathway",JLPT JLPT_2
-～遣い,～づかい,use of ~,JLPT JLPT_2
-～付,～つき,with ~,JLPT JLPT_2
-突き当たり,つきあたり,"end (e.g., of street)",JLPT JLPT_2
-突き当たる,つきあたる,"to run into, to collide with",JLPT JLPT_2
-月日,つきひ,"time, years, days",JLPT JLPT_2
-～続く,～つづく,"follow, continue, go on",JLPT JLPT_2
-突っ込む,つっこむ,"to plunge into, to stick into",JLPT JLPT_2
-務める,つとめる,"to serve, to act",JLPT JLPT_2
-努める,つとめる,"to try, to aim",JLPT JLPT_2
-綱,つな,rope,JLPT JLPT_2
-繋がり,つながり,"connection, link, relationship",JLPT JLPT_2
-粒,つぶ,grain,JLPT JLPT_2
-潰す,つぶす,"to smash, to waste",JLPT JLPT_2
-潰れる,つぶれる,"to be smashed, to go bankrupt",JLPT JLPT_2
-つまずく,つまずく,"to stumble, to trip",JLPT JLPT_2
-詰まる,つまる,"to be blocked, to be packed",JLPT JLPT_2
-爪,つめ,fingernail or toenail,JLPT JLPT_2
-艶,つや,"gloss, glaze",JLPT JLPT_2
-強気,つよき,"firm, strong",JLPT JLPT_2
-～辛い,～づらい,hard to do ~,JLPT JLPT_2
-釣り合う,つりあう,"to balance, to be in harmony, to suit",JLPT JLPT_2
-吊る,つる,to hang,JLPT JLPT_2
-吊す,つるす,to hang,JLPT JLPT_2
-手洗い,てあらい,"restroom, lavatory",JLPT JLPT_2
-低～,てい～,low ~,JLPT JLPT_2
-定員,ていいん,"fixed number of regular personnel, capacity (e.g., of boat)",JLPT JLPT_2
-定価,ていか,established price,JLPT JLPT_2
-低下,ていか,"fall, decline",JLPT JLPT_2
-定期券,ていきけん,"commuter pass, season ticket",JLPT JLPT_2
-定休日,ていきゅうび,regular holiday,JLPT JLPT_2
-停止,ていし,"suspension, interruption, stoppage",JLPT JLPT_2
-停車,ていしゃ,"stopping (e.g., train)",JLPT JLPT_2
-出入り,でいり,"in and out, coming and going",JLPT JLPT_2
-出入口,でいりぐち,exit and entrance,JLPT JLPT_2
-手入れ,ていれ,"repairs, maintenance",JLPT JLPT_2
-テーマ,テーマ,"theme, project, topic (GER: Thema)",JLPT_2 JLPT Intermediate_Japanese_Ln.15 Intermediate_Japanese
-～滴,～てき,drop,JLPT JLPT_2
-出来上がり,できあがり,"be finished, ready",JLPT JLPT_2
-出来上がる,できあがる,"to be finished, to be ready",JLPT JLPT_2
-的確,てきかく,"precise, accurate",JLPT JLPT_2
-適確,てきかく,"precise, accurate",JLPT JLPT_2
-手首,てくび,wrist,JLPT JLPT_2
-凸凹,でこぼこ,"unevenness, roughness, ruggedness",JLPT JLPT_2
-手頃,てごろ,"moderate, handy",JLPT JLPT_2
-弟子,でし,"pupil, disciple, apprentice",JLPT JLPT_2
-でたらめ,でたらめ,"irresponsible utterance, nonsense; random",JLPT JLPT_2
-手帳,てちょう,notebook,JLPT JLPT_2
-鉄橋,てっきょう,iron bridge,JLPT JLPT_2
-手続き,てつづき,"procedure, (legal) process, formalities",JLPT JLPT_2
-鉄砲,てっぽう,gun,JLPT JLPT_2
-テニスコート,テニスコート,tennis court,JLPT JLPT_2
-手拭い,てぬぐい,(hand) towel,JLPT JLPT_2
-手前,てまえ,"before, this side",JLPT JLPT_2
-出迎え,でむかえ,"meeting, reception",JLPT JLPT_2
-照らす,てらす,"to shine on, to illuminate",JLPT JLPT_2
-照る,てる,to shine,JLPT JLPT_2
-～点,～てん,counter for scores,JLPT JLPT_2
-展開,てんかい,"develop, expansion (opposite of compression)",JLPT JLPT_2
-伝記,でんき,"biography, life story",JLPT JLPT_2
-電球,でんきゅう,light bulb,JLPT JLPT_2
-点数,てんすう,"marks, points, score",JLPT JLPT_2
-伝染,でんせん,contagion,JLPT JLPT_2
-電池,でんち,battery,Genki_Ln.15 JLPT_2 JLPT Genki
-点々,てんてん,"here and there, little by little",JLPT JLPT_2
-転々,てんてん,from one to another,JLPT JLPT_2
-電柱,でんちゅう,"telephone pole, telegraph pole, light pole",JLPT JLPT_2
-天皇,てんのう,Emperor of Japan,JLPT JLPT_2
+expression,reading,meaning,tags,guid
+就任,しゅうにん,"inauguration, assumption of office",JLPT JLPT_2,HtcOE.Q|y4
+周辺,しゅうへん,"circumference, peripheral",JLPT JLPT_2,hN?qSe;l/I
+重役,じゅうやく,"director, high executive",JLPT JLPT_2,nHZ3{$.oV6
+終了,しゅうりょう,"end, close, termination",JLPT_1 JLPT JLPT_2,bv?qBa-JLm
+重量,じゅうりょう,heavyweight,JLPT JLPT_2,L@e.0E4LTG
+重力,じゅうりょく,gravity,JLPT JLPT_2,p;B+5;@b>T
+熟語,じゅくご,"idiom, kanji compound",JLPT JLPT_2,JfoRe)yOPp
+祝日,しゅくじつ,national holiday,JLPT JLPT_2,k6tGq~h4+p
+縮小,しゅくしょう,"reduction, curtailment",JLPT JLPT_2,A;W|R`P$FY
+受験,じゅけん,taking an examination,JLPT JLPT_2,h]:z)|nWsb
+主語,しゅご,(gram) subject,JLPT JLPT_2,E2f>S=Qsi$
+主人,しゅじん,(one's own) husband,JLPT JLPT_2 Intermediate_Japanese_Ln.9 Intermediate_Japanese,y0Vh0}pH&D
+出勤,しゅっきん,"going to work, at work",JLPT JLPT_2,j_B5AK}^J!
+述語,じゅつご,predicate,JLPT JLPT_2,"rBV;MM,_Ui"
+出張,しゅっちょう,"official tour, business trip",JLPT Intermediate_Japanese Genki_Ln.19 JLPT_2 Intermediate_Japanese_Ln.10 Genki,QbLl4<fBGE
+寿命,じゅみょう,life span,JLPT JLPT_2,ip@RR(6Q)w
+主役,しゅやく,leading part,JLPT JLPT_2,AAvA2F|qmF
+受話器,じゅわき,(telephone) receiver,JLPT JLPT_2,jRLR$b=wEf
+循環,じゅんかん,"circulation, rotation, cycle",JLPT JLPT_2,z/Jjqic)yW
+巡査,じゅんさ,policeman,JLPT JLPT_2,mWfGm:/O]=
+順々,じゅんじゅん,"in order, in turn",JLPT JLPT_2,lO7^4=~T>J
+順序,じゅんじょ,"order, sequence, procedure",JLPT JLPT_2,q=^2QGGaA
+純情,じゅんじょう,pure heart,JLPT JLPT_2,C6E@oxfT>)
+純粋,じゅんすい,"pure, genuine, unmixed",JLPT JLPT_2,x2gLnGo0Hy
+初～,しょ～,first ~,JLPT JLPT_2,Ni+{r7rs24
+諸～,しょ～,various ~,JLPT JLPT_2,Q5kl8(<^]h
+～所,～しょ,place,JLPT JLPT_2,qVV9fum9%7
+～所,～じょ,place,JLPT JLPT_2,cE:Y(}3[Wc
+女～,じょ～,things done by women,JLPT JLPT_2,LhI(13lT>E
+～女,～じょ,count for sisters,JLPT JLPT_2,D4j(w~c1gi
+省～,しょう～,economizing ~,JLPT JLPT_2,im>V5<%2Jx
+～省,～しょう,kind of ministry,JLPT JLPT_2,v9~DY$oS}A
+～商,～しょう,"merchant, business",JLPT JLPT_2,DK0!oyaXJR
+～勝,～しょう,count for victory,JLPT JLPT_2,E_qw?Tzvk_
+～条,～じょう,counter for article,JLPT_1 JLPT JLPT_2,q^S9+[e=*b
+～場,～じょう,"kind of field, ground",JLPT JLPT_2,eh5O)[W8C@
+～畳,～じょう,"count for tatami, mat",JLPT JLPT_2,gXTr~P6_;?
+消化,しょうか,digestion,JLPT JLPT_2,C#pz<pJ<eo
+小学生,しょうがくせい,elementary school pupil,JLPT JLPT_2,GKx{~(QY^<
+しょうがない,しょうがない,It is not worth ~,JLPT JLPT_2,H;w)!q6QIW
+将棋,しょうぎ,Japanese chess,JLPT JLPT_2,o>-[BTOgMu
+蒸気,じょうき,"steam, vapor",JLPT JLPT_2,yr+:#u3w]#
+定規,じょうぎ,(measuring) ruler,JLPT JLPT_2,y8|>I<):Fb
+上級,じょうきゅう,"advanced level, high grade, senior",JLPT JLPT_2,E]<)eitS5v
+商業,しょうぎょう,"commerce, trade, business",JLPT JLPT_2 Intermediate_Japanese_Ln.10 Intermediate_Japanese,tBxA`{EGUT
+消極的,しょうきょくてき,passive,JLPT JLPT_2,D7|$-Q)w)~
+賞金,しょうきん,"prize, monetary award",JLPT JLPT_2,h7834at`:k
+上下,じょうげ,"high and low, up and down",JLPT JLPT_2,o_^4=W.VM#
+障子,しょうじ,paper sliding door,JLPT JLPT_2,M[TE$UVbid
+商社,しょうしゃ,trading company,JLPT JLPT_2,J/lSCUTs~[
+乗車,じょうしゃ,"taking a train, entraining",JLPT JLPT_2,Nw+J{<dSau
+上旬,じょうじゅん,first 10 days of month,JLPT JLPT_2,h))LgN=I.e
+生ずる,しょうずる,"to cause, to arise, to be generated",JLPT JLPT_2,"vg9e=r3Tl,"
+小数,しょうすう,"fraction (part of), decimal",JLPT JLPT_2,z:q}dc<I:s
+商店,しょうてん,"shop, business firm",JLPT JLPT_2,glT|Kxp]>$
+焦点,しょうてん,"focus, point",JLPT JLPT_2,wHjNiqCz}x
+消毒,しょうどく,disinfection,JLPT JLPT_2,xo2iz}Ug@`
+勝敗,しょうはい,"victory or defeat, issue (of battle)",JLPT JLPT_2,BU<_6fBUh}
+蒸発,じょうはつ,evaporation; unexplained disappearance,JLPT JLPT_2,lr6Aj]|}(-
+上品,じょうひん,"refined, elegant, well-mannered",JLPT JLPT_2,M|bWva`I=w
+勝負,しょうぶ,"victory or defeat, game",JLPT JLPT_2,gj|IO4h=q;
+小便,しょうべん,"(col) urine, piss",JLPT JLPT_2,"bK|,0ua1Dl"
+消防署,しょうぼうしょ,fire station,JLPT JLPT_2,FRL.hg2R`~
+正味,しょうみ,net (weight),JLPT JLPT_2,E)H$Zvk^B:
+正面,しょうめん,front,JLPT JLPT_2,gfh>dfSUZU
+消耗,しょうもう,"exhaustion, consumption",JLPT JLPT_2,k}G5Ve])50
+初級,しょきゅう,elementary level,JLPT JLPT_2,s5Nz5KFo?B
+助教授,じょきょうじゅ,assistant professor,JLPT JLPT_2,C@A-m!z]Kq
+～色,～しょく,kind of color,JLPT JLPT_2,w$+z1REIYB
+食塩,しょくえん,table salt,JLPT JLPT_2,Hp0g>KLWj/
+職人,しょくにん,"artisan, craftsman",JLPT JLPT_2,"tJH,8Q27Qt"
+職場,しょくば,workplace,JLPT JLPT_2,P&{;#KVmG&
+初旬,しょじゅん,first 10 days of the month,JLPT JLPT_2,jZertmVDFe
+書籍,しょせき,"book, publication",JLPT JLPT_2,Bf)uYlO=AT
+食器,しょっき,tableware,JLPT JLPT_2,iPV[H=Yj`[
+ショップ,ショップ,a shop,JLPT JLPT_2,A=dH=_y-%Q
+書店,しょてん,bookshop,JLPT JLPT_2,s4qIEN6Bk}
+書道,しょどう,calligraphy,JLPT JLPT_2,f:%5][vkAc
+初歩,しょほ,"elements, rudiments",JLPT JLPT_2,wZ7G?ntb5}
+白髪,しらが,"white or grey hair, trendy hair bleaching",JLPT JLPT_2,uxCiljm@9n
+シリーズ,シリーズ,series,JLPT JLPT_2,DA5W7`%j#(
+私立,しりつ,private (establishment),JLPT_2 JLPT Intermediate_Japanese_Ln.7 Intermediate_Japanese,brR|}=<!Bd
+資料,しりょう,"materials, data",JLPT JLPT_2,C&tPzTV2wQ
+汁,しる,"juice, soup",JLPT JLPT_2,y647aHlaUn
+素人,しろうと,"layman, amateur, novice",JLPT JLPT_2 Intermediate_Japanese_Ln.12 Intermediate_Japanese,dWPWBG[+:j
+しわ (かおの～),しわ (かおの～),"wrinkles, creases",JLPT JLPT_2,Jk5.8cDx8n
+芯,しん,"core, heart, wick",JLPT JLPT_2,B=cR}zPm:}
+新幹線,しんかんせん,"Shinkansen, ""Bullet Train""",JLPT Intermediate_Japanese JLPT_2 Genki_Ln.9 Intermediate_Japanese_Ln.10 Genki,pM-.4/Ue$w
+真空,しんくう,vacuum,JLPT JLPT_2,tIYBRvP|M5
+人事,じんじ,"human resources, personnel management",JLPT JLPT_2,J+x/%Fy483
+信ずる,しんずる,to believe,JLPT JLPT_2,BQ&<yiF@u2
+心身,しんしん,mind and body,JLPT JLPT_2,H#/ONp0lez
+申請,しんせい,"application, request, petition",JLPT JLPT_2,M*(J<<s/@8
+人造,じんぞう,"man-made, synthetic, artificial",JLPT JLPT_2,v2{nYsGU&z
+寝台,しんだい,bed,JLPT JLPT_2,qO9j3@Hghp
+診断,しんだん,diagnosis,JLPT JLPT_2,g+wZt;=B>k
+侵入,しんにゅう,"invasion, raid, trespass",JLPT JLPT_2,H1b.p!HN7#
+人文科学,じんぶんかがく,"social sciences, humanities",JLPT JLPT_2,g+ud_9CPby
+人命,じんめい,(human) life,JLPT JLPT_2,Q6U(4ZXO=G
+深夜,しんや,late at night,JLPT JLPT_2,"u,9r~:<(rE"
+森林,しんりん,"forest, woods",JLPT JLPT_2,BVfTI:K.BL
+親類,しんるい,relative(s) (same as 親戚 (しんせき)),JLPT Intermediate_Japanese JLPT_2 Intermediate_Japanese_Ln.8 Intermediate_Japanese_Ln.9,lfd[d~BlbI
+針路,しんろ,"course, direction",JLPT JLPT_2,xt6+*3Xb17
+神話,しんわ,"myth, legend",JLPT JLPT_2,gbqw2%E-oa
+水産,すいさん,"marine products, fisheries",JLPT JLPT_2,c#54iPiGrb
+炊事,すいじ,cooking,JLPT JLPT_2,"xKch,yK?.P"
+水蒸気,すいじょうき,"water vapor, steam",JLPT JLPT_2,k8jAO*|}~5
+水素,すいそ,hydrogen,JLPT JLPT_2,i73L7}gO>6
+垂直,すいちょく,"vertical, perpendicular",JLPT JLPT_2,G8}j61|h6T
+推定,すいてい,"presumption, assumption, estimation",JLPT JLPT_2,jp6vOFS{a6
+水滴,すいてき,drop of water,JLPT JLPT_2,y}Hrc9&%7j
+水筒,すいとう,"canteen, flask, water bottle",JLPT JLPT_2,mJ90J(~1k%
+随筆,ずいひつ,"essays, miscellaneous writings",JLPT JLPT_2,h4p6ekF;42
+水分,すいぶん,moisture,JLPT JLPT_2,qq@<XjC)__
+水平,すいへい,"level, horizontal",JLPT JLPT_2,Kn`n)IG{Ta
+水平線,すいへいせん,horizon,JLPT JLPT_2,Ej.liCGYdk
+水面,すいめん,water's surface,JLPT JLPT_2,iZ{|=]VK5.
+図々しい,ずうずうしい,"impudent, shameless",JLPT JLPT_2,"w{41{qX1P,"
+ずうっと,ずうっと,"all the time, all the way",JLPT JLPT_2,xL3QlTnk>6
+末っ子,すえっこ,youngest child,JLPT JLPT_2,q2H?txJ(gz
+スカーフ,スカーフ,scarf,JLPT JLPT_2,QEu2m9Dj{V
+図鑑,ずかん,picture book,JLPT JLPT_2,"i,){||O+QG"
+隙,すき,"unguarded moment, chance",JLPT JLPT_2,FIQY`SsGB6
+杉,すぎ,Japanese cedar,JLPT JLPT_2,j[):R@cYZf
+好き嫌い,すききらい,"likes and dislikes, taste",JLPT JLPT_2,E7nO8cj@J.
+好き好き,すきずき,matter of taste,JLPT JLPT_2,LjV{PzjM5W
+透き通る,すきとおる,to be(come) transparent,JLPT JLPT_2,mdCfr_&Mjk
+隙間,すきま,"crack, gap, opening",JLPT JLPT_2,"hLO,M-m.c?"
+～過ぎる,～すぎる,too much ~,JLPT JLPT_2,"P,ja3J!YLK"
+スクール,スクール,school,JLPT JLPT_2,cGFe.>Ak]k
+図形,ずけい,figure,JLPT JLPT_2,q~#`u[+ICl
+鈴,すず,bell,JLPT JLPT_2,sPf>sM2#u
+涼む,すずむ,"to cool oneself, to cool off",JLPT JLPT_2,z:IPAXSnoW
+スタート,スタート,start,JLPT JLPT_2,lWJWm$Sh_7
+スチュワーデス,スチュワーデス,stewardess,JLPT JLPT_2,z4fbmz3-}|
+すっきり,すっきり,"shapely, clear, neat",JLPT JLPT_2,u=7m1&|4_G
+ステージ,ステージ,stage; performance,JLPT JLPT_2,dC1~iTR.Y
+ストッキング,ストッキング,stockings,JLPT JLPT_2,B5:XuLvrca
+ストップ,ストップ,stop,JLPT JLPT_2,nVeh3~p35:
+素直,すなお,"obedient, meek, docile",JLPT JLPT_2,t*v$gPIE?7
+頭脳,ずのう,"head, brains, intellect",JLPT JLPT_2,u_@7V}[&9>
+スピーカー,スピーカー,speaker,JLPT JLPT_2,ts:JB-[YU5
+図表,ずひょう,"chart, diagram, graph",JLPT JLPT_2,i|<`t3f+@>
+スマート,スマート,"smart, stylish, slim",JLPT JLPT_2,"L^]Yw(t($,"
+住まい,すまい,"dwelling, house",JLPT JLPT_2,D9Irez.shi
+すまない,すまない,sorry (phrase),JLPT JLPT_2,jcLXE?s?-j
+～済,～ずみ,finished,JLPT JLPT_2,ncGw.Yh;>r
+相撲,すもう,sumo wrestling,JLPT_2 JLPT Intermediate_Japanese_Ln.7 Intermediate_Japanese,td=~dzQi/B
+スライド,スライド,slide,JLPT JLPT_2,Cslvy][TeB
+ずらす,ずらす,"to put off, to delay",JLPT JLPT_2,gJl7<m:4pb
+ずらり,ずらり,"in a line, in a row",JLPT JLPT_2,AgA!P|w]$E
+スリッパ,スリッパ,slippers,JLPT JLPT_2,JKtWp2C{b`
+狡い,ずるい,"sly, cunning",JLPT JLPT_2,Sm-F;a3H
+寸法,すんぽう,"measurement, size, dimension",JLPT JLPT_2,A^SC?nUAcd
+税関,ぜいかん,customs,JLPT JLPT_2,Hdo?H|g?N-
+製作,せいさく,"manufacture, production",JLPT JLPT_2,"Hd33,!(oye"
+制作,せいさく,"work (e.g., film, book)",JLPT JLPT_2,pSg&--.6FI
+清書,せいしょ,clean copy,JLPT JLPT_2,GSG&]QQ!7S
+青少年,せいしょうねん,"youth, young person",JLPT JLPT_2,oKbcQZhJf7
+整数,せいすう,integer,JLPT JLPT_2,BFz!&|OKKj
+清掃,せいそう,cleaning,JLPT JLPT_2,eetChqGb=_
+生存,せいぞん,"existence, being, survival",JLPT JLPT_2,tV]CHeber1
+政党,せいとう,(member of) political party,JLPT JLPT_2,P>9hhdscC!
+性能,せいのう,"ability, capability",JLPT JLPT_2,zR:(P@rWk;
+整備,せいび,"maintenance, overhaul",JLPT JLPT_2,dN1Ziz6*}J
+成分,せいぶん,"ingredient, component, composition",JLPT JLPT_2,w)S(-qI7pB
+性別,せいべつ,"sex, gender",JLPT JLPT_2,gR@>7DZ?XN
+正方形,せいほうけい,square,JLPT JLPT_2,y)<J<%Cv$W
+正門,せいもん,"main gate, main entrance",JLPT JLPT_2,u>U|#l*q{k
+成立,せいりつ,"formation, establishment, completion",JLPT JLPT_2,z!=6/+)ChY
+西暦,せいれき,"Christian Era, after (Christ’s) death (A.D.)",JLPT JLPT_2,x`#%RAey^1
+背負う,せおう,to be burdened with; to carry on (one's) back or shoulder(s),Intermediate_Japanese_Ln.14 JLPT_2 JLPT Intermediate_Japanese,o17[rZC/J[
+～席,～せき,counter for seats,JLPT JLPT_2,sr9PdG~4;[
+赤道,せきどう,equator,JLPT JLPT_2,r2/#Bsz}<
+折角,せっかく,"with trouble, at great pains, long-awaited",JLPT JLPT_2,"dK?:fG/l-,"
+接近,せっきん,"getting closer, drawing nearer, approaching",JLPT JLPT_2,K^7JJPIGCs
+接する,せっする,to attend to (someone); to associate with,JLPT_2 JLPT Intermediate_Japanese_Ln.15 Intermediate_Japanese,P=&0U%h+V.
+せっせと,せっせと,"busily, away",JLPT JLPT_2,r%5r#-`-m]
+接続,せつぞく,"connection, union, join, link; changing trains",JLPT JLPT_2,z>djSMK(A7
+瀬戸物,せともの,"earthenware, crockery, china",JLPT JLPT_2,PMP|wB-k4/
+ぜひとも,ぜひとも,by all means (with sense of not taking 'no' for an answer),JLPT JLPT_2,A3Jbimizm0
+迫る,せまる,"to draw near, to press",JLPT JLPT_2,dn?%4*`.$=
+ゼミ,ゼミ,seminar,Intermediate_Japanese_Ln.5 JLPT JLPT_2 Intermediate_Japanese,lX$<5j-;VY
+せめて,せめて,at least,JLPT JLPT_2,"qY`,)^Uzza"
+セメント,セメント,cement,JLPT JLPT_2,gZo}Y#TRA.
+台詞,せりふ,"speech, words, one's lines, remarks",JLPT JLPT_2,p!R4:?$J5a
+栓,せん,"stopper, cork, stopcock",JLPT JLPT_2,GIQJL!C!u[
+～船,～せん,counter for ships,JLPT JLPT_2,JSy<S}QGsV
+～戦,～せん,"counter for games, matches",JLPT JLPT_2,M$gHOq[jYN
+前～,ぜん～,"former, late ~, past ~",JLPT JLPT_2,uziw.|&}u]
+～前,～ぜん,before ~,JLPT JLPT_2,DTK5j`gi24
+前後,ぜんご,"front and back, before and after",JLPT JLPT_2,P60vZ%@rQX
+全集,ぜんしゅう,complete works,JLPT JLPT_2,B?uUGxee6}
+扇子,せんす,folding fan,JLPT JLPT_2 Genki_Ln.20 Genki,EF=fq2c-JO
+専制,せんせい,"despotism, autocracy",JLPT JLPT_2,OL%g_RLZ1k
+先々月,せんせんげつ,month before last,JLPT JLPT_2,"zJ$.J8%d%,"
+先々週,せんせんしゅう,2 weeks before,JLPT JLPT_2,mB4QnlMrv3
+先祖,せんぞ,ancestor,JLPT JLPT_2,F0U>k-OIq$
+先端,せんたん,"pointed end, tip",JLPT JLPT_2,Q`_+]v?+=0
+センチ,センチ,centimeter,JLPT JLPT_2,inl%VC*Led
+先頭,せんとう,"head, lead, vanguard",JLPT JLPT_2,h9$H7YGNw$
+全般,ぜんぱん,"(the) whole, general",JLPT JLPT_2,KNd2446a(;
+扇風機,せんぷうき,electric fan,JLPT JLPT_2,bRk!KDE*$7
+洗面,せんめん,"wash up (one's face), have a wash",JLPT JLPT_2,C?dX|!4c7/
+全力,ぜんりょく,"all one's power, whole energy",JLPT JLPT_2,j*AhcD}311
+線路,せんろ,"line, track, roadbed",JLPT JLPT_2,mq#-qSUuS*
+～沿い,～そい,along,JLPT JLPT_2,"sbv*I,a%(h"
+総～,そう～,"gross, general, entire",JLPT JLPT_2,cSEd3l5jK<
+～艘,～そう,counter for ships,JLPT JLPT_2,AT^w8|Z/Tg
+相違,そうい,"difference, discrepancy, variation",JLPT JLPT_2 Intermediate_Japanese Intermediate_Japanese_Ln.11,zqQS?TR@WS
+そういえば,そういえば,which reminds me ..,JLPT JLPT_2,eo>F02B%a]
+雑巾,ぞうきん,"house-cloth, dust cloth",JLPT JLPT_2,r*{8DR<J4`
+増減,ぞうげん,"increase and decrease, fluctuation",JLPT JLPT_2,l(r&I9gZ<B
+倉庫,そうこ,"storehouse, warehouse",JLPT JLPT_2,w}}hNBPyr)
+相互,そうご,"mutual, reciprocal",JLPT JLPT_2,nR3lCT=~I%
+創作,そうさく,"production, creation, work",JLPT JLPT_2,PNw/q-z>l3
+葬式,そうしき,funeral,JLPT JLPT_2,Gbn]K/&TX&
+造船,ぞうせん,shipbuilding,JLPT JLPT_2,LyK0zsx!O1
+騒々しい,そうぞうしい,"noisy, boisterous",JLPT JLPT_2,cTG!~COW$P
+増大,ぞうだい,"increase, growth",JLPT JLPT_2,K:CEKV:9VX
+そうっと,そうっと,"softly, cautiously, gently",JLPT JLPT_2,vd>M3|]yht
+送別,そうべつ,"farewell, send-off",JLPT JLPT_2,"y,Tk;$&@x}"
+草履,ぞうり,Japanese sandals (footwear),JLPT JLPT_2,xD#*1}`sY?
+総理大臣,そうりだいじん,Prime Minister,JLPT JLPT_2,wr`qCug{r4
+送料,そうりょう,"postage, carriage",JLPT JLPT_2,D?;^6Pv:]&
+～足,～そく,counter for shoes,JLPT JLPT_2,q&YH/C!y&b
+属する,ぞくする,"to belong to, to come under",JLPT JLPT_2,i1]:]E>_bU
+続々,ぞくぞく,"successively, one after another",JLPT JLPT_2,hivME8/#WP
+速達,そくたつ,"express, special delivery",JLPT JLPT_2,v{{[}K0EMQ
+測定,そくてい,measurement,JLPT JLPT_2,Qp_^G4NnHY
+測量,そくりょう,"measurement, surveying",JLPT JLPT_2,N?XK_R(gNy
+速力,そくりょく,speed,JLPT JLPT_2,yC0f;tqC:X
+素質,そしつ,"talent, capability",JLPT JLPT_2,i~_:B9s_i]
+祖先,そせん,ancestor(s),JLPT JLPT_2 Intermediate_Japanese_Ln.8 Intermediate_Japanese,uEOVA+$QA-
+そそっかしい,そそっかしい,"careless, thoughtless",JLPT JLPT_2,lH2m/7jTDk
+卒直,そっちょく,"frank, candid, honest",JLPT JLPT_2,gGu?|m4th^
+そのころ,そのころ,"in those days, at that time, then",JLPT JLPT_2,h3oBLD<m4a
+そのため,そのため,"hence, for that reason",JLPT JLPT_2,m^MU-Y@MNe
+その他,そのほか,besides,JLPT JLPT_2,IwQj+]fL.2
+剃る,そる,to shave,JLPT JLPT_2,nRAd^[5pD1
+それなのに,それなのに,"though, although",JLPT JLPT_2,k+B-<2c#Pu
+それなら,それなら,"If that's the case..., If so..., That being the case...",JLPT JLPT_2,tEgCn;#W+`
+それはいけませんね (かん),それはいけませんね (かん),that's not good,JLPT JLPT_2,t8:jf{Ldnz
+逸れる,それる,"to stray (turn) from subject, to go astray",JLPT JLPT_2,P^@I_Rocse
+算盤,そろばん,abacus,JLPT JLPT_2,jX~`V;cedM
+存じる,ぞんじる,(humble) to know,JLPT JLPT_2,Aym5:5*IUD
+存ずる,ぞんずる,(humble) to know,JLPT JLPT_2,MsmBGs6}hD
+損得,そんとく,"loss and gain, advantage and disadvantage",JLPT JLPT_2,x~apBZA1n:
+田ぼ,たんぼ,"paddy field, farm",JLPT JLPT_2,muOiSP8NL>
+第～,だい～,~th,JLPT JLPT_2,kbFu6B=v;g
+だいいち (とりわけ),だいいち (とりわけ),"first, foremost,&nbsp;&nbsp;#1",JLPT JLPT_2,sS|Rl>y(P~
+大学院,だいがくいん,graduate school,Genki_Ln.16 JLPT Intermediate_Japanese JLPT_2 Intermediate_Japanese_Ln.1 Genki,k|Ws#.@Z(?
+大工,だいく,carpenter,JLPT JLPT_2,HUM8bf&^L-
+体系,たいけい,"system, organization",JLPT JLPT_2,I*QRaBQl@l
+太鼓,たいこ,"drum, tambourine",JLPT JLPT_2,wz3E+65(~&
+対策,たいさく,"counter-plan, counter-measure",JLPT JLPT_2,GGGQEDkEUY
+大して,たいして,"(not so) much, (not) very",JLPT JLPT_2,"u,Waa>(/*g"
+大小,だいしょう,size,JLPT JLPT_2,nI5$isC-V|
+体制,たいせい,"order, system, structure",JLPT JLPT_2,Dn9.|Ri$s|
+体積,たいせき,"capacity, volume",JLPT JLPT_2,u*y*LZ`?*U
+大層,たいそう,"very much, greatly",JLPT JLPT_2,w>w}K&}qSs
+体操,たいそう,"gymnastics, physical exercises, calisthenics",JLPT JLPT_2,"Av($>5,YT@"
+大分,だいぶん,"considerably, greatly, a lot",JLPT JLPT_2,BIv*|D!}u.
+大木,たいぼく,large tree,JLPT JLPT_2,ChcUad;Yr=
+代名詞,だいめいし,pronoun,JLPT JLPT_2,"l##{!5f,2T"
+タイア,タイア,"tire, tyre",JLPT JLPT_2,42m3.zlHb
+ダイヤグラム,ダイヤグラム,diagram,JLPT JLPT_2,iaafymmrCe
+ダイヤモンド,ダイヤモンド,diamond,JLPT JLPT_2,i=C9?(aW#r
+ダイヤル,ダイヤル,dial,JLPT JLPT_2,utE>l/p-3-
+対立,たいりつ,"confrontation, opposition, antagonism",JLPT JLPT_2,"Ncc,Acum~c"
+田植え,たうえ,rice planting,JLPT JLPT_2,OgO</<`l`b
+絶えず,たえず,constantly,JLPT JLPT_2 Intermediate_Japanese_Ln.10 Intermediate_Japanese,pW;2y7R<mV
+楕円,だえん,ellipse,JLPT JLPT_2,P}wFC7s?&j
+耕す,たがやす,"to till, to plow, to cultivate",JLPT JLPT_2,"xA,3MUb6~T"
+滝,たき,waterfall,JLPT JLPT_2,"ohAHw^26T,"
+蓄える,たくわえる,"to save, to store, to lay in stock",JLPT JLPT_2,m.Z{vIv259
+竹,たけ,bamboo,JLPT JLPT_2,w4_>96h/eO
+ただいま,ただいま,"Here I am, I'm home!",JLPT JLPT_2,p|S.`7CI}c
+但し,ただし,"but, however, provided that",JLPT JLPT_2,nIm>W;=6s~
+立ち止まる,たちどまる,"to stop, to halt, to stand still",JLPT JLPT_2,B95OXSZO5r
+たちまち,たちまち,"instantly, suddenly, all at once",JLPT_2 JLPT Intermediate_Japanese_Ln.7 Intermediate_Japanese,"f|EvU~_,t!"
+発,はつ,"to depart (e.g., on a plane, train)",JLPT JLPT_2,d|z)aYBq<F
+脱線,だっせん,"derailment, digression",JLPT JLPT_2,HD(zBG2%H)
+妥当,だとう,"proper, appropriate",JLPT JLPT_2,JHO!PQp^-#
+例える,たとえる,"to compare, to liken",JLPT JLPT_2,b.^|xu(Lu=
+頼もしい,たのもしい,"reliable, promising",JLPT JLPT_2,d|t<2zx{AN
+ダブル,ダブル,double,JLPT_1 JLPT JLPT_2,n5sGaL[nrJ
+ダム,ダム,dam,JLPT JLPT_2,lwjw.sbO3t
+溜息,ためいき,a sigh,JLPT JLPT_2,M{mrZXe(xA
+ためらう,ためらう,to be hesitant,JLPT JLPT_2 Intermediate_Japanese_Ln.12 Intermediate_Japanese,G;FUJQ+<&I
+～だらけ,～だらけ,"be full of ~, be filled with ~",JLPT JLPT_2,C*zDXpDGOo
+だらしない,だらしない,"slovenly, loose, a slut",JLPT JLPT_2,y)zumMnB[a
+足る,たる,"to be sufficient, to be enough",JLPT JLPT_2,f=F6.jTK0j
+短～,たん～,short ~,JLPT JLPT_2,zZ~;hL0?5C
+～団,～だん,"group, corps, party",JLPT JLPT_2,"JAUz(u,OT1"
+オーケストラ,オーケストラ,orchestra,JLPT JLPT_2,E(IY~:+.r]
+おおざっぱ,おおざっぱ,"rough (not precise), broad, sketchy",JLPT JLPT_2,OHMTu7)N;!
+大通り,おおどおり,main street,JLPT JLPT_2,e8NE2/)L:D
+オートメーション,オートメーション,automation,JLPT JLPT_2,w$xtVM50Wd
+大凡,おおよそ,"about, approximately",JLPT JLPT_2,"j>e8>g+K{,"
+お帰り,おかえり,"return, welcome",JLPT JLPT_2,J&)&R*:;&e
+おかけください,おかけください,please sit down,JLPT JLPT_2,LmStb*}|~b
+おかげさまで,おかげさまで,"Thanks to god, thanks to you",JLPT JLPT_2,E&mEeh`mWM
+おかず,おかず,"side dish, accompaniment for rice dishes",JLPT JLPT_2,IW;hR&<.DQ
+おかまいなく,おかまいなく,please don't fuss over me,JLPT JLPT_2,Bag34Ev^HT
+拝む,おがむ,"to worship, to pray",JLPT JLPT_2,BLY_FNPzlS
+お代わり,おかわり,"second helping, another cup",JLPT JLPT_2,b}Avsf0g_X
+補う,おぎなう,to compensate for,JLPT JLPT_2,F#($cJz>C
+お気の毒に,おきのどくに,I'm sorry to hear that…,JLPT JLPT_2,I}O}}43=OW
+屋外,おくがい,outdoors,JLPT JLPT_2,"b,/pc$HdnI"
+送り仮名,おくりがな,part of word written in kana,JLPT JLPT_2,L0[6p2c}y;
+お元気で,おげんきで,Take care',JLPT JLPT_2,P?(I*3(kaT
+怠る,おこたる,"to neglect, to fail",JLPT JLPT_2,hI%Hy&@P79
+お先に,おさきに,"before, after you",JLPT JLPT_2,O/_cfB(;1v
+伯父,おじ,(humble) uncle (older than one's parent),JLPT JLPT_2,b<;4u^|F5a
+叔父,おじ,uncle (younger than one's parent),JLPT JLPT_2,b5[<>DjhLo
+惜しい,おしい,"regrettable, disappointing",JLPT JLPT_2,u~)4Hh}G<5
+伯父さん,おじさん,"(hon.) middle-aged gentleman, uncle",JLPT JLPT_2,oFQ*.$]vx}
+小父さん,おじさん,"(hon.) middle-aged gentleman, uncle",JLPT JLPT_2,LsGH|S+7Q3
+叔父さん,おじさん,"(hon.) middle-aged gentleman, uncle",JLPT JLPT_2,"k@Fydl,X2%"
+お邪魔します,おじゃまします,Excuse me for disturbing you,JLPT JLPT_2,LMVMI71T}{
+お世話になりました,おせわになりました,I've been in your care,JLPT JLPT_2,s4cBT5H*[h
+お大事に,おだいじに,"Take care of yourself, Take care!, Get well soon",JLPT Genki_Ln.12 Intermediate_Japanese JLPT_2 Intermediate_Japanese_Ln.12 Genki,Km@NEq/P(_
+落着く,おちつく,"to calm down, to settle down",JLPT JLPT_2,u?j1|t;RlK
+お出掛け,おでかけ,outing,JLPT JLPT_2,"gaqrD^P,Ry"
+お手伝いさん,おてつだいさん,maid,JLPT JLPT_2,iZR<wUzc/1
+脅かす,おどかす,"to threaten, to coerce",JLPT JLPT_2,Q>m)3/qe`#
+落し物,おとしもの,lost property,JLPT JLPT_2,bMV+Q#2]G~
+驚かす,おどろかす,"to surprise, to frighten",JLPT JLPT_2,DG2lo{usAe
+お願いします,おねがいします,"Please (lit., I request)",JLPT JLPT_2 Intermediate_Japanese_Ln.1 Intermediate_Japanese,oy}-GPhVx}
+各々,おのおの,"each, every, either",JLPT JLPT_2,s;E$Q88Yv[
+伯母,おば,(humble) aunt (older than one's parent),JLPT JLPT_2,z:m(P{*wZ?
+叔母,おば,aunt (younger than one's parent),JLPT JLPT_2,Ek4&AJulO*
+小母さん,おばさん,"lady, woman, ma'am",JLPT JLPT_2,tO0?[][Q}q
+おはよう,おはよう,(abbr.) Good morning,JLPT JLPT_2,hzlc9[n5z=
+お参り,おまいり,"worship, shrine visit",JLPT JLPT_2,j2uP1/H2nj
+お待たせしました,おまたせしました,Sorry to have kept you waiting,JLPT JLPT_2,tWES^gs*3w
+お待ちください,おまちください,Please wait a moment,JLPT JLPT_2,A/UH`kBoC-
+おまちどおさま,おまちどおさま,Sorry to have kept you waiting,JLPT JLPT_2,kyL%[N^|az
+おめでたい,おめでたい,"happy event, matter for congratulation",JLPT JLPT_2,"eET,n2`P|Z"
+思い掛けない,おもいがけない,"unexpected, casual",JLPT JLPT_2,pxYW;;jVL[
+思い切り,おもいきり,"with all one's strength (heart), resignation, resolution",JLPT JLPT_2,u6znaLhPyo
+思い込む,おもいこむ,"to be under impression that, to be convinced that",JLPT JLPT_2,ggq%!UTv!w
+思いっ切り,おもいっきり,"very, much, fully",JLPT JLPT_2,"z,O=En=;Mc"
+重たい,おもたい,"heavy, massive, serious",JLPT JLPT_2,kxf3li]&Z0
+お休み,おやすみ,"holiday, absence; (exp.) Good night",JLPT JLPT_2,g*1:u%%pd(
+おやつ,おやつ,"between meal snack, afternoon refreshment",JLPT JLPT_2,F0Bgt+CKGH
+親指,おやゆび,thumb,JLPT JLPT_2,Q]+3Y_+I|o
+オルガン,オルガン,organ,JLPT JLPT_2,r4P=wfH}tX
+恩恵,おんけい,"blessing, benefit",JLPT JLPT_2,t6?1>QfZ5F
+温室,おんしつ,greenhouse,JLPT JLPT_2,j@PV(c1<I%
+温泉,おんせん,"spa, hot spring",JLPT Intermediate_Japanese JLPT_2 Genki_Ln.9 Intermediate_Japanese_Ln.10 Genki,p7%rZNufe3
+温帯,おんたい,temperate zone,JLPT JLPT_2,it?~KTCCdv
+御中,おんちゅう,Messrs.,JLPT JLPT_2,i:g_|_*4fM
+女の人,おんなのひと,woman,Genki_Ln.7 JLPT JLPT_2 Genki,k`gpRcVkY^
+～日,～か,counter for days,JLPT JLPT_2,rDuT4FxT)r
+～下,～か,under ~,JLPT JLPT_2,fbg-jA#f{K
+～化,～か,action of making something,JLPT JLPT_2,jA{o6okAW~
+～科,～か,"family, group, course",JLPT JLPT_2,G*u5fLwYB~
+～歌,～か,song of ~,JLPT JLPT_2,b!q>|EX?]V
+～画,～が,"picture, painting",JLPT_1 JLPT JLPT_2,A:x.SahEv8
+カーブ,カーブ,curve; curve ball (baseball),JLPT JLPT_2,"H$,bx/Aa*A"
+外～,がい～,"foreign ~, outside ~",JLPT JLPT_2,hm9sVyWCE}
+～外,～がい,out of ~,JLPT JLPT_2,v.D6N)Jn-M
+開会,かいかい,opening of a meeting,JLPT JLPT_2,Lh4g/O2OJM
+会館,かいかん,"meeting hall, assembly hall",JLPT JLPT_2,liybJFP&?H
+改札,かいさつ,examination of tickets,JLPT JLPT_2,y:jbDc8VoT
+解散,かいさん,"breakup, dissolution",JLPT JLPT_2,k.tjPn~)Hk
+海水浴,かいすいよく,"sea bathing, seawater bath",JLPT JLPT_2,b`BB!zK8zx
+回数,かいすう,"number of times, frequency",JLPT JLPT_2,e]X6r<D@Yf
+回数券,かいすうけん,book of tickets,JLPT JLPT_2,vh5]if8XnX
+改正,かいせい,"revision, amendment, alteration",JLPT JLPT_2,wJ:fR1W1sK
+快晴,かいせい,good weather,JLPT JLPT_2,ud00-YM]pE
+解説,かいせつ,"explanation, commentary",JLPT JLPT_2,"z,rNuHyUJ$"
+改造,かいぞう,remodeling,JLPT JLPT_2,GV-RfF@Gn1
+開通,かいつう,"opening, open",JLPT JLPT_2,BJU-xej2c~
+回転,かいてん,"rotation, turning",JLPT JLPT_2,bT_5rLaFDl
+解答,かいとう,"answer, solution",JLPT JLPT_2,"yT|.1iJ,_Q"
+回答,かいとう,"reply, answer",JLPT JLPT_2,E!J[iX3Ig-
+外部,がいぶ,"the outside, external",JLPT JLPT_2,yk*]@{a4/.
+解放,かいほう,"release, liberation, emancipation",JLPT JLPT_2,zS7|<$4Sg9
+開放,かいほう,"open, throw open, liberalization",JLPT JLPT_2,K(=v$Si}Sa
+海洋,かいよう,ocean,JLPT JLPT_2,"c?Kf,aYa,k"
+概論,がいろん,"introduction, general remark",JLPT JLPT_2,EagQlRaO<~
+却って,かえって,"on the contrary, rather",JLPT JLPT_2,Ff-Dhop([3
+家屋,かおく,"house, building",JLPT JLPT_2,K9=P{6t9d@
+係わる,かかわる,"to concern oneself in, to be involved in",JLPT JLPT_2,e1]obK7qg.
+書留,かきとめ,registered mail,JLPT JLPT_2,"P,x~yeJiAf"
+書取,かきとり,dictation,JLPT JLPT_2,nlq[7d^Cda
+垣根,かきね,hedge,JLPT JLPT_2,s%pg!Off-$
+限り,かぎり,"limit(s), as far as possible",JLPT JLPT_2,nd]$n-hPJY
+各～,かく～,"every ~, each ~",JLPT JLPT_2,JIKk5aY~sz
+架空,かくう,"imaginary, fiction, fanciful",JLPT JLPT_2,keLv$&NvXw
+各自,かくじ,"individual, each",JLPT JLPT_2,u>j/FKC5==
+拡充,かくじゅう,expansion,JLPT JLPT_2,k9>S;S#x^)
+学術,がくじゅつ,"science, learning, scholarship",JLPT JLPT_2,y2n!_T5t*M
+各地,かくち,various parts of the country,JLPT JLPT_2 Intermediate_Japanese_Ln.10 Intermediate_Japanese,M_|B!vf-KS
+拡張,かくちょう,"expansion, extension",JLPT JLPT_2,"qk,U%yom=n"
+角度,かくど,angle,JLPT JLPT_2,xYUahGWaOD
+学年,がくねん,"year in school, grade in school",JLPT JLPT_2,snv|Q^7V&<
+格別,かくべつ,exceptional,JLPT JLPT_2,ew:H.)$lIz
+確率,かくりつ,probability,JLPT JLPT_2,B^!PO()@Fj
+学力,がくりょく,"scholarship, knowledge",JLPT JLPT_2,fg#sj4f&H/
+掛け算,かけざん,multiplication,JLPT JLPT_2,NBNX=8%`mD
+可決,かけつ,"approval, adoption (e.g., motion, bill), passage",JLPT JLPT_2,?AdRO|`D3
+火口,かこう,crater (of a volcano),JLPT JLPT_2,I>{#77)U2L
+下降,かこう,"decline, descent, fall",JLPT JLPT_2,olO#.LVae]
+火山,かざん,volcano,JLPT JLPT_2 Intermediate_Japanese_Ln.10 Intermediate_Japanese,nQ^q[SYzad
+かしこまりました,かしこまりました,Certainly,JLPT JLPT_2 Genki_Ln.20 Genki,K[_B[U0SFm
+貸し出し,かしだし,"lending, loaning",JLPT JLPT_2,jgwQltf^|5
+過失,かしつ,"error, mistake, negligence",JLPT JLPT_2,wGXKGa.Q$k
+果実,かじつ,fruit,JLPT JLPT_2,Hr5#b<WZv5
+貸間,かしま,room to let,JLPT JLPT_2,f;Mu?;YNxY
+貸家,かしや,house for rent,JLPT JLPT_2,xG+iA}dT^k
+箇所,かしょ,"place, point, part",JLPT JLPT_2,"u73w,EFcqC"
+過剰,かじょう,"excess, over-",JLPT JLPT_2,gyP>>^hD);
+かじる,かじる,"to chew, to bite (at)",JLPT JLPT_2,HPUE@sF)^#
+課税,かぜい,taxation,JLPT JLPT_2,v<>5#MB}<q
+下線,かせん,"underline, underscore",JLPT JLPT_2,pq&rc|>fY.
+カセット,カセット,cassette (tape),JLPT JLPT_2,O31|Fi(S7Q
+加速,かそく,acceleration,JLPT JLPT_2,MT@qI_:;KR
+加速度,かそくど,acceleration,JLPT JLPT_2,ic-:spL~M@
+塊,かたまり,"lump, mass, cluster",JLPT JLPT_2,iJm<x_b^7C
+固まる,かたまる,"to harden, to solidify, to become firm",JLPT JLPT_2,iT33@SKQ0$
+片道,かたみち,one-way (trip),JLPT JLPT_2,tN}hoBEcWZ
+傾く,かたむく,"to incline toward, to slant, to lurch",JLPT JLPT_2,"eRHA+m,LAe"
+片寄る,かたよる,"to be one-sided, to incline, to be partial",JLPT JLPT_2,Q|RAcaS;Ac
+～がち,～がち,tend to do ~,JLPT JLPT_2,"HC!2|,O=Uv"
+学科,がっか,"study subject, course of study",JLPT JLPT_2,d/U/mP87B<
+学会,がっかい,academic conference,JLPT_2 JLPT Intermediate_Japanese_Ln.15 Intermediate_Japanese,rvd2E[%d:l
+学級,がっきゅう,class,JLPT JLPT_2,xHn7Zkw(je
+担ぐ,かつぐ,"to shoulder, to carry on shoulder",JLPT JLPT_2,uNP=4K#|_6
+括弧,かっこ,"parenthesis, brackets",JLPT JLPT_2,E4PO59(otM
+活字,かつじ,printing type,JLPT JLPT_2,lS9+ur8Rhy
+勝手に,かってに,"arbitrarily,",JLPT JLPT_2,c;rdge_lIB
+活力,かつりょく,"vitality, energy",JLPT JLPT_2,P=dyC+Atno
+仮名,かな,kana,JLPT JLPT_2,r+|=nvx{%}
+仮名遣い,かなづかい,"kana orthography, syllabary spelling",JLPT JLPT_2,q:v%>e2~9#
+加熱,かねつ,heating,JLPT JLPT_2,D58GJ/(V81
+兼ねる,かねる,to simultaneously serve two or more functions,JLPT JLPT_2,s0EuumM^s>
+カバー,カバー,"cover (e.g., book)",JLPT JLPT_2,h7<4il+kD=
+過半数,かはんすう,majority,JLPT JLPT_2,t.8/F.$N=Y
+かび (～がはえる),かび (～がはえる),"mold, mildew",JLPT JLPT_2,Q.7b{&DG}o
+被せる,かぶせる,to cover (with something),JLPT JLPT_2,BdRmJ;EC_8
+釜,かま,"iron pot, kettle",JLPT JLPT_2,M+N1Y3/)pj
+構いません,かまいません,it's all right; one doesn’t mind,Intermediate_Japanese_Ln.4 JLPT JLPT_2 Intermediate_Japanese,vd/0yY>i6%
+紙屑,かみくず,wastepaper,JLPT JLPT_2,vvZ;(*{sDL
+神様,かみさま,god,JLPT JLPT_2 Genki_Ln.20 Genki,QtI1aTgK3F
+剃刀,かみそり,razor,JLPT JLPT_2,EUVj(OJ|`3
+ガム,ガム,chewing gum,JLPT JLPT_2,IjCKN~>gDp
+貨物,かもつ,"cargo, freight",JLPT JLPT_2,Ee3iA.}E1T
+カラー,カラー,"collar, color",JLPT JLPT_2,hoWS%R]$xc
+からかう,からかう,"to ridicule, to make fun of",JLPT JLPT_2,f1|Z(DjQl3
+空っぽ,からっぽ,"empty, vacant, hollow",JLPT JLPT_2,ymKUE(fK%o
+かるた,かるた,playing cards (POR: carta),JLPT JLPT_2,cJB:Z0SpF-
+枯れる,かれる,"to wither, to die (plant), to be blasted (plant)",JLPT JLPT_2,w%ev2Rq1&r
+カロリー,カロリー,calorie,JLPT JLPT_2,"diZF6u*,sD"
+可愛がる,かわいがる,"to love, to be affectionate",JLPT JLPT_2,zX92vgkXT;
+為替,かわせ,"money order, exchange",JLPT JLPT_2,JjeKsySAG^
+瓦,かわら,roof tile,JLPT JLPT_2,Bf6o<dScJ^
+～刊,～かん,"~ issued (magazine, newspaper)",JLPT JLPT_2,J]XIoil*2L
+～間,～かん,"between, during",JLPT JLPT_2,Qm1qWlocEP
+～巻,～かん,volume,JLPT JLPT_2,K19uzsMb_o
+～館,～かん,"~ hall, ~ building",JLPT JLPT_2,c3uPE$j0G@
+～感,～かん,"feeling, sense, impression",JLPT JLPT_2,gv?{M:3Nl+
+換気,かんき,ventilation,JLPT JLPT_2,to8!Q9kk&}
+感激,かんげき,"deep emotion, impression, inspiration",JLPT JLPT_2,yU>I7PD.[:
+関西,かんさい,"south-western half of Japan, including Osaka",JLPT JLPT_2,"mfDDR,OXu:"
+元日,がんじつ,New Year's Day,JLPT JLPT_2,u|JK#Xa]e5
+鑑賞,かんしょう,appreciation,JLPT JLPT_2,E642S>/DUA
+感ずる,かんずる,"to feel, to sense",JLPT JLPT_2,Nfi9|FOf@O
+間接,かんせつ,"indirect, indirectness",JLPT JLPT_2,dxp6!l6@:y
+観測,かんそく,observation,JLPT JLPT_2,DpaRQHledo
+寒帯,かんたい,frigid zone,JLPT JLPT_2,kuZZ@R:&?
+官庁,かんちょう,"government office, authorities",JLPT JLPT_2,e-}veyn2>L
+勘違い,かんちがい,"misunderstanding, wrong guess",JLPT JLPT_2,Hn~gIt2Uw4
+缶詰,かんづめ,"canning, canned goods,",JLPT JLPT_2,dGjAI6[GGs
+乾電池,かんでんち,"dry cell, battery",JLPT JLPT_2,kSO!})gG5D
+関東,かんとう,"eastern half of Japan, including Tokyo",JLPT JLPT_2,q$Rzr7k!?N
+観念,かんねん,"idea, notion; sense",JLPT JLPT_2,H`W;t.blod
+乾杯,かんぱい,Cheers! (a toast),JLPT_2 JLPT Genki_Ln.8 Genki,qtXR3lc8pv
+看板,かんばん,"sign, signboard",JLPT JLPT_2,f~lT@>sl(B
+看病,かんびょう,nursing (a patient),JLPT JLPT_2,d4(@OW=wzg
+冠,かんむり,"crown, wreath",JLPT JLPT_2,"u>]rwp,Fs["
+漢和,かんわ,"Chinese Character-Japanese (e.g., dictionary)",JLPT JLPT_2,"mNHDxx[&,N"
+～期,～き,"~age, ~period",JLPT JLPT_2,kCfW%K6Q|D
+～器,～き,"device, equipment",JLPT JLPT_2,u+~Y!_LNSC
+～機,～き,machine,JLPT JLPT_2,k3|o@N56?1
+気圧,きあつ,atmospheric pressure,JLPT JLPT_2,w71unwo/e>
+着替え,きがえ,"changing clothes, change of clothes",JLPT JLPT_2,vi{&DRUjwE
+着替える,きがえる,to change (one's) clothes,JLPT Intermediate_Japanese JLPT_2 Genki Intermediate_Japanese_Ln.10 Genki_Ln.21,"Az6,#K9!yB"
+機関車,きかんしゃ,"locomotive, engine",JLPT JLPT_2,dyq%>=g>@K
+飢饉,ききん,famine,JLPT JLPT_2,of0kMjM40p
+器具,きぐ,instrument,JLPT JLPT_2,f04oZ+_FOX
+記号,きごう,"symbol, code",JLPT JLPT_2,"NF?>3T^,JP"
+刻む,きざむ,"to mince, to carve, to engrave",JLPT JLPT_2,"LlS,o9O&r1"
+儀式,ぎしき,"ceremony, rite, ritual",JLPT JLPT_2,KIl/;heLfD
+基準,きじゅん,"standard, basis, criteria",JLPT JLPT_2,l&fXwd/g5#
+規準,きじゅん,"standard, basis, criteria",JLPT JLPT_2,Efh]$;|u`t
+起床,きしょう,"rising, getting out of bed",JLPT JLPT_2,"fOY,Ghbw-s"
+着せる,きせる,to put on clothes,JLPT JLPT_2,NKt/PdYQsd
+基礎,きそ,"foundation, basis",JLPT JLPT_2,IMHZY>OvkD
+基地,きち,base,JLPT JLPT_2,I7{+B~;-Cv
+きっかけ,きっかけ,"prompt, trigger, cue",JLPT JLPT_2,e9iq#7`z5g
+ぎっしり,ぎっしり,"tightly, fully",JLPT JLPT_2,roF`vi5#iH
+基盤,きばん,"foundation, basis",JLPT JLPT_2,Q#hD0![*dh
+～気味,～ぎみ,slightly ~,JLPT JLPT_2,H[Vo.[BxaR
+客席,きゃくせき,guest seating,JLPT JLPT_2,oKF%:%YXd4
+客間,きゃくま,"parlor, guest room",JLPT JLPT_2,PWjQKkx$-q
+ギャング,ギャング,gang,JLPT JLPT_2,rmu8iNTz;H
+キャンパス,キャンパス,campus,JLPT JLPT_2,me;5WQ2vTb
+休業,きゅうぎょう,"closure, shutdown, holiday",JLPT JLPT_2,oX~(4uE=OX
+休講,きゅうこう,lecture canceled,JLPT JLPT_2,IblG6P2b4^
+給与,きゅうよ,salary,JLPT JLPT_2,PCn?h_u$qZ
+休養,きゅうよう,"rest, break, recreation",JLPT JLPT_2,RcKyI3I]Oc
+清い,きよい,"clear, pure, noble",JLPT JLPT_2,Gl5ERuBRxp
+～教,～きょう,religion,JLPT JLPT_2,"vbb{{,/z36"
+～行,～ぎょう,"line, row",JLPT JLPT_2,E5TA@2@XRb
+～業,～ぎょう,type of business,JLPT JLPT_2,r#B%nh/j8;
+強化,きょうか,"strengthen, intensify, reinforce",JLPT JLPT_2,uXIPpdZC1R
+境界,きょうかい,boundary,JLPT JLPT_2,j7=Rl[TZ[~
+共産～,きょうさん～,communist ~,JLPT JLPT_2,j8+=)[q7=i
+行事,ぎょうじ,"event, function",JLPT JLPT_2,"H,ijyT4Xeg"
+恐縮,きょうしゅく,sorry to trouble,JLPT JLPT_2,zQMs(1T)5O
+教養,きょうよう,"culture, education, sophistication",JLPT JLPT_2,z>(b`0D^UW
+行列,ぎょうれつ,"line, procession; matrix (math)",JLPT JLPT_2,NW3kj#3*Pp
+漁業,ぎょぎょう,fishing (industry),JLPT JLPT_2,oFZ3yBC.8y
+曲線,きょくせん,curve,JLPT JLPT_2,iDUc0okp@!
+規律,きりつ,"order, rules, law",JLPT JLPT_2,qH%%&6n|uU
+斬る,きる,"to behead, to murder",JLPT JLPT_2,npLP+:S/ui
+～きる,～きる,"nevertheless, to carry through",JLPT JLPT_2,lY)YcCGPox
+～切れ,～きれ,out of ~,JLPT JLPT_2,BI!R8>v)8r
+気を付ける,きをつける,"to be careful, to pay attention, to take care",JLPT JLPT_2,KJo;WsH_ui
+金魚,きんぎょ,goldfish,JLPT JLPT_2,f4r;e>P:iY
+区域,くいき,"zone, district, area",JLPT JLPT_2,fYQq7`cNuc
+空～,くう～,empty ~,JLPT JLPT_2,A&!JE@t/D3
+偶数,ぐうすう,even number,JLPT JLPT_2,"iw7<JlzmC,"
+空想,くうそう,"daydream, fantasy",JLPT JLPT_2,H5ov7CW8[y
+空中,くうちゅう,"sky, air",JLPT JLPT_2,A;^pVv^)~a
+クーラー,クーラー,air conditioner,JLPT JLPT_2,m[g>=z]wN/
+釘,くぎ,nail,JLPT JLPT_2,Gb>Lz*bq3+
+区切る,くぎる,"to punctuate, to cut off, to mark off",JLPT JLPT_2,s|j=prYd&B
+櫛,くし,comb,JLPT JLPT_2,dzg}!o26=)
+くしゃみ,くしゃみ,sneeze,JLPT JLPT_2,jgl;4q1>wE
+苦情,くじょう,"complaint, grievance, grumble",JLPT JLPT_2,"GDdlB.2)],"
+苦心,くしん,"pain, trouble",JLPT JLPT_2,scKS9[]M|w
+屑,くず,"waste, scrap",JLPT JLPT_2,BqN1|GlY;b
+崩す,くずす,"to destroy, to make change (money)",JLPT JLPT_2,m%M5UejA$^
+薬指,くすりゆび,ring finger,JLPT JLPT_2,lPy;T<L~6G
+崩れる,くずれる,"to collapse, to crumble",JLPT JLPT_2,cC8vUqHlPz
+砕く,くだく,"to break, to smash",JLPT JLPT_2,wiAgy$Rvgg
+砕ける,くだける,"to break, to be broken",JLPT JLPT_2,I_dH|P3phU
+くたびれる,くたびれる,"to get tired, to wear out",JLPT JLPT_2,G(IR)z:5pO
+くだらない,くだらない,"good-for-nothing, stupid, worthless",JLPT JLPT_2,"A~U,=Hx4eT"
+～口,～くち,"~ opening; ~ entrance, ~ exit",JLPT JLPT_2,pT(<V!lc5R
+唇,くちびる,lip,JLPT JLPT_2,Ojx~b|>9H|
+口紅,くちべに,lipstick,JLPT JLPT_2,tS@_TWWY!2
+くっつく,くっつく,"to adhere to, to keep close to",JLPT JLPT_2,oS}[QfJCGM
+くっつける,くっつける,to attach,JLPT JLPT_2,oyj+vcm-!3
+くどい,くどい,"verbose, importunate, heavy (taste)",JLPT JLPT_2,"hrEZ=;H,}N"
+句読点,くとうてん,punctuation marks,JLPT JLPT_2,l-RV08NZgs
+配る,くばる,"to distribute, to deliver",JLPT JLPT_2,lXb3hdtDlZ
+工夫,くふう,"device, artifice, ingenuity",JLPT JLPT_2,H+)pz^uf{J
+区分,くぶん,"division, section, classification",JLPT JLPT_2,F<dg-k3#W>
+組合せ,くみあわせ,combination,JLPT JLPT_2,Bg89BEb&%-
+組み立てる,くみたてる,"to assemble, to set up, to construct",JLPT JLPT_2,v|l>4TT$)t
+悔やむ,くやむ,"to regret, to mourn",JLPT JLPT_2 Intermediate_Japanese Intermediate_Japanese_Ln.11,H!N`qFr_#7
+クリーニング,クリーニング,"cleaning, dry cleaning, laundry service",JLPT JLPT_2,i[]|N=O%MV
+くるむ,くるむ,"to be enveloped by, to wrap up",JLPT JLPT_2,"BR}5xbe,nI"
+くれぐれも,くれぐれも,"repeatedly, sincerely, earnestly",JLPT JLPT_2,Fa/6^Kk;|O
+～家,～け,"~'s family, the house of ~",JLPT JLPT_2,OVLMa7l[Gn
+～形,～けい,shape of ~,JLPT JLPT_2,M3p*&+Wj>%
+～系,～けい,"~ system, ~ lineage, ~ group",JLPT_1 JLPT JLPT_2,AgNe/GkjZM
+稽古,けいこ,"practice, training, study",JLPT JLPT_2,j8X.KY|=u:
+敬語,けいご,"honorific language (lit., respect language)",JLPT Intermediate_Japanese Genki_Ln.19 JLPT_2 Intermediate_Japanese_Ln.13 Genki,yjE)OYPe3Q
+蛍光灯,けいこうとう,fluorescent lamp,JLPT JLPT_2,"QTW-;W~W,r"
+形式,けいしき,"form, formality, format",JLPT JLPT_2,Ab_)N~*$PV
+継続,けいぞく,continuation,JLPT JLPT_2,CaHy~Z7JH4
+毛糸,けいと,knitting wool,JLPT JLPT_2,Gb?267tT>>
+経度,けいど,longitude,JLPT JLPT_2,Av7~pbz~Hq
+系統,けいとう,"system, genealogy",JLPT JLPT_2,Q-55n75c-r
+芸能,げいのう,"public entertainment, performing arts",JLPT JLPT_2,f.Hh_!4j.)
+競馬,けいば,horse racing,JLPT JLPT_2,n:NmLS-y><
+警備,けいび,"defense, guard, policing, security",JLPT JLPT_2,G/A=@_E]L]
+形容詞,けいようし,adjective,JLPT JLPT_2,cL`y[jUOq<
+形容動詞,けいようどうし,"adjectival noun, quasi-adjective",JLPT JLPT_2,uV+nfBdxmh
+外科,げか,surgical department,JLPT JLPT_2,E>G.GzTwL/
+毛皮,けがわ,"fur, skin, pelt",JLPT JLPT_2,c{EG;%-8)#
+激増,げきぞう,sudden increase,JLPT JLPT_2,yz;Sw2]1o2
+下車,げしゃ,"alighting, getting off",JLPT JLPT_2,s3V^Z_7&3=
+下旬,げじゅん,month (last third of),JLPT JLPT_2,ydXtTo$/3C
+下水,げすい,"drainage, sewage, ditch, gutter, sewerage",JLPT JLPT_2,kv>S4!V~UF
+削る,けずる,"to cut down little by little, to take a percentage",JLPT JLPT_2,"b>,#]bkBBs"
+桁,けた,"column, beam, digit",JLPT JLPT_2,h3Lj0KDxA;
+下駄,げた,"(Japanese footwear), wooden clogs",JLPT JLPT_2,Lsi@O2Lyg^
+血圧,けつあつ,blood pressure,JLPT JLPT_2,gAl*9Gbi)S
+月給,げっきゅう,monthly salary,JLPT JLPT_2,HF>n5v#}UC
+傑作,けっさく,"masterpiece, best work",JLPT JLPT_2,Cv}k6t8gW-
+月末,げつまつ,end of the month,JLPT JLPT_2,yG[@;%)^%!
+気配,けはい,"indication, sign, hint",JLPT JLPT_2,vEl!:!Y]<7
+下品,げひん,"vulgar, indecent, coarse",JLPT JLPT_2,Mu42*K8+!p
+煙い,けむい,smoky,JLPT JLPT_2,jZ9K)#wLUe
+険しい,けわしい,"steep, rugged; severe",JLPT JLPT_2,sL2hQ27Y;>
+～圏,～けん,"bloc, sphere, area",JLPT_1 JLPT JLPT_2,Ddk.oC`&.J
+現～,げん～,"present, incumbent",JLPT JLPT_2,j5m@yw%F5s
+見学,けんがく,"tour, study by observation",JLPT JLPT_2,AGWPud)jCW
+謙虚,けんきょ,"modesty, humble",JLPT JLPT_2,dX|trSe.K0
+原稿,げんこう,"manuscript, copy",JLPT JLPT_2,tF(k44d8V3
+原産,げんさん,place of origin,JLPT JLPT_2,oEB|tzMZJ~
+原始,げんし,"origin, primeval",JLPT JLPT_2,omD?4Zjs@O
+研修,けんしゅう,training,JLPT JLPT_2,GG4]qYN81r
+厳重,げんじゅう,"strict, severe, firm",JLPT JLPT_2,v!xFiav6KX
+謙遜,けんそん,"humble, humility, modesty",JLPT JLPT_2,<K5$n`CYI
+県庁,けんちょう,prefectural office,JLPT JLPT_2,zvZL32PgqO
+限度,げんど,"limit, bounds",JLPT JLPT_2,JA`c9FaS}R
+現に,げんに,"actually, really",JLPT JLPT_2,"u,j=UO^+?,"
+顕微鏡,けんびきょう,microscope,JLPT JLPT_2,sxMC{StEnT
+懸命,けんめい,"eagerness, strenuous",JLPT JLPT_2,q]z=kgzWuF
+原理,げんり,"principle, theory, fundamental truth",JLPT JLPT_2,k&wukQ5nce
+原料,げんりょう,raw materials,JLPT JLPT_2,c@Y5nO/W2_
+小～,こ～,small ~,JLPT JLPT_2,nc*Pi>[z&(
+恋しい,こいしい,"dear, beloved; to miss",JLPT JLPT_2,B6>l>%o=|:
+高～,こう～,high (level) ~,JLPT JLPT_2,D00VmIU)t|
+～校,～こう,counter for school,JLPT JLPT_2,m]41H0.3l-
+～港,～こう,~ port,JLPT JLPT_2,vQbZYeISYX
+～号,～ごう,counter for magazine; the name of ship,JLPT JLPT_2,qiAK;eRQt!
+工員,こういん,factory worker,JLPT JLPT_2,vkV[De+:pH
+強引,ごういん,"forcible, assertive, pushy",JLPT JLPT_2,sKp0o2A:hc
+公害,こうがい,"public nuisance, pollution",JLPT JLPT_2,QpY.UtLIJ[
+高級,こうきゅう,high class; first-rate,Intermediate_Japanese_Ln.6 JLPT_2 JLPT Intermediate_Japanese,ft;T5?9HzM
+公共,こうきょう,"public, community, communal",JLPT JLPT_2,sgv0$[#74*
+工芸,こうげい,industrial arts,JLPT JLPT_2,Bwh|-zOd@t
+孝行,こうこう,filial piety,JLPT JLPT_2,qZRbxu/C>i
+交差,こうさ,cross,JLPT JLPT_2,"fDo8@&J]V,"
+講師,こうし,lecturer,JLPT_2 JLPT Intermediate_Japanese_Ln.15 Intermediate_Japanese,zd6hLYf74N
+工事,こうじ,construction work,JLPT JLPT_2,I]-Fc)+f`5
+公式,こうしき,"formula, formality, official",JLPT JLPT_2,"nVcCuyV_X,"
+口実,こうじつ,excuse,JLPT JLPT_2,f`zk^AisY[
+こうして,こうして,"like this, with this",JLPT JLPT_2,ur#5.<4sqd
+公衆,こうしゅう,the public,JLPT JLPT_2,bE}u4]$3>(
+香水,こうすい,perfume,JLPT JLPT_2,o.:4b?]N+f
+功績,こうせき,"achievements, merit",JLPT JLPT_2,OI:=[B.(~f
+光線,こうせん,"beam, light ray",JLPT JLPT_2,ter3YDX-e<
+高層,こうそう,"tall, high rise",JLPT JLPT_2,AyG~sZay?6
+構造,こうぞう,"structure, construction",JLPT JLPT_2,hQ&6u.oz?k
+交替,こうたい,"change, relief, alteration",JLPT JLPT_2,MK%iQJeoa*
+耕地,こうち,arable land,JLPT JLPT_2,k*|BtPi.!l
+交通機関,こうつうきかん,transportation facilities,JLPT JLPT_2,uNV6#=3}0=
+校庭,こうてい,school yard,JLPT JLPT_2,w[Wu+:]Zss
+肯定,こうてい,"positive, affirmation",JLPT JLPT_2,oZ3[Bf(H{{
+高度,こうど,"altitude, height; advanced",JLPT JLPT_2,CQAS#*&&=/
+高等,こうとう,"high class, high grade",JLPT JLPT_2,dbk]Zc:3rz
+合同,ごうどう,"combination, incorporation",JLPT JLPT_2,c!+-6kS6~S
+高等学校,こうとうがっこう,senior high school,JLPT JLPT_2,k>`;igc0Pv
+公表,こうひょう,"official announcement, proclamation",JLPT JLPT_2,Frp(j`FqPK
+鉱物,こうぶつ,mineral,JLPT JLPT_2,"g7V_q,WB=T"
+公務,こうむ,"official business, public business",JLPT JLPT_2,ph__$$f`>`
+項目,こうもく,item,JLPT JLPT_2,IR)]Uw=>ew
+紅葉,こうよう,fall colors (of leaves),Intermediate_Japanese_Ln.4 JLPT JLPT_2 Intermediate_Japanese,QVPJ]RT}3i
+合理,ごうり,rational,JLPT JLPT_2,i7M&H:#flC
+交流,こうりゅう,exchange; alternating current,JLPT JLPT_2,QGlx1yaY72
+合流,ごうりゅう,"confluence, merge, join",JLPT JLPT_2,FQa#d;SBEZ
+効力,こうりょく,"effect, efficacy",JLPT JLPT_2,m[c_>TpG7t
+コース,コース,course,JLPT JLPT_2,oysa|(e$-M
+コーラス,コーラス,chorus,JLPT JLPT_2,Humxyi-3mI
+焦がす,こがす,"to burn, to scorch",JLPT JLPT_2,DR^K9TVHMB
+～国,～こく,nation of ~,JLPT JLPT_2,m~(IN:3:#0
+国王,こくおう,king,JLPT JLPT_2,CA0:(YU5WC
+国立,こくりつ,national,JLPT JLPT_2,n0&v0]`V#?
+ご苦労様,ごくろうさま,Thank you for your hard work,JLPT JLPT_2,t%p^_:OJ|i
+焦げる,こげる,"to burn, to be burned",JLPT JLPT_2,inwlPXnA$z
+凍える,こごえる,"to freeze, to be chilled, to be frozen",JLPT JLPT_2,L+KY/9pga6
+心当たり,こころあたり,"having some knowledge of, happening to know",JLPT JLPT_2,d$_UA7~;A}
+心得る,こころえる,"to understand, to have thorough knowledge",JLPT JLPT_2,nby@b2~VRE
+腰掛け,こしかけ,"seat, bench",JLPT JLPT_2,B.?hce;|M.
+腰掛ける,こしかける,to sit (down),JLPT JLPT_2,C/%Q;o7b11
+五十音,ごじゅうおん,the Japanese syllabary,JLPT JLPT_2,jxVh59#|-M
+こしらえる,こしらえる,"to make, to manufacture",JLPT JLPT_2,i-3W|?L%O1
+擦る,こする,"to rub, to chafe, to file, to frost (glass), to strike (match)",JLPT JLPT_2,P#|X3kVk2a
+個体,こたい,an individual,JLPT JLPT_2,K@FOqw]g/=
+ごちそうさま,ごちそうさま,Thank you for the meal,JLPT JLPT_2,Jul:^;Dy``
+こちらこそ,こちらこそ,it is I who should say so,JLPT JLPT_2,B-I}wWoF~[
+小遣い,こづかい,"pocket money, allowance",JLPT JLPT_2,Mi}UDGGnPb
+コック,コック,"cook; tap, cock",JLPT JLPT_2,IM?]qPl^[d
+こっそり,こっそり,"stealthily, secretly",JLPT JLPT_2,o.yZt_~llY
+古典,こてん,"classics, classic",JLPT JLPT_2,"o,g/8g3=5w"
+～毎,～ごと,"every ~, each ~",JLPT JLPT_2,Bs7#M8Tn1H
+〜 (まる) ごと,〜 (まる) ごと,"whole ~, all of ~",JLPT JLPT_2,Ja%uZn!l8Y
+言付ける,ことづける,to leave a message,JLPT JLPT_2,kGvj%:f4#<
+言葉遣い,ことばづかい,"speech, expression, wording",JLPT JLPT_2,I8U([];a3j
+こないだ,こないだ,"the other day, lately, recently",JLPT JLPT_2,JgsjMc&2iB
+御無沙汰,ごぶさた,not writing or contacting for a while,JLPT JLPT_2,h*n>sYK!3z
+ゴム,ゴム,"gum, rubber",JLPT JLPT_2,oFg|-D}k2~
+御免,ごめん,"declining (something); pardon, sorry",JLPT JLPT_2,o2=%ufIq+G
+ごめんください,ごめんください,"May I come in, Is anyone here",JLPT JLPT_2,guZ7b6UJ;s
+小指,こゆび,little finger,JLPT JLPT_2,l.YopEDJ!I
+堪える,こらえる,"to bear, to endure, to put up with",JLPT JLPT_2,hM1GeQIR^s
+娯楽,ごらく,"pleasure, amusement, recreation",JLPT JLPT_2,tFNg*5LjGq
+御覧,ごらん,"(hon.) look, inspection, try",JLPT JLPT_2,pLv<:y@zpf
+コレクション,コレクション,collection; correction,JLPT JLPT_2,H}>p%NJ>aq
+転がす,ころがす,to roll,JLPT JLPT_2,d5Iyiq5t}5
+転がる,ころがる,"to roll, to tumble",JLPT JLPT_2,u0s)#a{$F&
+紺,こん,"navy blue, deep blue",JLPT JLPT_2 Intermediate_Japanese_Ln.9 Intermediate_Japanese,P;kAa8K;qq
+今～,こん～,"this, current",JLPT JLPT_2,"lXSg,J@v4n"
+コンクール,コンクール,contest (FRE: concours),JLPT JLPT_2,O:S`(}<v)K
+コンクリート,コンクリート,concrete,JLPT JLPT_2,lEhN4;/BMM
+混合,こんごう,"mixing, mixture",JLPT JLPT_2,IMB+$DZG1H
+コンセント,コンセント,consent; power outlet,JLPT JLPT_2,d{^OuMbhJw
+献立,こんだて,menu,JLPT JLPT_2,Nuu_A~-?pe
+こんばんは,こんばんは,good evening,JLPT JLPT_2,lL0e]&K7U?
+サークル,サークル,"circle, sports club (e.g., at a company)",JLPT JLPT_2,H[N:3J2F+>
+再～,さい～,re ~,JLPT JLPT_2,eK[KX|A&U*
+最～,さい～,the most ~,JLPT JLPT_2,ry(m3m#pOU
+在学,ざいがく,(enrolled) in school,JLPT JLPT_2,b)R1W8]IN[
+再三,さいさん,"again and again, repeatedly",JLPT JLPT_2,yXL@E3-qW)
+祭日,さいじつ,"national holiday, festival day",JLPT JLPT_2,Ol|U}K0|@/
+催促,さいそく,"demand, urge (action), press for",JLPT JLPT_2,w[uz5KW1#O
+採点,さいてん,"marking, grading",JLPT JLPT_2,cf[<`dEms.
+災難,さいなん,"calamity, misfortune",JLPT JLPT_2,t+<u_pEc%l
+裁縫,さいほう,sewing,JLPT JLPT_2,l5uxjaa~([
+材木,ざいもく,"lumber, timber",JLPT JLPT_2,C^wcz[@i~I
+サイレン,サイレン,siren,JLPT JLPT_2,GcBu%p~IY}
+逆さ,さかさ,"reverse, upside down",JLPT JLPT_2,Qv$@Ku&bq3
+逆様,さかさま,"reverse, upside down",JLPT JLPT_2,Kss4zt#UsY
+捜す,さがす,"to search, to seek, to look for",JLPT JLPT_2,Id5DHZywm4
+遡る,さかのぼる,"to go back, to date back; ascend",JLPT JLPT_2,Eh_na+J@mx
+酒場,さかば,"bar, bar-room",JLPT JLPT_2,5|=y]wzJ!
+一昨昨日,さきおととい,"two days before yesterday, three days ago",JLPT JLPT_2,Gdz+)4!X77
+先程,さきほど,a little while ago,JLPT JLPT_2,olU114Wmm^
+索引,さくいん,"index, indices",JLPT JLPT_2,v|4{<K[((2
+作者,さくしゃ,"author, artist",JLPT JLPT_2,rc*1{`F2s[
+削除,さくじょ,"elimination, deletion",JLPT JLPT_2,w?HDbz0CK?
+作成,さくせい,"creation, preparation, to make",JLPT JLPT_2,etM+H9CoJX
+作製,さくせい,"manufacture, production",JLPT JLPT_2,Dc+`_1Q;zM
+探る,さぐる,"to search, to look for, investigate",JLPT JLPT_2,ez.n0eIW>4
+囁く,ささやく,"to whisper, to murmur",JLPT JLPT_2,k[yB!L/Yv(
+匙,さじ,spoon,JLPT JLPT_2,ggmZY%(nJ!
+座敷,ざしき,tatami room,JLPT JLPT_2,gHE$Jut%a_
+差し支え,さしつかえ,"hindrance, impediment",JLPT JLPT_2,qX^cb43pTg
+差し引き,さしひき,"deduction, balance",JLPT_1 JLPT JLPT_2,"n;eVw.,_?J"
+刺身,さしみ,sliced raw fish,JLPT JLPT_2,o-]lrw>z:B
+(かさを～) さす,(かさを～) さす,to open; hold (an umbrella),JLPT JLPT_2 MediaMissing,g~n;/-.8!D
+流石,さすが,"indeed, truly, as one would expect",JLPT JLPT_2,gcnvOm#<j9
+撮影,さつえい,photographing,JLPT JLPT_2,G!OhK*g%$p
+雑音,ざつおん,"noise (jarring, grating)",JLPT JLPT_2,o!*<keFQ(
+さっさと,さっさと,quickly,JLPT JLPT_2,s%v?jJ#PZ?
+早速,さっそく,"at once, immediately, promptly",JLPT JLPT_2,rf6~4qt=M6
+錆,さび,rust (color),JLPT JLPT_2,d#S^BY##3K
+錆びる,さびる,"to rust, to become rusty",JLPT JLPT_2,C(}#^wxuf~
+座布団,ざぶとん,cushion (Japanese),JLPT JLPT_2,gUF`H{-)g*
+妨げる,さまたげる,"to disturb, to prevent",JLPT JLPT_2,G7Hja9s=#I
+さようなら,さようなら,good-bye,JLPT JLPT_2,C7QcXl{kSl
+サラリーマン,サラリーマン,salaryman; company employee,Genki_Ln.17 JLPT JLPT_2 Genki,u[I9*22.YA
+騒がしい,さわがしい,noisy,JLPT JLPT_2,&bX;1oe0.
+さわやか,さわやか,"fresh, refreshing",JLPT JLPT_2,b-&ZHIB(b]
+～山,～さん,the name of mountain,JLPT JLPT_2,vw^f*9f$12
+～産,～さん,made in ~,JLPT JLPT_2,tJtC7!P@]H
+三角,さんかく,"triangle, triangular",JLPT JLPT_2,g[NvO}S(1/
+算数,さんすう,arithmetic,JLPT JLPT_2,Lv{*x9Ct]q
+産地,さんち,producing area,JLPT JLPT_2,kpOhDuN0^l
+サンプル,サンプル,sample,JLPT JLPT_2,qFsr;i5_z<
+山林,さんりん,mountain forest,JLPT JLPT_2,LBW4R6~{r}
+～史,～し,history of ~,JLPT JLPT_2,y`(f6xau3#
+～紙,～し,"newspaper, type of paper",JLPT JLPT_2,y0d}(mMiCt
+～寺,～じ,the name of temple,JLPT JLPT_2,Nj@/ru^JH5
+仕上がる,しあがる,to be finished,JLPT JLPT_2,L*U(LWwN%j
+明明後日,しあさって,two days after tomorrow,JLPT JLPT_2,p^=QyTJ7@c
+シーズン,シーズン,season (sporting),JLPT JLPT_2,IARwo(E^_$
+シーツ,シーツ,sheet,JLPT JLPT_2,tb>Ty8@c:P
+寺院,じいん,temple,JLPT JLPT_2,w+~OO%V(dB
+しいんと (する),しいんと (する),"silent (as the grave), (deathly) quiet",JLPT JLPT_2,GmX&j]f:`Y
+自衛,じえい,self-defense,JLPT JLPT_2,Fd@~(E2C4&
+塩辛い,しおからい,salty (taste),JLPT JLPT_2,KK5?3S-Og)
+司会,しかい,"host, chairperson",JLPT JLPT_2,"gh[FPAuk7,"
+四角い,しかくい,square,JLPT JLPT_2,liXo^C-VTz
+仕方がない,しかたがない,"it can't be helped, it's inevitable",JLPT JLPT_2,cRtc^s*^ci
+～時間目,～じかんめ,"~th hour, ~th period",JLPT JLPT_2,LonTM0:Ie8
+時間割,じかんわり,"timetable, schedule",JLPT JLPT_2,mSn8*?kmA+
+〜(日本) 式,～(にほん) しき,"custom,",JLPT JLPT_2 MediaMissing,no!e4=rwH(
+敷地,しきち,site,JLPT JLPT_2,t=sgg6orFn
+敷く,しく,"to spread out, to lay out",JLPT JLPT_2,hY&B~>la@q
+茂る,しげる,to grow thick,JLPT JLPT_2,y~9GLud1<c
+持参,じさん,"bringing, taking, carrying",JLPT JLPT_2,uJOaLu{Ti(
+磁石,じしゃく,magnet,JLPT JLPT_2,e]r5-RFRmm
+四捨五入,ししゃごにゅう,rounding up (fractions),JLPT JLPT_2,w6=>W+1pkD
+始終,しじゅう,"continuously, always, constantly",JLPT JLPT_2,HB8Y[u1tjN
+自習,じしゅう,self-study,JLPT JLPT_2 Intermediate_Japanese_Ln.13 Intermediate_Japanese,iZw[Yfn@{a
+静まる,しずまる,"to quieten down, to calm down",JLPT JLPT_2,A~fP.]oCg-
+姿勢,しせい,attitude; posture,JLPT JLPT_2,lp[GD#kfJS
+自然科学,しぜんかがく,natural science,JLPT JLPT_2,w27iZU{YJD
+時速,じそく,speed (per hour),JLPT JLPT_2,q>FyJWeavm
+子孫,しそん,"descendant, offspring",JLPT JLPT_2,egUI-y7^J$
+死体,したい,corpse,JLPT JLPT_2,O;LU1cw%r-
+下書き,したがき,"rough copy, draft",JLPT JLPT_2,y{OC~2tpj{
+自宅,じたく,one's own home (same as 自分の家 (じぶんのいえ)),Intermediate_Japanese_Ln.5 JLPT JLPT_2 Intermediate_Japanese,y~_1oOR=)i
+下町,したまち,old parts of town,JLPT JLPT_2,tyOH?ReUJ?
+自治,じち,"self-government, autonomy",JLPT JLPT_2,oaY@jv0[<m
+室～,しつ～,room,JLPT JLPT_2,D1_T8l(@L#
+～室,～しつ,counter for room,JLPT JLPT_2,eycwn`U+hZ
+～日,～じつ,day,JLPT JLPT_2,jkFuTgpXi`
+実感,じっかん,"feelings, realization",JLPT JLPT_2,wrZR3pRs]d
+湿気,しっき,"moisture, humidity, dampness",JLPT JLPT_2,"E,5F1zc&nb"
+しつこい,しつこい,"insistent, obstinate",JLPT JLPT_2,cl$L-`(2=_
+実習,じっしゅう,"practice, training",JLPT JLPT_2,Q?<8X`Y6`0
+実績,じっせき,"achievements, actual results",JLPT JLPT_2,PTJ&0rneJs
+執筆,しっぴつ,writing,JLPT JLPT_2,d&KI~[gCB*
+実物,じつぶつ,an actual thing,Intermediate_Japanese_Ln.6 JLPT_2 JLPT Intermediate_Japanese,fJhH*-i=?2
+しっぽ,しっぽ,tail (animal),JLPT JLPT_2,p%JPLRsrQ5
+実用,じつよう,"practical use, utility",JLPT JLPT_2,P$.|MnAuqw
+しつれいしました (かん),しつれいしました (かん),"Excuse me., I'm sorry.",JLPT JLPT_2,x&i%T@U%I?
+実例,じつれい,"example, instance",JLPT JLPT_2,ewdd$MkDp/
+失恋,しつれん,"broken heart, unrequited love",JLPT JLPT_2,HeXichFW(h
+指定,してい,"designation, specification, assignment",JLPT JLPT_2,LeO/O}WHQF
+私鉄,してつ,private railway,JLPT JLPT_2,c~zLGStXx;
+縛る,しばる,"to tie, to bind",JLPT JLPT_2,u<vp]tuxC:
+地盤,じばん,(the) ground,JLPT JLPT_2,"w,S*6c4+}g"
+しびれる,しびれる,to become numb,JLPT JLPT_2,fFBvw=J;Al
+紙幣,しへい,"paper money, notes, bills",JLPT JLPT_2,"OV<,Z6HPYF"
+しぼむ,しぼむ,"to wither, to shrivel",JLPT JLPT_2,rQV|ihDTH/
+絞る,しぼる,"to press, to wring, to squeeze",JLPT JLPT_2,H^H!^blNEc
+縞,しま,stripe,JLPT JLPT_2,O7bnFhR1.s
+～おしまい (おわり),～おしまい (おわり),end up ~,JLPT JLPT_2,B07i&;klYX
+しみじみ,しみじみ,"keenly, deeply, heartily",JLPT JLPT_2,e8*+SqN?3E
+氏名,しめい,full name,JLPT JLPT_2,i423XMuGh3
+締切,しめきり,deadline,JLPT JLPT_2 Intermediate_Japanese Intermediate_Japanese_Ln.3,L=ve:1mZw7
+締め切る,しめきる,"to close, cancel",JLPT JLPT_2,G!n|7FGUeD
+しめた (かん),しめた (かん),"I've got it, all right, fine",JLPT JLPT_2,"zl!oUL,zds"
+地面,じめん,"ground, earth's surface",JLPT JLPT_2,sKB=F~Okr&
+～車,～しゃ,~ car,JLPT JLPT_2,h)<Q^X85ag
+～者,～しゃ,person,JLPT JLPT_2,MTv(a]7l!6
+～社,～しゃ,counter for company,JLPT JLPT_2,sQmjhXA-Mr
+ジャーナリスト,ジャーナリスト,journalist,JLPT JLPT_2,"J*kn.#JF,]"
+社会科学,しゃかいかがく,social science,JLPT JLPT_2,k09..p/K:$
+しゃがむ,しゃがむ,to squat,JLPT JLPT_2,oIYnDS)YJi
+蛇口,じゃぐち,"faucet, tap",JLPT JLPT_2,zRkqq!QHkN
+弱点,じゃくてん,"weak point, weakness",JLPT JLPT_2,H/[LFJ:IvA
+車庫,しゃこ,"garage, car shed",JLPT JLPT_2,lE^9nzt^2-
+車掌,しゃしょう,(train) conductor,JLPT JLPT_2,b.n4^BFEbO
+写生,しゃせい,"sketching, drawing from nature",JLPT JLPT_2,C+dKrz0lC&
+社説,しゃせつ,editorial,JLPT JLPT_2,OPZsh9XL6-
+しゃっくり,しゃっくり,"hiccough, hiccup",JLPT JLPT_2,yp$Z>Vh|zo
+シャッター,シャッター,shutter,JLPT JLPT_2,KMNzQgzh26
+しゃぶる,しゃぶる,"to suck, to chew",JLPT JLPT_2,yZO~f#ZDsc
+車輪,しゃりん,(car) wheel,JLPT JLPT_2,w^RM.{Q-65
+洒落,しゃれ,"joke, pun, witticism",JLPT JLPT_2,FiN|9?=c;o
+じゃんけん,じゃんけん,rock-scissors-paper game,JLPT JLPT_2,"r[@>bl*,N."
+～手,～しゅ,"~ player, person who does ~",JLPT JLPT_2,IkixzX56yl
+～酒,～しゅ,kind of alcohol,JLPT JLPT_2,k?BC&(RjAH
+～集,～しゅう,collection of ~,JLPT JLPT_2,LdT;R@utl1
+重～,じゅう～,heavy ~,JLPT JLPT_2,"j{}Q,b8AUe"
+集会,しゅうかい,"meeting, assembly",JLPT JLPT_2,FB%)C]f(i:
+集金,しゅうきん,money collection,JLPT JLPT_2,vqI&vRYrZz
+集合,しゅうごう,"gathering, assembly",JLPT JLPT_2,QQkx-.?$px
+習字,しゅうじ,penmanship,JLPT JLPT_2,DHN{BIzy9J
+修繕,しゅうぜん,"repair, mending",JLPT JLPT_2,8Hn$K(/y&
+じゅうたん (カーペット),じゅうたん (カーペット),carpet,JLPT JLPT_2,wuSQ.Es4!<
+終点,しゅうてん,"terminus, last stop (e.g train)",JLPT JLPT_2,yoA+}ku9{T
+重点,じゅうてん,"important point, lay stress on, emphasis",JLPT JLPT_2,m03VNo)9t$
+リズム,リズム,rhythm,JLPT JLPT_2,sEJgqt=slc
+リットル,リットル,liter,JLPT JLPT_2,J=WKC<9({c
+リボン,リボン,ribbon,JLPT JLPT_2,d<&zzlZBY`
+略す,りゃくす,to abbreviate,JLPT JLPT_2,tS9.Rzrjw(
+～流,～りゅう,"fashion, manner, way",JLPT JLPT_2,zpH1qv^$%p
+流域,りゅういき,(river) basin,JLPT JLPT_2,fHWZ-KtDHt
+両～,りょう～,both ~,JLPT JLPT_2,i/MiSZ3!G4
+～料,～りょう,"fare, charge",JLPT JLPT_2,IX116ZKh4C
+～領,～りょう,territory,JLPT JLPT_2,MXZX<Kqb>
+両側,りょうがわ,both sides,JLPT JLPT_2,I4rwSM+9WF
+漁師,りょうし,fisherman,JLPT JLPT_2,lKSSx-0&_N
+領事,りょうじ,consul,JLPT JLPT_2,Pu=nQI2MaF
+領収,りょうしゅう,"receipt, voucher",JLPT JLPT_2,g0BH(u/;@f
+～力,～りょく,power of ~,JLPT JLPT_2,G<sBHiz^]!
+臨時,りんじ,"temporary, special, extraordinary",JLPT JLPT_2,"IQ{y{$,U6]"
+留守番,るすばん,"care-taking, caretaker, house-watching",JLPT JLPT_2 Genki_Ln.23 Genki,MW#7DF[RQ)
+零点,れいてん,"zero, no marks",JLPT JLPT_2,Hh<_pAYn4<
+冷凍,れいとう,"freezing, cold storage, refrigeration",JLPT JLPT_2,iIL[pf<7Zb
+レインコート,レインコート,raincoat,JLPT JLPT_2,h{`Micb;bg
+レクリェーション,レクリェーション,recreation,JLPT JLPT_2,MmD@s.(0])
+レジャー,レジャー,leisure,JLPT JLPT_2,o0|E{X}Nj}
+列島,れっとう,chain of islands,JLPT JLPT_2,Ev?wG8aB}r
+リポート,リポート,"report, paper",JLPT JLPT_2,"C>!.T,TyRb"
+煉瓦,れんが,brick,JLPT JLPT_2,cY@sqBwW67
+連合,れんごう,"union, alliance",JLPT JLPT_2,F3-L+C:h6>
+レンズ,レンズ,lens,JLPT JLPT_2,w1(O7Kos8|
+ろうそく,ろうそく,candle,JLPT_2 JLPT Genki_Ln.18 Genki,w_)UKdrs_:
+ローマ字,ローマじ,"romanization, Roman letters (alphabet)",JLPT_2 JLPT Intermediate_Japanese_Ln.15 Intermediate_Japanese,"n,*Nb4*]$5"
+録音,ろくおん,(audio) recording,JLPT JLPT_2,E#iNpJw]tp
+ロッカー,ロッカー,locker,JLPT JLPT_2,m*zHe7hzP9
+ロビー,ロビー,lobby,JLPT JLPT_2,i8ig9mjNdK
+～論,～ろん,theory,JLPT JLPT_2,"ec<,e&v$V7"
+論ずる,ろんずる,"to argue, to discuss",JLPT JLPT_2,y/^Bn9Z9<_
+和～,わ～,Japanese style,JLPT JLPT_2,JBvdN:J16X
+～羽,～わ,counter for rabbits; birds,JLPT JLPT_2,FQL)TF/a}O
+和英,わえい,Japanese-English,JLPT JLPT_2,"B*@cU.E9,A"
+我～,わが～,our ~,JLPT JLPT_2,L0:Cs<lBa|
+若々しい,わかわかしい,"youthful, young",JLPT JLPT_2,EC2u(({!rQ
+詫びる,わびる,to apologize,JLPT JLPT_2,x!9QsM6~r{
+和服,わふく,Japanese clothes,JLPT JLPT_2,v@K#0^dxIj
+割合に,わりあいに,"relatively, comparatively",JLPT JLPT_2,A0do>r1!)l
+割算,わりざん,division (math),JLPT JLPT_2,eZw4N!$Eu-
+割と,わりと,"relatively, comparatively",JLPT JLPT_2,"I-,z(jixJ,"
+割引,わりびき,discount,JLPT JLPT_2,oLo@nz.I(q
+ワンピース,ワンピース,one-piece dress,JLPT JLPT_2,l({SDlo@!^
+アイデア; アイディア,アイデア; アイディア,idea,JLPT JLPT_2,NkL-h!TKp$
+あいまい,あいまい,"vague, ambiguous",JLPT JLPT_2,"y8aZ,my]%p"
+扇ぐ,あおぐ,"to fan, to flap",JLPT JLPT_2,Gk2+[0&j}c
+青白い,あおじろい,pale,JLPT JLPT_2,B[(dutQ)|%
+呆れる,あきれる,"to be shocked, to be appalled",JLPT JLPT_2,o8s#rYeo4>
+アクセント,アクセント,accent,JLPT JLPT_2,"w=+|,GhTIn"
+あくび,あくび,yawn,JLPT JLPT_2,v|~6.5@[n^
+飽くまで,あくまで,"to the end, to the last, stubbornly",JLPT JLPT_2,"vD,5@+@_q]"
+明くる～,あくる～,"next, following",JLPT JLPT_2,c0UJ5Dk9?v
+明け方,あけがた,dawn,JLPT JLPT_2,pi=5b}Xk:R
+憧れる,あこがれる,"to long for, to yearn after",JLPT JLPT_2,c:=`W|}Gw`
+朝寝坊,あさねぼう,"oversleeping, late riser",JLPT JLPT_2,kR|>&(p6rG
+足跡,あしあと,footprint,JLPT JLPT_2,lj:ebvgd-q
+足元,あしもと,at one's feet,JLPT JLPT_2,Ha)Qe[babj
+味わう,あじわう,"to taste, to savor",JLPT JLPT_2,uxSo4jtf~d
+あちらこちら,あちらこちら,here and there,JLPT JLPT_2,Q~Ip4wR{af
+厚かましい,あつかましい,"impudent, shameless,",JLPT JLPT_2,"wZ0,_rCNQo"
+圧縮,あっしゅく,"compression, condensation, pressure",JLPT JLPT_2,G:WAF/Dx1i
+宛名,あてな,"address, direction",JLPT JLPT_2,"Q!,(6>`cO,"
+当てはまる,あてはまる,"to be applicable, to come under (a category)",JLPT JLPT_2,gWVd1Z[tfA
+当てはめる,あてはめる,"to apply, to adapt",JLPT JLPT_2,OP(Hu}mMQq
+暴れる,あばれる,"to act violently, to rage",JLPT JLPT_2,L6trU>v^!
+あぶる,あぶる,"to scorch, to roast",JLPT JLPT_2,Jz@lzbGk7x
+あふれる,あふれる,"to flood, to overflow",JLPT JLPT_2,be7:(ploED
+雨戸,あまど,sliding storm door,JLPT JLPT_2,v+crs*_nva
+甘やかす,あまやかす,"to pamper, to spoil",JLPT JLPT_2,f~Uvnb+KP=
+余る,あまる,"to be left over, to be in excess",JLPT JLPT_2,r`ob2WL<}I
+編み物,あみもの,knitting,JLPT JLPT_2,KBOilYWmo2
+編む,あむ,to knit,Genki Genki_Ln.13 JLPT JLPT_2,"Bcd5,b]]w5"
+危うい,あやうい,"dangerous, critical",JLPT JLPT_2,JYnP1Z3O1n
+怪しい,あやしい,"suspicious, dubious, doubtful",JLPT JLPT_2,r?rB[7EP>5
+荒い,あらい,"rough, rude, wild",JLPT JLPT_2,P5h|CxAaCE
+粗い,あらい,"coarse, rough",JLPT JLPT_2,t~Hs$2O?FD
+粗筋,あらすじ,"outline, synopsis",JLPT JLPT_2,GLP0^5#h&@
+改めて,あらためて,"another time, again",JLPT JLPT_2,M$)j_R%uiN
+改める,あらためる,"to change, to reform, to revise",JLPT JLPT_2,k-ggJ#W2U)
+有難い,ありがたい,"grateful, thankful, appreciated",JLPT JLPT_2,yLS%JRr`~I
+あれこれ,あれこれ,"one thing or another, this and that",JLPT JLPT_2,H3{e@Ms<u9
+荒れる,あれる,"to be stormy, to be rough, to be ruined",JLPT JLPT_2,opLT~#LruK
+慌ただしい,あわただしい,"busy, hurried",JLPT JLPT_2,"d*5}[C^,EG"
+安易,あんい,easy-going,JLPT JLPT_2,cpsk;f2&m/
+アンテナ,アンテナ,antenna,JLPT JLPT_2,u25h^5*Vx<
+～位,～い,~th place,JLPT JLPT_2,G*#PQ&xZe;
+言い出す,いいだす,"to start talking, to suggest",JLPT JLPT_2,ma-oStit-!
+言い付ける,いいつける,"to tell, to order",JLPT JLPT_2,K=!C~7x9Db
+意義,いぎ,"meaning, significance",JLPT JLPT_2,K*wt2r`%<B
+生き生き,いきいき,"vividly, lively",JLPT JLPT_2,Am|5$tSksY
+いきなり,いきなり,all of a sudden,Intermediate_Japanese Intermediate_Japanese_Ln.13 JLPT JLPT_2,J=<-XB_N-t
+幾～,いく～,several ~,JLPT JLPT_2,o<XZoP)ZFl
+育児,いくじ,"childcare, nursing",Intermediate_Japanese Intermediate_Japanese_Ln.14 JLPT JLPT_2,hwmLlQK_:7
+幾分,いくぶん,somewhat,JLPT JLPT_2,wUiE3U*>P6
+生け花,いけばな,flower arrangement,JLPT JLPT_2,o!9H~`j>Ob
+以後,いご,after this; from now on; hereafter,JLPT JLPT_2 Intermediate_Japanese_Ln.8 Intermediate_Japanese,"OpKq9d,k&%"
+以降,いこう,"on and after, hereafter",JLPT JLPT_2,"hI7gX,ojpA"
+イコール,イコール,equal,JLPT JLPT_2,F:$jr>Gcvz
+勇ましい,いさましい,"brave, valiant",JLPT JLPT_2,jh9$B&!xLP
+衣食住,いしょくじゅう,"food, clothing and shelter",JLPT JLPT_2,yYjE5SKh.|
+～いち (にほんいち),～いち (にほんいち),No. 1 ~ (in),JLPT JLPT_2,GmGAkPKtVr
+いちいち,いちいち,"one by one, separately",JLPT JLPT_2,c`q7>|uO;;
+一応,いちおう,"tentatively, for the time being",JLPT JLPT_2,DUm[|ty]2z
+一段と,いちだんと,"by far, greater",JLPT_2 JLPT Intermediate_Japanese_Ln.15 Intermediate_Japanese,H2Se/ybI3t
+一流,いちりゅう,"first class, leading",JLPT JLPT_2,Q-z[xmuvA*
+一昨日,いっさくじつ,day before yesterday,JLPT JLPT_2,q)l_a#Mm^@
+一昨年,いっさくねん,year before last,JLPT JLPT_2,H3]XYSojiI
+一斉,いっせい,"simultaneous, all at once",JLPT JLPT_2,H3C62{9DP`
+一旦,いったん,"once, for a moment",JLPT JLPT_2,"Fv;m,:R#X("
+一定,いってい,"fixed, settled, regular",JLPT JLPT_2,Qx{lB{;UG~
+行っていらっしゃい,いっていらっしゃい,"have a nice day, see you",JLPT JLPT_2,Q~[>k~aD(O
+行ってらっしゃい,いってらっしゃい,"have a nice day, see you",JLPT JLPT_2,eL-o)31hPE
+いってまいります,いってまいります,"(Lit.) I'll go and come back, 'I'm going, see you later'",JLPT JLPT_2,wg6qf;hcRZ
+いってきます,いってきます,"(Lit.) I'll go and come back, 'I'm going, see you later'",JLPT JLPT_2,O;VZoV$S8W
+移転,いてん,"moving, transfer",JLPT JLPT_2,A[fI%[bpSh
+井戸,いど,water well,JLPT JLPT_2,"Fw}ob1+9,G"
+緯度,いど,latitude (navigation),JLPT JLPT_2,mKsQtDevFo
+威張る,いばる,"to be proud, to swagger",JLPT JLPT_2,kEp;c{E_R1
+嫌がる,いやがる,"reluctant, to dislike",JLPT JLPT_2,wwKIWtwwb&
+いよいよ,いよいよ,"more and more, increasingly, at last",JLPT JLPT_2,h5$?Ko/s)4
+煎る,いる,to roast,JLPT JLPT_2,"bLrppO],[q"
+炒る,いる,"to parch, to roast",JLPT JLPT_2,dcy>(4#yAy
+入れ物,いれもの,"container, case",JLPT JLPT_2,RbLFeu/vvY
+インキ,インキ,ink,JLPT JLPT_2,I{rR0;+{t|
+引力,いんりょく,gravity,JLPT JLPT_2,cP:.V7Ysb%
+ウーマン,ウーマン,woman,JLPT JLPT_2,"O5m,c!v(H5"
+ウール,ウール,wool,JLPT JLPT_2,bgePnfbn;n
+ウエートレス,ウエートレス,waitress,JLPT JLPT_2,C$[Z6H5/gO
+植木,うえき,"garden shrubs, trees, potted plant",JLPT JLPT_2,j}3Ny1eUVB
+飢える,うえる,to starve,JLPT JLPT_2,CQMZtp4T24
+浮ぶ,うかぶ,"to float, to rise to surface, to come to mind",JLPT JLPT_2,IN|gezRxCl
+浮かべる,うかべる,to float; to express,JLPT JLPT_2,Nj{^.3q>-V
+浮く,うく,to float,JLPT JLPT_2,JS6e6ewLTQ
+承る,うけたまわる,"(humble) to hear, to be told, to know",JLPT JLPT_2,IKhK:kjp?E
+受取,うけとり,receipt,JLPT JLPT_2,"k?,%G]kD{4"
+受け持つ,うけもつ,to take (be in) charge of,JLPT JLPT_2,b1cU__S&E=
+薄暗い,うすぐらい,"dim, gloomy",JLPT JLPT_2,m6<YpAEgo!
+薄める,うすめる,"to dilute, to water down",JLPT JLPT_2,F/33?d^ON{
+打合せ,うちあわせ,"business meeting, previous arrangement",JLPT JLPT_2,I>LU.f-`NP
+打ち消す,うちけす,"to deny, to negate",JLPT JLPT_2,HCI~2sil9S
+うどん,うどん,udon noodles (Japanese traditional noodles),Intermediate_Japanese_Ln.6 JLPT_2 JLPT Intermediate_Japanese,zUsFPVRoV;
+うなずく,うなずく,to nod,JLPT JLPT_2,qP>fuv+29W
+敬う,うやまう,"to show respect, to honor",JLPT JLPT_2,hRta^!r1WT
+裏返す,うらがえす,"to turn inside out, to turn (something) over",JLPT JLPT_2,cJR[<yA$vw
+裏口,うらぐち,"backdoor, rear entrance",JLPT JLPT_2,xTA1N/QL{`
+占う,うらなう,"to predict, to divine",JLPT JLPT_2,isAnLJU5w0
+恨み,うらみ,resentment,JLPT JLPT_2,"A+B,^3x]O="
+恨む,うらむ,"to curse, to feel bitter",JLPT JLPT_2,D@R<vxJ)<U
+羨む,うらやむ,to envy,JLPT JLPT_2,tthSa[}tg_
+売上,うりあげ,"amount sold, proceeds",JLPT JLPT_2,p9d{%uQSR:
+売り切れ,うりきれ,sold-out,JLPT JLPT_2,J#x&HGI1=J
+売り切れる,うりきれる,to be sold out,JLPT JLPT_2,Ls1JX0p>PP
+売行き,うれゆき,sales,JLPT JLPT_2,t0r)gygLV
+うろうろ,うろうろ,"loitering, aimless wandering",JLPT JLPT_2,h0R8Gh3Y^Q
+上～,うわ～,upper ~,JLPT JLPT_2,IiRGZY[b#L
+運河,うんが,"canal, waterway",JLPT JLPT_2,os15ZQMcmE
+うんと,うんと,"a great deal, very much",JLPT JLPT_2,K1|_U:?Zi2
+英文,えいぶん,sentence in English,JLPT JLPT_2,N6cGn)]tI&
+英和,えいわ,"English-Japanese (e.g., dictionary)",JLPT JLPT_2,iL]q/<ICwB
+ええと,ええと,"let me see, well, er...",JLPT JLPT_2,k9QoK3_%6*
+液体,えきたい,"liquid, fluid",JLPT JLPT_2,CdyMwPZr;-
+エチケット,エチケット,etiquette,JLPT JLPT_2,JD<(LA+lT8
+絵の具,えのぐ,"colors, paints",JLPT JLPT_2,il.hIkd5@*
+エプロン,エプロン,apron,JLPT JLPT_2,iE$K!WaP&V
+偉い,えらい,"great, celebrated, remarkable,",JLPT JLPT_2,va_:XsaQZY
+～園,～えん,~ garden (especially man made),JLPT JLPT_2,z)[Ulzmb?X
+宴会,えんかい,"party, banquet",JLPT JLPT_2,i-sdwsFh$Z
+園芸,えんげい,"horticulture, gardening",JLPT JLPT_2,BqeOt&R7YG
+演劇,えんげき,play (theatrical),JLPT JLPT_2,"Otg5e*No,p"
+円周,えんしゅう,circumference,JLPT JLPT_2,Q#$a9V=}iv
+遠足,えんそく,"trip, hike, picnic",JLPT JLPT_2,K/i>jpon?&
+延長,えんちょう,"extension, prolongation",JLPT JLPT_2,kv5xP;(9Nh
+煙突,えんとつ,chimney,JLPT JLPT_2,vA~$8Qi$g7
+御～,おん～,honorific ~,JLPT JLPT_2,oiyGIL2u!>
+追いかける,おいかける,to chase or run after someone,JLPT JLPT_2,IwJw]GEFbC
+追い越す,おいこす,"to pass (e.g., car), to outdistance, to outstrip",JLPT JLPT_2,QFqJ-N@k`a
+オイル,オイル,oil,JLPT JLPT_2,lfd7.m*9JT
+王女,おうじょ,princess,JLPT JLPT_2,mtg%KXTE/:
+応ずる,おうずる,"to respond, to comply with",JLPT JLPT_2,uaD~LH-B3=
+応接,おうせつ,reception,JLPT JLPT_2,bEx~ccePEK
+応対,おうたい,"receiving, dealing with",JLPT JLPT_2,"cy],C~WcL}"
+往復,おうふく,"(col) round trip, coming and going, return ticket",JLPT JLPT_2,n3GyO1oyI7
+欧米,おうべい,"Europe and America, the West",JLPT_2 JLPT Intermediate_Japanese_Ln.7 Intermediate_Japanese,n1r<]dO&N/
+応用,おうよう,"application, put to practical use",JLPT JLPT_2,KS%06Cn^yw
+電波,でんぱ,electro-magnetic wave,JLPT JLPT_2,cg0Ez+Y@GU
+テンポ,テンポ,tempo,JLPT JLPT_2,Hi]gxBaRU^
+電流,でんりゅう,electric current,JLPT JLPT_2,w3QM-(pmFO
+電力,でんりょく,electric power,JLPT JLPT_2,BkP9bGxxa`
+問い合わせ,といあわせ,inquiry,JLPT JLPT_2,h}t;%K/E(N
+～頭,～とう,counter for animals,JLPT JLPT_2,Q04jNq<%}1
+～等,～とう,"level, place",JLPT JLPT_2,t~N);db(/R
+～島,～とう,kind of islands,JLPT JLPT_2,xDO?MQ[t-7
+銅,どう,copper,JLPT JLPT_2,t]G?*GHI@U
+同～,どう～,same ~,JLPT JLPT_2,"n,@c1nuA~O"
+～道,～どう,"kind of path, road",JLPT JLPT_2,NK#jvaQLbz
+どういたしまして (かん),どういたしまして (かん),"you are welcome, don't mention it",JLPT JLPT_2,qsFKJD&|L2
+統一,とういつ,"unity, consolidation, uniformity",JLPT JLPT_2,Qgn:y`-!#|
+同格,どうかく,"the same rank, equality, apposition",JLPT JLPT_2,MiJmwE9)Tk
+峠,とうげ,"ridge, (mountain) pass, difficult part",JLPT JLPT_2,"N<{B4W~=,!"
+統計,とうけい,"scattering, a scatter, dispersion",JLPT JLPT_2,vX}p`nL9tJ
+動作,どうさ,"action, movements, motions",JLPT JLPT_2,dT{x#l3poW
+東西,とうざい,"East and West, whole country",JLPT JLPT_2,j$kHEw}u=O
+当日,とうじつ,"appointed day, very day",JLPT JLPT_2,DMRuSTW/kN
+投書,とうしょ,"letter to the editor, letter from a reader, contribution",JLPT_2 JLPT Intermediate_Japanese_Ln.15 Intermediate_Japanese,cIf~cB@d=B
+登場,とうじょう,entry (on stage),JLPT JLPT_2,Ly]{kwvk<^
+どうせ,どうせ,"anyhow, in any case, at any rate",JLPT JLPT_2,qUZxLcShyb
+灯台,とうだい,lighthouse,JLPT JLPT_2,z?>!uGNDHa
+盗難,とうなん,"theft, robbery",JLPT JLPT_2,HhHB}s;s98
+当番,とうばん,being on duty,JLPT JLPT_2,t5f^H;G`pb
+等分,とうぶん,division into equal parts,JLPT JLPT_2,gvTvgz{bLa
+透明,とうめい,"transparency, cleanness",JLPT JLPT_2,P(@#|>UOt0
+灯油,とうゆ,"lamp oil, kerosene",JLPT JLPT_2,vZ4oHV;=:a
+童話,どうわ,fairy tale,JLPT JLPT_2,D&Yh:&s%jk
+～通り,～とおり,"in accordance with ~; following ~; ~ street, ~ avenue",JLPT JLPT_2,i!k>vq-guB
+通り掛かる,とおりかかる,to happen to pass by,JLPT JLPT_2,"luDHt,5Sk,"
+溶かす,とかす,"to melt, to dissolve",JLPT JLPT_2,l;^zOZ_oE|
+尖る,とがる,"to taper to a point, to become sharp",JLPT JLPT_2,"e{Pl+,CC6G"
+どきどき,どきどき,"throb, beat (fast)",JLPT JLPT_2,x-PSkMj&q>
+特殊,とくしゅ,"special, unique",JLPT JLPT_2,w^_lcgoHoI
+特色,とくしょく,"characteristic, feature",JLPT JLPT_2,B-+4Us]g7J
+特定,とくてい,"specific, special, particular",JLPT JLPT_2,t|TfJJg|sz
+特売,とくばい,special sale,JLPT JLPT_2,p@T8CIs-/#
+溶け込む,とけこむ,to melt into; to become a part of,JLPT JLPT_2 Intermediate_Japanese Intermediate_Japanese_Ln.11,x]~8B=uZCs
+退ける,どける,"to dislodge, to put something out of the way",JLPT JLPT_2,"l,uqdq*vL$"
+床の間,とこのま,alcove,JLPT JLPT_2,DWuzigwd1O
+～ところ,～ところ,about to do ~,JLPT JLPT_2,B;8DjvC&9}
+所々,ところどころ,"here and there, some parts (of something)",JLPT JLPT_2,JBl+zKfWO=
+都心,としん,heart (of city),JLPT JLPT_2,q@;X-KR+6x
+戸棚,とだな,"cupboard, cabinet",JLPT JLPT_2,fA;1NRcg;.
+とっくに,とっくに,"long ago, already, a long time ago",JLPT JLPT_2,"s1FB+z(/k,"
+どっと,どっと,suddenly,JLPT JLPT_2,l_f3!1:=g.
+整う,ととのう,"to be prepared, to be in order, to be arranged",JLPT JLPT_2,qFP1)1i}(/
+留まる,とどまる,"to be fixed; to abide, to stay (in the one place)",JLPT JLPT_2,"f],Vz_=*R]"
+怒鳴る,どなる,"to shout, to yell",JLPT JLPT_2,PA4d>_N*GM
+殿,どの,Mister (mostly in addressing someone on an envelope),JLPT JLPT_2,G)i@|4rCFu
+飛び込む,とびこむ,"to jump in, to leap in, to plunge into",JLPT JLPT_2,m)8^_h=xfZ
+留まる,とまる,"to be fixed; to abide, to stay (in the one place)",JLPT JLPT_2,lR~zbQY;%4
+ともかく,ともかく,"anyhow, at any rate, anyway",JLPT JLPT_2,CwP{EP}I?z
+捕える,とらえる,"to seize, to capture, to arrest",JLPT JLPT_2,"j}2L,caH~b"
+取り入れる,とりいれる,"to harvest, to take in, to adopt",JLPT JLPT_2,w2_26oic>]
+取り消す,とりけす,to cancel,JLPT JLPT_2,c++rlW<4bj
+取り出す,とりだす,"to take out, to pick out",JLPT JLPT_2,mbHbo^x=YD
+採る,とる,"to adopt (measure, proposal); to pick (fruit)",JLPT JLPT_2,Kwcy6Nu#VV
+捕る,とる,"to take, to catch (fish)",JLPT JLPT_2,h-foFU)J+%
+丼,どんぶり,"porcelain bowl, bowl of rice with food on top",JLPT JLPT_2,K/7)Qgev~b
+～内,～ない,inside ~,JLPT JLPT_2,K?<zC9:h:N
+内科,ないか,"internist clinic, internal medicine",JLPT JLPT_2,cL3Q<QI{Xi
+内線,ないせん,phone extension,JLPT JLPT_2,vWixbAJ8L3
+ナイロン,ナイロン,nylon,JLPT JLPT_2,"J#^zz>A,)}"
+長～,なが～,long ~,JLPT JLPT_2,"!(,ztix|0"
+仲直り,なかなおり,"reconciliation, make peace with",JLPT JLPT_2,lg&xbaku[H
+長引く,ながびく,"to be prolonged, to drag on",JLPT JLPT_2,KFJ:-OqPv)
+中指,なかゆび,middle finger,JLPT JLPT_2,OVu}*4o9[-
+仲良し,なかよし,"intimate friend, bosom buddy",JLPT JLPT_2,bY}?0:RFF`
+慰める,なぐさめる,"to comfort, to console",JLPT JLPT_2,OOn!)Q5mF^
+為す,なす,"to accomplish, to do",JLPT JLPT_2,sRagOZ&+9+
+謎謎,なぞなぞ,riddle,JLPT JLPT_2,kh;qXYZm$x
+傾らか,なだらか,"gradual, gentle",JLPT JLPT_2,N*gYt%kA/%
+懐かしい,なつかしい,"dear, desired, missed",JLPT JLPT_2,AgDX*Gpp{!
+撫でる,なでる,"to brush gently, to stroke",JLPT JLPT_2,x?eU}#7q`n
+斜め,ななめ,"diagonal, oblique",JLPT JLPT_2,e/[lM~+tA8
+なにしろ,なにしろ,"at any rate, in any case",JLPT JLPT_2,p8WN.jfeNo
+何々,なになに,"such and such, What?",JLPT JLPT_2,v!2OpO8|[
+何分,なにぶん,"by all means, please",JLPT JLPT_2,t3>sbe_K8<
+生意気,なまいき,"impertinent, impudent",JLPT JLPT_2,mw&FA%y!wL
+並木,なみき,"roadside tree, row of trees",JLPT JLPT_2,B&w5g2.BdM
+倣う,ならう,"to imitate, to follow, to emulate",JLPT JLPT_2,bk+_vg]*X*
+南極,なんきょく,"south pole, Antarctic",JLPT JLPT_2,i(}x3JhEWk
+なんとなく,なんとなく,"somehow or other, for some reason or another",JLPT JLPT_2,NHiEMH@?%b
+なんとも,なんとも,"nothing (with neg. verb), quite, not a bit",JLPT JLPT_2,d60cvEnM@g
+ナンバー,ナンバー,number,JLPT JLPT_2,w%6-K{mlSu
+南米,なんべい,South America,JLPT_2 JLPT Intermediate_Japanese_Ln.15 Intermediate_Japanese,IS$N[3lqN_
+南北,なんぼく,south and north,JLPT JLPT_2,v&@^W~@3Lc
+匂う,におう,"to be fragrant, to smell",JLPT JLPT_2,HNXw9CMq7V
+逃がす,にがす,"to let loose, to set free, to let escape",JLPT JLPT_2,ze5+}#f{P4
+憎い,にくい,"hateful, abominable, detestable",JLPT JLPT_2,Qq0d(|J(G%
+～難い,～がたい,hard (difficult) to do ~,JLPT_1 JLPT JLPT_2,q5_^x`K^C~
+憎む,にくむ,"to hate, to detest",JLPT JLPT_2,vu`fYICMu{
+憎らしい,にくらしい,"odious, hateful",JLPT JLPT_2,f/_kC?^S&d
+にこにこ,にこにこ,"smile sweetly, smiley",JLPT JLPT_2,"n^be_-@ly,"
+濁る,にごる,"to become muddy, to get cloudy",JLPT JLPT_2,Lky&[Q-5R2
+虹,にじ,rainbow,JLPT JLPT_2,GlQhx;DK8+
+日時,にちじ,date and time,JLPT JLPT_2,PH9R9B_JX5
+日用品,にちようひん,daily necessities,JLPT JLPT_2,c&vov/+z8>
+日課,にっか,"daily work, daily routine",JLPT JLPT_2,c6js~O66Z[
+日程,にってい,schedule,JLPT JLPT_2,AHKP7#Wd&/
+鈍い,にぶい,"dull (e.g., a knife), thickheaded, slow (opposite of fast), stupid",JLPT JLPT_2,s~5sFu`bb@
+入社,にゅうしゃ,entry to a company,JLPT JLPT_2,w-`JY=1e/D
+女房,にょうぼう,wife,JLPT JLPT_2,sU~=iRlvo]
+睨む,にらむ,"to glare at, to stare; to keep an eye on",JLPT JLPT_2,fHjyY#znW:
+俄,にわか,"sudden, abrupt, unexpected",JLPT JLPT_2,t[:`;rL-va
+縫う,ぬう,to sew,JLPT JLPT_2,"Ng&<M,@BtR"
+ねじ,ねじ,(a) screw,JLPT JLPT_2,Re-*YljhSS
+捩る,ねじる,to twist,JLPT JLPT_2,D{g8=@A4<B
+ネックレス,ネックレス,necklace,JLPT JLPT_2,MuQQ$:&B5C
+熱する,ねっする,to heat,JLPT JLPT_2,rJh1ly.2gv
+寝間着,ねまき,"sleep-wear, pajamas",JLPT JLPT_2,lkd)EF+;p^
+寝巻,ねまき,"sleep-wear, pajamas",JLPT JLPT_2,bI$hc3f6^A
+狙い,ねらい,aim,JLPT JLPT_2,+@]APxhP:
+狙う,ねらう,to aim at,JLPT JLPT_2,"u_Zq{@}_,2"
+～年生,～ねんせい,counter for school year,JLPT JLPT_2,seB~`F&UPJ
+年度,ねんど,"year, fiscal year",JLPT JLPT_2,zOnWMA:uDf
+農産物,のうさんぶつ,agricultural produce,JLPT JLPT_2,"NI`BmF+,nH"
+農村,のうそん,agricultural community,JLPT JLPT_2,x4+Tr<A;s]
+濃度,のうど,"concentration, density",JLPT JLPT_2,P+%XFi<sCv
+農薬,のうやく,agricultural chemicals,JLPT JLPT_2,l1C346K%hs
+能率,のうりつ,efficiency,JLPT JLPT_2,Na^nQlXLin
+のこぎり,のこぎり,saw,JLPT JLPT_2,Mi-TTuwz8!
+残らず,のこらず,"completely, without exception",JLPT JLPT_2,C>>Dz3Vn+r
+上り,のぼり,"up-train (going to Tokyo), ascent",JLPT JLPT_2,x3At`fIc#9
+糊,のり,"glue, paste, starch",JLPT JLPT_2,xb.2gr28hJ
+乗換,のりかえ,"a transfer (e.g., trains, buses)",JLPT JLPT_2,mEuM{0XEgL
+乗り越し,のりこし,riding past (one's station),JLPT JLPT_2,msQgthowMg
+鈍い,のろい,"dull (e.g., a knife), slow (opposite of fast), stupid",JLPT JLPT_2,"x,FV2}Y%-X"
+のろのろ,のろのろ,"slowly, sluggishly",JLPT JLPT_2,KUA4SG[)M:
+呑気,のんき,"carefree, optimistic, careless",JLPT JLPT_2,t$DYuRW-VV
+はい (かん),はい (かん),yes,JLPT JLPT_2,AiQ1*c2HyJ
+灰色,はいいろ,"grey, ashen",JLPT JLPT_2,ss^FM_Mq2^
+俳句,はいく,haiku poetry,JLPT JLPT_2,hwb=j~#GQg
+売店,ばいてん,"shop, stand",JLPT JLPT_2,z@FJMhw{sZ
+バイバイ,バイバイ,bye bye,JLPT JLPT_2,o^SdrB~Ugj
+売買,ばいばい,"trade, buying and selling",JLPT JLPT_2,w9ww[Mi8PB
+這う,はう,"to creep, to crawl",JLPT JLPT_2,J$@-ykytmX
+剥す,はがす,"to tear off, to peel off, to rip off",JLPT JLPT_2,w1IgSLSCS%
+ばからしい,ばからしい,absurd,JLPT JLPT_2,"Ac.j@?6<t,"
+秤,はかり,"scales, weighing machine",JLPT JLPT_2,K:$(:hKZp/
+吐き気,はきけ,"nausea, sickness in the stomach",JLPT JLPT_2,kx+nKGh/`U
+はきはき,はきはき,clearly,JLPT JLPT_2,JVjc#=Q+e1
+～泊,～はく,"counter for staying (e.g., 2 nights)",JLPT JLPT_2,PblG<4:M5~
+歯車,はぐるま,"gear, cog-wheel",JLPT JLPT_2,j7]b4f$098
+バケツ,バケツ,"bucket, pail",JLPT JLPT_2,s9Y+YEtVRT
+挟まる,はさまる,"to get between, to be caught in",JLPT JLPT_2,e1(3K^._OQ
+挟む,はさむ,to pinch; to hold between; to insert,JLPT JLPT_2,l~cQobWV^N
+梯子,はしご,"ladder, stairs",JLPT JLPT_2,M(f1q$Y$t;
+始めに,はじめに,"to begin with, first of all",JLPT JLPT_2,"IrD7xzN,r4"
+初めに,はじめに,"to begin with, first of all",JLPT JLPT_2,d;;?&/B6za
+はじめまして,はじめまして,"How do you do, I am glad to meet you",JLPT JLPT_2,"M]0`I,lN9&"
+斜,はす,diagonal,JLPT JLPT_2,yZ/JT}.{x%
+パターン,パターン,pattern,JLPT JLPT_2,yMee~-[vv4
+肌着,はだぎ,underwear,JLPT JLPT_2,tm(~La~OiQ
+果して,はたして,"as was expected, really",JLPT JLPT_2,vU#n=PULcb
+鉢,はち,"a bowl, a pot",JLPT JLPT_2,s9xu=`E7V:
+～発,～はつ,counter for bullets,JLPT JLPT_2,e#d]&/=XN}
+×,ばつ,cross,JLPT JLPT_2,v(;vsH!5b/
+発揮,はっき,"exhibition, demonstration, display",JLPT JLPT_2,QaKs[tB)A-
+バック,バック,back,JLPT JLPT_2,qbsm~Jf<LF
+発想,はっそう,idea; way of thinking (same as 考え方 (かんがえかた)),JLPT_2 JLPT Intermediate_Japanese_Ln.15 Intermediate_Japanese,I2:s]~J?s+
+発電,はつでん,"generation (e.g., power)",JLPT JLPT_2,Q0`dq+3A0&
+発売,はつばい,sale,JLPT JLPT_2,I[uv@sX4sM
+話合い,はなしあい,"discussion, talk",JLPT JLPT_2,j6IK#HXQe7
+話し掛ける,はなしかける,"to accost a person, to talk (to someone)",JLPT JLPT_2,E42/+JfB`_
+話中,はなしちゅう,"while talking, the line is busy",JLPT JLPT_2,jx-7nhaG2(
+甚だしい,はなはだしい,"extreme, excessive, terrible",JLPT JLPT_2,omWb^)11J$
+花火,はなび,fireworks,JLPT JLPT_2,BVYu+ySjFN
+花嫁,はなよめ,bride,JLPT JLPT_2,GcW:<A-hl8
+ばね,ばね,"spring (e.g., coil, leaf)",JLPT JLPT_2,sxRo:)][hz
+跳ねる,はねる,"to jump, to leap",JLPT JLPT_2,P8[ijvqr@Z
+破片,はへん,"fragment, broken piece",JLPT JLPT_2,O.%CD32Cda
+歯磨き,はみがき,"toothbrushing, toothpaste",JLPT JLPT_2,y*(]=Ref/C
+はめる,はめる,"(col) to get in, to insert, to put on",JLPT JLPT_2,"v[M8{,w&%8"
+早口,はやくち,fast-talking,JLPT JLPT_2,b65.982w^u
+払い込む,はらいこむ,"to deposit, to pay in",JLPT JLPT_2,"mq,-bG@>>i"
+払い戻す,はらいもどす,"to repay, to pay back",JLPT JLPT_2,"r!!#G!lK,,"
+針金,はりがね,wire,JLPT JLPT_2,qxYELD(-ed
+張り切る,はりきる,"to be in high spirits, to be full of vigor",JLPT JLPT_2,/+}3T(9Ff
+反～,はん～,"anti ~, counter ~",JLPT JLPT_2,"b>W-n87t,>"
+反映,はんえい,"reflection, influence",JLPT JLPT_2,vM%0h=/p|a
+半径,はんけい,radius,JLPT JLPT_2,nr>gnOk7x^
+判子,はんこ,seal (used for signature),JLPT JLPT_2,u_*2c15[TP
+万歳,ばんざい,"banzai, Long live ~!",JLPT JLPT_2,u0&SMmf&^/
+判事,はんじ,"judge, justice",JLPT JLPT_2,j^b+T-<*N1
+番地,ばんち,"house number, address",JLPT JLPT_2,f=_&Y!K(GI
+パンツ,パンツ,underpants,JLPT_2 JLPT Genki_Ln.10 Genki,f1!Jgm1h.|
+バンド,バンド,band,JLPT JLPT_2,hx3pu3yzgf
+半島,はんとう,peninsula,JLPT JLPT_2,"O1,CCe9Bk!"
+ハンドル,ハンドル,"handle, steering wheel",JLPT JLPT_2,r$a6UvR({y
+～番目,～ばんめ,~th,JLPT JLPT_2,i*esVeP_ak
+非～,ひ～,"anti~, counter~, an~, non~",JLPT_1 JLPT JLPT_2,BUWz9(5^B)
+～費,～ひ,cost of ~,JLPT JLPT_2,u[jm+{6L3X
+日当たり,ひあたり,"exposure to the sun, sunny place",JLPT JLPT_2,lKSG[Co_dv
+日帰り,ひがえり,day trip,JLPT JLPT_2,Jh-TX_`>w~
+比較的,ひかくてき,comparatively; relatively,Intermediate_Japanese_Ln.5 JLPT JLPT_2 Intermediate_Japanese,yRf$aJ+cvj
+日陰,ひかげ,shadow,JLPT JLPT_2,PxZa@!UPI;
+ぴかぴか,ぴかぴか,"glitter, sparkle",JLPT JLPT_2,d/V>YPI*X<
+引受る,ひきうける,"to undertake, to take up, to take over",JLPT JLPT_2,qCz>U/7EL?
+引き返す,ひきかえす,"to turn back, to go back, reverse",JLPT JLPT_2,bC`+HSQ:%I
+引算,ひきざん,subtraction,JLPT JLPT_2,ML@]2G:q]2
+引き出す,ひきだす,"to pull out, to take out, to withdraw",JLPT JLPT_2,NdsG``/m~k
+引き止める,ひきとめる,"to keep back, to prevent, to hold back",JLPT JLPT_2,A3*mBL.p{k
+卑怯,ひきょう,"cowardice, meanness, unfairness",JLPT JLPT_2,"Q(9,y^6;ZC"
+引分け,ひきわけ,"a draw (in competition), tie game",JLPT JLPT_2,h}[lK:0XS$
+陽射,ひざし,"sunlight, rays of the sun",JLPT JLPT_2,Ftb3RG(bbe
+肘,ひじ,elbow,JLPT JLPT_2,C6rg9Pm`+%
+ピストル,ピストル,pistol,JLPT JLPT_2,JEp~p=`2Vn
+ビタミン,ビタミン,vitamin,JLPT JLPT_2,qt<L6><O-N
+ぴたり,ぴたり,exactly; close-fitting,JLPT JLPT_2,t)/G)m|eXB
+引っ掛かる,ひっかかる,"to be caught in, to be stuck in",JLPT JLPT_2,jDrr(LpUYx
+筆記,ひっき,"note taking, writing",JLPT JLPT_2,E:WY<l^}a6
+引っ繰り返す,ひっくりかえす,"to turn over, to overturn, to knock over",JLPT JLPT_2,Aa#A!KWab;
+引っ繰り返る,ひっくりかえる,"to be overturned, to be upset, to topple over, to be reversed",JLPT JLPT_2,y#X%-CW-M~
+引っ込む,ひっこむ,"to draw back, to sink, to cave in",JLPT JLPT_2,ozz?OwjfOs
+筆者,ひっしゃ,"writer, author",JLPT JLPT_2,BHGOtbE2VB
+必需品,ひつじゅひん,"necessities, essential",JLPT JLPT_2,cTMH.0S#__
+一～,ひと～,one ~,JLPT JLPT_2,MA<ALV)8oH
+人差指,ひとさしゆび,index finger,JLPT JLPT_2,yXv{vsytE-
+一通り,ひととおり,"general, briefly",JLPT JLPT_2,z>*AdeJ/za
+人通り,ひとどおり,pedestrian traffic,JLPT JLPT_2,okfC7]@36^
+ひとまず,ひとまず,"for the present, once, for the time being",JLPT JLPT_2,",^[NCX-JA"
+瞳,ひとみ,pupil (of eye),JLPT JLPT_2,n?(M2yxG]e
+一休み,ひとやすみ,a rest,JLPT JLPT_2,HyAGEDQ8c+
+独り言,ひとりごと,"a soliloquy, a monologue, speaking to oneself",JLPT JLPT_2,oE(Rtaq/4c
+ひとりでに,ひとりでに,"by itself, automatically, naturally",JLPT JLPT_2,PMPsW_S3Fc
+ビニール,ビニール,vinyl,JLPT JLPT_2,"B]r_&,m?0_"
+皮肉,ひにく,"cynicism, sarcasm",JLPT JLPT_2,pu+RSzayXS
+日日,ひにち,date,JLPT JLPT_2,EDa-Ss*/(C
+捻る,ひねる,"to twist, to turn",JLPT JLPT_2,Lsxjk5@=vY
+日の入り,ひのいり,sunset,JLPT JLPT_2,rz|&d2Q(rd
+日の出,ひので,sunrise,JLPT JLPT_2,"G!/]^,ZBLq"
+響き,ひびき,"echo, sound",JLPT JLPT_2,l&)NHT{BaW
+響く,ひびく,to resound; to affect,JLPT JLPT_2,rOD*#KgIYp
+皮膚,ひふ,skin,JLPT JLPT_2,cVU`)a>m;T
+ひゃっかじてん,ひゃっかじてん,encyclopedia,JLPT JLPT_2,wQ6w2}QAv=
+美容,びよう,beauty of figure or form,JLPT JLPT_2,D(GaCqwm&U
+～病,～びょう,kind of disease,JLPT JLPT_2,A*!}.Pwu5m
+表紙,ひょうし,"front cover, binding",JLPT JLPT_2,exq#1;SO@*
+標識,ひょうしき,"sign, mark",JLPT JLPT_2,kDX[w^RE%^
+標準,ひょうじゅん,"standard, level",JLPT JLPT_2,r$bk_|d--C
+標本,ひょうほん,"example, specimen",JLPT JLPT_2,"lfNW^di`Y,"
+評論,ひょうろん,"criticism, critique",JLPT JLPT_2,s}Ej!kw1~9
+ビルディング,ビルディング,building,JLPT JLPT_2,J8!M@z<nsR
+昼寝,ひるね,"nap (at home), siesta",JLPT JLPT_2,"x,{aI?hy6D"
+広さ,ひろさ,extent,JLPT JLPT_2,lG>A7gDV9/
+広場,ひろば,plaza,JLPT JLPT_2,t3z@d(WD;9
+広々,ひろびろ,"extensive, spacious",JLPT JLPT_2,Eye9Pf.VGV
+ピンク,ピンク,pink,JLPT JLPT_2,}M:Z#WBUl
+便箋,びんせん,"writing paper, stationery",JLPT JLPT_2,DAZ9H$OhvM
+瓶詰,びんづめ,"bottling, bottled",JLPT JLPT_2,N_#i?7cB#[
+～部,～ぶ,~ part,JLPT JLPT_2,fPDrnMwV)X
+ファスナー,ファスナー,"fastener, zipper",JLPT JLPT_2,n!rH#}$IH?
+～風,～ふう,~ style,JLPT JLPT_2,l^t;?>.nOp
+風船,ふうせん,balloon,JLPT JLPT_2,oE(8x]l~K[
+不運,ふうん,"unlucky, misfortune, bad luck",JLPT JLPT_2,Ek=uOv}jTZ
+不規則,ふきそく,"irregularity, unsteadiness",JLPT JLPT_2,dufg6SP37F
+普及,ふきゅう,"diffusion, spread",JLPT JLPT_2,sprE2d}(>:
+付近,ふきん,"neighborhood, vicinity",JLPT JLPT_2,cz$T?0Oc1>
+副～,ふく～,vice ~,JLPT JLPT_2,x7/psMz*#F
+副詞,ふくし,adverb,JLPT JLPT_2,A2D&p<Rh*?
+複写,ふくしゃ,"copy, duplicate",JLPT JLPT_2,"f.(+H@$,m~"
+複数,ふくすう,"plural, multiple",JLPT JLPT_2,"df,MeSNnZ^"
+膨らます,ふくらます,"to swell, to expand, to inflate",JLPT JLPT_2,eZJ~QnaPP^
+膨らむ,ふくらむ,"to expand, to swell (out), to become inflated",JLPT JLPT_2,gX9*eZWr#^
+不潔,ふけつ,"unclean, dirty",JLPT JLPT_2,OlF9IGIpI)
+更ける,ふける,"to get late, to wear on",JLPT JLPT_2,wdqFkMvXan
+符号,ふごう,"sign, mark, symbol",JLPT JLPT_2,IGH`HBBpBL
+夫妻,ふさい,"man and wife, married couple",JLPT JLPT_2,lo.$s^W>a[
+塞がる,ふさがる,"to be plugged up, to be shut up",JLPT JLPT_2,m<:=EwmCiH
+塞ぐ,ふさぐ,"to stuff, to close up, to block (up)",JLPT JLPT_2,pJWqjf]P&p
+ふざける,ふざける,"to romp, to gambol, to frolic",JLPT JLPT_2,"wxJ[ZD,*?f"
+無沙汰,ぶさた,neglecting to stay in contact,JLPT JLPT_2,mXdlHZOuK>
+武士,ぶし,"warrior, samurai",JLPT JLPT_2,kh|VM6~+N]
+部首,ぶしゅ,radical (of a kanji character),JLPT JLPT_2,rB[8HW{H3]
+襖,ふすま,sliding screen,JLPT JLPT_2,Gfj{ovvCbc
+附属,ふぞく,"attached, belonging, affiliated",JLPT JLPT_2,b5{>br)8^T
+蓋,ふた,"cover, lid, cap",JLPT JLPT_2,tB(]=dUF]{
+物騒,ぶっそう,"dangerous, disturbed, insecure",JLPT JLPT_2,y)>wu(aHUg
+ぶつぶつ,ぶつぶつ,"grumbling, complaining in a small voice",JLPT JLPT_2,qMxSqk8|QN
+船便,ふなびん,surface mail (ship),JLPT JLPT_2,iRS_8@xn)m
+部品,ぶひん,"parts, accessories",JLPT JLPT_2,FDy}XMy%{O
+吹雪,ふぶき,snow storm,JLPT JLPT_2,v+({l-j^oM
+父母,ふぼ,"father and mother, parents",JLPT JLPT_2,Ll;-.SjS/Y
+踏切,ふみきり,"railway crossing, level crossing, starting line, scratch, crossover",JLPT JLPT_2,GO4{@dw9M.
+麓,ふもと,"the foot, the bottom, the base (of a mountain)",JLPT JLPT_2,gGv+C<J!h4
+フライパン,フライパン,"fry pan, frying pan",JLPT JLPT_2,"kaG8,BADao"
+ブラウス,ブラウス,blouse,JLPT JLPT_2,QM^Obt[T3I
+ぶらさげる,ぶらさげる,"to hang, to suspend, to swing",JLPT JLPT_2,zsGS&1j7k4
+ブラシ,ブラシ,brush,JLPT JLPT_2,GK-sv9zX*O
+プラットホーム,プラットホーム,platform,JLPT JLPT_2,bkr1lkRi*.
+～振り,～ぶり,after an interval of ~,JLPT JLPT_2,;^fUn`g0d
+フリー,フリー,free,JLPT JLPT_2,LgNW8Pd}P5
+振り仮名,ふりがな,pronunciation key,JLPT JLPT_2,tp7b;~);$&
+振り向く,ふりむく,"to turn one's face, to turn around",JLPT JLPT_2,M!}tc99p$L
+プリント,プリント,"print, handout",JLPT JLPT_2,qRutfPmJ_A
+古～,ふる～,old ~,JLPT JLPT_2,yOy85A_d[A
+故郷,ふるさと,"home town, birthplace",JLPT JLPT_2,fPH>SIa_~L
+古里,ふるさと,"home town, birthplace",JLPT JLPT_2,L?3e+b0LsP
+振舞う,ふるまう,"to behave, to conduct",JLPT JLPT_2,ocy;g4y/Lf
+ブローチ,ブローチ,brooch,JLPT JLPT_2,A1E`_ZNs45
+プログラム,プログラム,program,JLPT JLPT_2,CmX8s[W2Qv
+風呂敷,ふろしき,"wrapping cloth, cloth wrapper",JLPT JLPT_2,dHx|An0<B^
+ふわふわ,ふわふわ,"light, soft",JLPT JLPT_2,"ouE+^X,qav"
+噴火,ふんか,eruption,JLPT JLPT_2,AH/^[s43Q(
+分解,ぶんかい,"analysis, disassembly",JLPT JLPT_2,OB#FbcA~qO
+文芸,ぶんげい,"literature, art and literature",JLPT JLPT_2,tt`(b(:~bY
+文献,ぶんけん,"literature, books (reference)",JLPT JLPT_2,GAy|sEvJyq
+噴水,ふんすい,water fountain,JLPT JLPT_2,"jk9H]:,ETq"
+分数,ぶんすう,fraction (in math),JLPT JLPT_2,c/zwPyy+.b
+文体,ぶんたい,literary style,JLPT JLPT_2,ttyj|<%!tP
+分布,ぶんぷ,distribution,JLPT JLPT_2,"F&4[s,*.xr"
+文房具,ぶんぼうぐ,stationery,JLPT JLPT_2,q`Zjj<5}i7
+文脈,ぶんみゃく,context,JLPT JLPT_2,etxX79/6Kg
+分量,ぶんりょう,"amount, quantity",JLPT JLPT_2,g>~(m<JIvb
+分類,ぶんるい,classification,JLPT JLPT_2,t{7wYNi1W2
+閉会,へいかい,closure,JLPT JLPT_2,cAcpFr>2mr
+平気,へいき,"coolness, calmness, unconcern",JLPT JLPT_2,z(xagV[dg-
+並行,へいこう,"(going) side by side, concurrent, at the same time",JLPT_1 JLPT JLPT_2,oq7x11wlwL
+平日,へいじつ,weekday,JLPT JLPT_2,"PX,G5cgs03"
+兵隊,へいたい,soldier,JLPT JLPT_2,toM&i}fuLv
+平凡,へいぼん,"common, ordinary",JLPT JLPT_2,"s`b],MR&9J"
+平野,へいや,"plain, open field",JLPT JLPT_2,L[uUr}G9/R
+凹む,へこむ,"to be dented, to be indented",JLPT JLPT_2,ORF0ctV6X[
+へそ,へそ,"navel, belly-button",JLPT JLPT_2,qr%|N/rOJm
+隔てる,へだてる,to be shut out,JLPT JLPT_2,QSnbE1ue1O
+別荘,べっそう,villa; vacation home; summer cottage,JLPT Intermediate_Japanese Genki_Ln.23 JLPT_2 Intermediate_Japanese_Ln.13 Genki,__kVP|dTW
+別々,べつべつ,"separately, individually",JLPT JLPT_2,jZHX%HAw.@
+ベテラン,ベテラン,veteran,JLPT JLPT_2,N$f]d}-cKp
+ヘリコプター,ヘリコプター,helicopter,JLPT JLPT_2,q)Q=o$Y_hX
+～遍,～へん,time,JLPT JLPT_2,K&5Px_U7gs
+～弁,～べん,"speech, dialect",JLPT JLPT_2,jOUF!M-NS3
+編集,へんしゅう,"editing, compilation, editorial (e.g., committee)",JLPT JLPT_2 Intermediate_Japanese_Ln.8 Intermediate_Japanese,CMY4=Qx!?>
+便所,べんじょ,"toilet, lavatory",JLPT JLPT_2,vS8<$f00~!
+ペンチ,ペンチ,pliers (lit: pinchers),JLPT JLPT_2,ypii1BOJF+
+～歩,～ほ,"step, pace",JLPT JLPT_2,Bd!L5Wz^Su
+～ぽい,～ぽい,~ish,JLPT JLPT_2,f_=g;f`{~[
+～ほう (ひかく),～ほう (ひかく),(in comparison),JLPT JLPT_2,bVM<L+hK+`
+防～,ぼう～,~ prevention,JLPT JLPT_2,b83:v}U.rY
+望遠鏡,ぼうえんきょう,telescope,JLPT JLPT_2,"eUp{Pt}o,e"
+方角,ほうがく,"direction, way",JLPT JLPT_2,By.)=t/^Rp
+箒,ほうき,broom,JLPT JLPT_2,f:ESSC#*}*
+方言,ほうげん,dialect,JLPT JLPT_2,&2X^_SdQt
+坊さん,ぼうさん,"Buddhist priest, monk",JLPT JLPT_2,"Qc,c}WSH)C"
+防止,ぼうし,"prevention, check",JLPT JLPT_2,Nh.L=|T~RY
+方針,ほうしん,"objective, plan, policy",JLPT JLPT_2,stt^|Hkbmf
+法則,ほうそく,"law, rule",JLPT JLPT_2,iMzqR&2E$7
+包帯,ほうたい,bandage,JLPT JLPT_2,jdeHukm4CR
+膨大,ぼうだい,"enormous, extensive",JLPT JLPT_2,hDhfR$-iz
+包丁,ほうちょう,"kitchen knife, carving knife",JLPT JLPT_2,F|0`&E;>^U
+方程式,ほうていしき,equation,JLPT JLPT_2,CWj-S*o0>!
+防犯,ぼうはん,prevention of crime,JLPT JLPT_2,ud5?<C%(~-
+方面,ほうめん,direction; area,JLPT JLPT_2 Intermediate_Japanese_Ln.8 Intermediate_Japanese,pYi7d6I9bd
+坊や,ぼうや,boy,JLPT JLPT_2,G_?oo:%KzF
+放る,ほうる,to let go,JLPT JLPT_2,"C{B(cB/!,S"
+ボーナス,ボーナス,bonus,JLPT JLPT_2 Genki_Ln.23 Genki,HVcj_;{/5t
+朗らか,ほがらか,"bright, cheerful, melodious",JLPT JLPT_2,"biS@,:!mm:"
+牧場,ぼくじょう,farm (livestock); pasture land,JLPT JLPT_2,"D[,+7?JI;Q"
+牧畜,ぼくちく,stock-farming,JLPT JLPT_2,oCu$DV_SOs
+保健,ほけん,"health preservation, hygiene, sanitation",JLPT JLPT_2,"tY,tXP&1EW"
+募集,ぼしゅう,recruitment,JLPT JLPT_2 Genki_Ln.13 Genki,IXW1A3^TP]
+干す,ほす,"to air, to dry, to drink up",JLPT JLPT_2,G2&WPE#=vv
+ポスター,ポスター,poster,JLPT_2 JLPT Genki_Ln.21 Genki,vz]f3qYXvW
+北極,ほっきょく,North Pole,JLPT JLPT_2,bgjpd&a{kA
+坊っちゃん,ぼっちゃん,son (of others),JLPT JLPT_2,F}X~i4B*xw
+解く,ほどく,to unfasten,JLPT JLPT_2,FAb2m|I`v1
+掘る,ほる,"to dig, to excavate",JLPT JLPT_2,P(Ii(].EKe
+彫る,ほる,"to carve, to chisel",JLPT JLPT_2,w:dO4e{8Ji
+ぼろ,ぼろ,"rag, tattered clothes",JLPT JLPT_2,"NW1R}tvp,P"
+盆,ぼん,Festival of the Dead; tray,JLPT JLPT_2,qj@{)T)L*<
+盆地,ぼんち,"basin (e.g., between mountains)",JLPT JLPT_2,cA[T.nYJ`t
+ほんの～,ほんの～,"mere, just",JLPT JLPT_2,LD`QTJO;b~
+本部,ほんぶ,headquarters,JLPT JLPT_2,j_S85q;bAx
+本来,ほんらい,"essentially, naturally, by nature",JLPT JLPT_2,d:u_JtOqN$
+まあまあ,まあまあ,okay; so-so; decent,JLPT JLPT_2 Genki_Ln.11 Genki,gEu+!$P11#
+毎～,まい～,every ~,JLPT JLPT_2,A((3F0kA(~
+枚数,まいすう,the number of flat things,JLPT JLPT_2,txIx.*SQ<<
+毎度,まいど,"each time, common service-sector greeting",JLPT JLPT_2,tNEeyhC?CO
+枕,まくら,pillow,JLPT JLPT_2,r:aSt_cmjW
+曲げる,まげる,"to bend, to crook, to lean",JLPT JLPT_2,c^Y!O@AS0!
+まごまご,まごまご,"confused, be at a loss",JLPT JLPT_2,fsndtXo3d3
+摩擦,まさつ,friction; rubbing; chafe,JLPT_2 JLPT Intermediate_Japanese_Ln.15 Intermediate_Japanese,s]MF/PuI>5
+マスク,マスク,mask,JLPT JLPT_2,C!G`yaEZpC
+またぐ,またぐ,to straddle,JLPT JLPT_2,MVE!gLhDn<
+待合室,まちあいしつ,waiting room,JLPT JLPT_2,K=0IrWVZf4
+待ち合わせる,まちあわせる,"to rendezvous, to meet at a prearranged place and time",JLPT JLPT_2,ba8vXTF^0z
+街角,まちかど,street corner,JLPT JLPT_2,Qdd<k6I!B.
+真っ暗,まっくら,total darkness,JLPT JLPT_2,L9D&pF9do3
+真っ黒,まっくろ,pitch black,JLPT JLPT_2,uf8qa)}H~~
+真っ青,まっさお,"deep blue, ghastly pale",JLPT JLPT_2,O<9;wBZ~L0
+真っ先,まっさき,"foremost, beginning",JLPT JLPT_2,J/q2ej|!r|
+真っ白,まっしろ,pure white,JLPT JLPT_2,J6?OmtkLVX
+祭る,まつる,"to deify, to enshrine",JLPT JLPT_2,GdV0$T|dnJ
+窓口,まどぐち,(ticket) window,JLPT JLPT_2 Intermediate_Japanese_Ln.10 Intermediate_Japanese,xdz)^i]j;[
+真似る,まねる,"to mimic, to imitate",JLPT JLPT_2,uJZVzYu2Ry
+まぶた,まぶた,eyelids,JLPT JLPT_2,G%BvRagvhI
+マフラー,マフラー,a winter scarf,JLPT_2 JLPT Genki_Ln.14 Genki,Q87-B${@Jc
+間も無く,まもなく,"soon, in a short time",JLPT JLPT_2,vaV9T=MxPD
+マラソン,マラソン,marathon,JLPT JLPT_2,x1bZ*0{Jmx
+稀,まれ,"rare, seldom",JLPT JLPT_2,fI}bUBDb~F
+回り道,まわりみち,detour,JLPT JLPT_2,EmJ?soVNP8
+満員,まんいん,"full house, no vacancy, sold out",JLPT JLPT_2,lNFNyW1^.O
+マンション,マンション,"multistory apartment house, condominium",JLPT_2 JLPT Genki_Ln.14 Genki,BK;@JartEg
+満点,まんてん,perfect score,JLPT JLPT_2,wMe[}41xth
+未～,み～,not yet ~,JLPT JLPT_2,jlo$?jcv~p
+見上げる,みあげる,"to look up at, to admire",JLPT JLPT_2,f/_Ecz_n}6
+見送る,みおくる,to see off; to escort; to let pass,JLPT JLPT_2,k=}(8{DG3E
+見下ろす,みおろす,"to overlook, to look down on something",JLPT JLPT_2,"J,1|nmvT6*"
+見掛け,みかけ,outward appearance,JLPT JLPT_2,M{6UR7>ns)
+三日月,みかづき,crescent moon,JLPT JLPT_2,"oy@Fx($<,|"
+岬,みさき,cape (on coast),JLPT JLPT_2,mse@aZCB{~
+みじめ,みじめ,"sad, pitiful, wretched",JLPT JLPT_2,yJ1{6!ct=e
+ミシン,ミシン,sewing machine,JLPT JLPT_2,d1j}k[P`go
+自ら,みずから,"for one's self, personally",JLPT JLPT_2,Jm|Fujfl1c
+水着,みずぎ,bathing suit (woman's),JLPT JLPT_2,o%MGb.}$^_
+店屋,みせや,"store, shop",JLPT JLPT_2,vv#zIkIc#p
+～みたい,～みたい,looks like ~,JLPT JLPT_2,N{CD^3;+~1
+見出し,みだし,"heading, index",JLPT JLPT_2,H76Ot%CaXm
+道順,みちじゅん,"itinerary, route",JLPT JLPT_2,e.TVg<fHh^
+みっともない,みっともない,"shameful, indecent",JLPT JLPT_2 Intermediate_Japanese Intermediate_Japanese_Ln.11,NM_z!JuhP7
+見詰める,みつめる,"to stare at, to gaze at",JLPT JLPT_2,ggyxS%fcH3
+見直す,みなおす,"to look over again, to review",JLPT JLPT_2,i4L<t=G)#$
+見慣れる,みなれる,"to become used to seeing, to be familiar with",JLPT JLPT_2,L|*x29{!8`
+醜い,みにくい,ugly,JLPT JLPT_2 Intermediate_Japanese_Ln.10 Intermediate_Japanese,>3rAC]n#o
+実る,みのる,"to bear fruit, to ripen",JLPT JLPT_2,s?siXG_F6O
+身分,みぶん,"position, status",JLPT JLPT_2,QAgzyPeRRn
+見本,みほん,sample,JLPT JLPT_2,AWma@Eod@B
+見舞う,みまう,"to ask after (health), to visit",JLPT JLPT_2,zTV4Yost{h
+未満,みまん,"less than, insufficient",JLPT JLPT_2,nt1s0!NVdz
+名字,みょうじ,"surname, family name",JLPT JLPT_2,"Ew6=${R8,S"
+ミリ (メートル),ミリ (メートル),milli-,JLPT JLPT_2,kM;@-}8}0R
+民間,みんかん,"private, civilian",JLPT JLPT_2,vv3cePKnIT
+民主～,みんしゅ～,democratic,JLPT JLPT_2,K3~5HUQIAM
+民謡,みんよう,"folk song, popular song",JLPT JLPT_2,pP&9kI-fbS
+～向け,～むけ,for ~,JLPT JLPT_2,"Gc8ij%t,3="
+無限,むげん,infinite,JLPT JLPT_2,gDON}p~:3b
+無地,むじ,plain,JLPT JLPT_2,o<F6#GtsCJ
+矛盾,むじゅん,"contradiction, inconsistency",JLPT JLPT_2,o%DtBbl{ew
+無数,むすう,"countless number, infinite number",JLPT JLPT_2,CTm.Li6V%.
+紫,むらさき,"purple color, violet",JLPT JLPT_2,L>.R5hInn&
+群れ,むれ,"crowd, flock, herd",JLPT JLPT_2,B_zh7-tRm8
+姪,めい,niece,JLPT JLPT_2 Intermediate_Japanese_Ln.8 Intermediate_Japanese,kEuo{su[^Q
+名～,めい～,famous ~,JLPT JLPT_2,Ojv<[]|SWz
+～名,～めい,counter for people,JLPT JLPT_2,u?LD1<v]&U
+名作,めいさく,masterpiece,JLPT JLPT_2,h/LK6GJnNJ
+名所,めいしょ,famous place,JLPT JLPT_2,n}/wr4@6m|
+命ずる,めいずる,"to command, to appoint",JLPT JLPT_2,Qc}ueJ@_WT
+迷信,めいしん,superstition,JLPT JLPT_2,"p|p0h,n7H0"
+名物,めいぶつ,"famous product, special product, speciality",JLPT JLPT_2,q76$d]Uuar
+銘々,めいめい,"each, individual",JLPT JLPT_2,N3.+yn]5jC
+恵まれる,めぐまれる,"to be blessed with, to be rich in",JLPT JLPT_2,"s!Z[_1,-&j"
+巡る,めぐる,to go around,JLPT JLPT_2,GKyShII|t^
+目指す,めざす,"to aim at, to have an eye on",JLPT JLPT_2,oG%j5iiHnk
+目覚し,めざまし,alarm-clock,JLPT JLPT_2,d0&ePwjG0x
+目下,めした,"at present, now",JLPT JLPT_2,K0{dBA~W!9
+目印,めじるし,"mark, sign, landmark",JLPT JLPT_2,q`zWJQ:%c#
+目立つ,めだつ,"to be conspicuous, to stand out",JLPT JLPT_2,tk[T8cc59E
+めちゃくちゃ,めちゃくちゃ,"absurd, messed up, wrecked",JLPT JLPT_2,uO5)`QU0vj
+めっきり,めっきり,remarkably,JLPT JLPT_2,"wL+5c9k~v,"
+めでたい,めでたい,"happy, propitious, joyous",JLPT JLPT_2,sd<5h;im*g
+メニュー,メニュー,menu,JLPT Intermediate_Japanese JLPT_2 Intermediate_Japanese_Ln.6 Genki_Ln.2 Genki,Qb[M(zgy5[
+めまい,めまい,"dizziness, giddiness",JLPT JLPT_2,w[+/szbGSa
+目安,めやす,"criterion, aim",JLPT JLPT_2,"BF>,#hrn[;"
+免税,めんぜい,tax exemption,JLPT JLPT_2,ED4QKkxoOi
+面積,めんせき,area,JLPT JLPT_2,nvFYwK_.$V
+面倒臭い,めんどうくさい,"bother to do, tiresome",JLPT JLPT_2,v_H;=Sw:>n
+儲かる,もうかる,"to be profitable, to yield a profit",JLPT JLPT_2,"x^)#,>iTuV"
+儲ける,もうける,"to earn, to have (bear, beget) a child",JLPT JLPT_2,knorMFQjZa
+申し訳ない,もうしわけない,"inexcusable, I am sorry",JLPT JLPT_2,hK_t:TVUx-
+モーター,モーター,motor,JLPT JLPT_2,"wBaq,e|KHL"
+木材,もくざい,"lumber, timber, wood",JLPT JLPT_2,p])fTiJgeI
+目次,もくじ,table of contents,JLPT JLPT_2,M+OIm~SY-.
+潜る,もぐる,"to dive, to pass through; to evade, to hide",JLPT JLPT_2,qj|MaKX?5J
+もしかしたら,もしかしたら,"perhaps, maybe, by some chance",JLPT JLPT_2,j:FmHM43yb
+もたれる,もたれる,"to lean against, to lean on",JLPT JLPT_2,Qh6t6//2Z$
+モダン,モダン,modern,JLPT JLPT_2,N5!.;_=H-k
+餅,もち,sticky rice cake,JLPT JLPT_2,OEgIoQ4(`q
+～もち,～もち,person who has ~,JLPT JLPT_2,kcFc6H|EaR
+モデル,モデル,a fashion model,JLPT JLPT_2 Intermediate_Japanese_Ln.8 Intermediate_Japanese,hjD+7m/[]w
+元々,もともと,"originally, by nature, from the start",JLPT JLPT_2,u[5ChLTTM_
+物置,ものおき,storage room,JLPT JLPT_2,JX]1h3C@-y
+物語る,ものがたる,"to tell, to indicate",JLPT JLPT_2,M5^N%-Zkc~
+物差し,ものさし,"ruler, measure",JLPT JLPT_2,c.4G}[6Jdw
+物凄い,ものすごい,"earth-shattering, staggering, to a very great extent",JLPT JLPT_2,P17Ihw(4J*
+モノレール,モノレール,monorail,JLPT JLPT_2,l0q)O[^}S)
+紅葉,もみじ,(Japanese) maple,JLPT JLPT_2,hx<2A]~{T*
+揉む,もむ,"to rub, to crumple (up), to wrinkle",JLPT JLPT_2,0PUyW_0#W
+催し,もよおし,"event, festivities, function",JLPT JLPT_2,"EIU(L,`^Eh"
+盛る,もる,to serve (food); to fill up; to prescribe,JLPT JLPT_2,N]CqJA)#E%
+～問,～もん,counter for questions,JLPT JLPT_2,r$GN8{}74-
+問答,もんどう,"questions and answers, dialogue",JLPT JLPT_2,A@X}Rt9?ZV
+～夜,～や,counter for nights,JLPT JLPT_2,Cczj9?Yw&<
+やかましい,やかましい,"to be fussy, to be overly critical",JLPT JLPT_2 Intermediate_Japanese Intermediate_Japanese_Ln.11,K^1j<(hE_K
+夜間,やかん,"at night, nighttime",JLPT JLPT_2,l-mqt6Hx:l
+やかん,やかん,kettle,JLPT JLPT_2,"tkW,zBf(b9"
+役者,やくしゃ,actor,JLPT JLPT_2,v7(WAy>oTx
+役所,やくしょ,"government office, public office",JLPT JLPT_2,tYh<Y-yS(<
+役人,やくにん,government official,JLPT JLPT_2,fB!QQWF_/~
+薬品,やくひん,"medicine(s), chemical(s)",JLPT JLPT_2,B95{D=Mv7A
+役目,やくめ,"duty, business",JLPT JLPT_2,eJf:#JG.ri
+火傷,やけど,"burn, scald",JLPT JLPT_2,7I)hC`TW?
+夜行,やこう,"night train, night travel",JLPT JLPT_2,"y;lSnX%t,>"
+矢印,やじるし,directing arrow,JLPT JLPT_2,An<(bJl4^{
+やたらに,やたらに,"randomly, recklessly, blindly",JLPT JLPT_2,D]ow_1`[wN
+薬局,やっきょく,"pharmacy, drugstore",JLPT JLPT_2,N194=aZ:d#
+やっつける,やっつける,"to attack (an enemy), to beat, to finish off",JLPT JLPT_2,l@9):k=!@X
+家主,やぬし,landlord,JLPT JLPT_2,DUdGHLB_/_
+やっぱり,やっぱり,"after all, anyway",Genki_Ln.17 JLPT JLPT_2 Genki,"wZ<[J,i02f"
+破く,やぶく,to tear,JLPT JLPT_2,sH>!N}Nah~
+やむをえない,やむをえない,"cannot be helped, unavoidable",JLPT JLPT_2,h@Tq3wqB9&
+軟らかい,やわらかい,"soft, tender, limp",JLPT JLPT_2,I1/=F(E;;H
+遊園地,ゆうえんち,amusement park,JLPT JLPT_2,dC>55R1XHE
+夕刊,ゆうかん,evening paper,JLPT JLPT_2,G?pT?]klj{
+郵送,ゆうそう,mailing,JLPT JLPT_2,"pak,%]0,3<"
+夕立,ゆうだち,(sudden) evening shower (rain),JLPT JLPT_2,FOO]a;xGYZ
+夕日,ゆうひ,"(in) the evening sun, setting sun",JLPT JLPT_2,BF*@*C-(FW
+悠々,ゆうゆう,"quiet, calm, leisurely",JLPT JLPT_2,H<2A&m;&q9
+有料,ゆうりょう,"admission-paid, toll",JLPT JLPT_2,tT[a^[Mtvi
+浴衣,ゆかた,"bathrobe, informal summer kimono",JLPT JLPT_2 Intermediate_Japanese_Ln.10 Intermediate_Japanese,h-?-L8Q|2u
+行方,ゆくえ,one's whereabouts,JLPT JLPT_2,P?=c#@orQc
+湯気,ゆげ,steam,JLPT JLPT_2,fcrd=}hEtO
+輸血,ゆけつ,blood transfusion,JLPT JLPT_2,ui=5Rt>-i.
+輸送,ゆそう,"transport, transportation",JLPT JLPT_2,nl?PiUS:Q5
+油断,ゆだん,"negligence, unpreparedness",JLPT JLPT_2,"L&`<@,Zftu"
+湯飲み,ゆのみ,teacup,JLPT JLPT_2,s*/X<SI&g1
+緩い,ゆるい,"loose, lenient, slow",JLPT JLPT_2,f-=j^I>k%>
+溶岩,ようがん,lava,JLPT JLPT_2,"z`5eZ>DM,!"
+用語,ようご,"term, terminology",JLPT JLPT_2 Intermediate_Japanese_Ln.2 Intermediate_Japanese,q6%7}a8txx
+要旨,ようし,"gist, essentials, summary",JLPT JLPT_2,"v/s,Hals&5"
+幼児,ようじ,"infant, baby, child",JLPT JLPT_2,Fb~|WLt[gi
+容積,ようせき,"capacity, volume",JLPT JLPT_2,qn|]G/bN%y
+幼稚,ようち,"infancy, childish, infantile",JLPT JLPT_2,I1`Ngu(?)h
+幼稚園,ようちえん,kindergarten,JLPT_2 JLPT Intermediate_Japanese_Ln.15 Intermediate_Japanese,GBPX%?VOoV
+用途,ようと,"use, usefulness",JLPT JLPT_2,ydM@yIpgUu
+洋品店,ようひんてん,clothes store,JLPT JLPT_2,LZsjB@a&45
+養分,ようぶん,"nourishment, nutrient",JLPT JLPT_2,lk^;Qp?#ur
+羊毛,ようもう,wool,JLPT JLPT_2,w_=+w8H+Ok
+漸く,ようやく,"at last, finally, hardly",JLPT JLPT_2,C^iNv5N4/*
+要領,ようりょう,"gist, essentials, outline",JLPT JLPT_2,za3T9]!5JM
+翌～,よく～,next ~,JLPT JLPT_2,Q|Y?=K(5C;
+欲張り,よくばり,greedy,JLPT JLPT_2,b3gWN3k9:4
+余計,よけい,"too much, unnecessary, abundance, surplus, excess, superfluity",JLPT JLPT_2,FkpUW)M;0p
+よこす,よこす,"to send, to forward; to hand over (e.g., money)",JLPT JLPT_2,GJ|S}*`g9u
+余所,よそ,"another place, somewhere else, strange parts",JLPT JLPT_2,GE|2R=rvQy
+四つ角,よつかど,"four corners, crossroads",JLPT JLPT_2,EBB^]8mrLm
+酔っ払い,よっぱらい,drunkard,JLPT JLPT_2,m$-1zT#)h6
+予備,よび,"preparation, spare",JLPT JLPT_2,oCDbXIVuCu
+呼び掛ける,よびかける,"to call out to, to accost, to address (crowd), to appeal",JLPT JLPT_2,E]+6r}%ERq
+呼び出す,よびだす,"to summon, to call (e.g., phone)",JLPT JLPT_2,B]HE<fu.Gh
+蘇る,よみがえる,"to be resurrected, to be revived",JLPT JLPT_2,bFWlW*}Y0x
+慶ぶ,よろこぶ,"to be delighted, to be glad",JLPT JLPT_2,bYQ/7BX1[E
+～等,～ら,plural persons,JLPT JLPT_2,yo94:>GuX6
+来日,らいにち,"coming to Japan, visit to Japan",JLPT JLPT_2,F=tQ&:UgOr
+落第,らくだい,"failure, dropping out of a class",JLPT JLPT_2,Q(J~:!^_h.
+ラッシュアワー,ラッシュアワー,rush hour,JLPT JLPT_2 Intermediate_Japanese_Ln.10 Intermediate_Japanese,qG.v6=72Ou
+欄,らん,"column of text (e.g., as in a newspaper)",JLPT JLPT_2,"I[,7dha!hT"
+ランチ,ランチ,lunch,JLPT JLPT_2,G/r6l:J~B?
+ランニング,ランニング,running; tank top,JLPT JLPT_2,Ctg/L&AR{n
+乱暴,らんぼう,"rude, violent, rough",JLPT JLPT_2,s8$*-j{s@r
+理科,りか,science,JLPT JLPT_2,f#/2Fo6[T)
+利害,りがい,"advantages and disadvantages, interest",JLPT JLPT_2,BYu5o+Pi5&
+段階,だんかい,"gradation, grade, stage",JLPT JLPT_2,jG]K@ghVXd
+短期,たんき,short term,JLPT JLPT_2,q<4V7>Q;K[
+炭鉱,たんこう,"coal mine, coal pit",JLPT JLPT_2,k;/>)mhS{3
+短所,たんしょ,"defect, weak point; disadvantage",JLPT JLPT_2,H{`G1#jtpf
+たんす,たんす,chest of drawers,JLPT JLPT_2,m~G#CLkml)
+淡水,たんすい,fresh water,JLPT JLPT_2,qe4&W^T?1T
+断水,だんすい,water outage,JLPT JLPT_2,i;K5<cgucK
+単数,たんすう,singular (number),JLPT JLPT_2,l])jQ./Ree
+団地,だんち,housing complex,JLPT JLPT_2,gOlbcdBj<$
+断定,だんてい,"conclusion, decision",JLPT JLPT_2,A$|V(|!0O8
+短編,たんぺん,"short (e.g., story, film)",JLPT JLPT_2,bU~DAA@V)_
+誓う,ちかう,"to swear, to vow",JLPT JLPT_2,MT!|3=)2Nd
+地下水,ちかすい,underground water,JLPT JLPT_2,p4eK+EuKD%
+近々,ちかぢか,"soon, before long",JLPT JLPT_2,z!thddh444
+近付ける,ちかづける,"to bring near, to put close, to let come near",JLPT JLPT_2,"tY,9|Y-dCA"
+近寄る,ちかよる,"to approach, to draw near",JLPT JLPT_2,PADniz;h7y
+力強い,ちからづよい,"powerful, strong, vigorous",JLPT JLPT_2,esKt]N.[nn
+ちぎる,ちぎる,"to cut up fine, to pick (fruit)",JLPT JLPT_2,n1$55xxJH)
+地質,ちしつ,geological features,JLPT JLPT_2,OY*f%Q>2A{
+知人,ちじん,"friend, acquaintance",JLPT JLPT_2 Intermediate_Japanese_Ln.1 Intermediate_Japanese,yhSeK?G|5o
+地帯,ちたい,"area, zone",JLPT JLPT_2,Cixjw@G7=!
+縮む,ちぢむ,"to shrink, to be contracted",JLPT JLPT_2,s+NV#|Vzsj
+縮める,ちぢめる,"to shorten, to reduce, to shrink",JLPT JLPT_2,K2!izn(Ec%
+縮れる,ちぢれる,"to be wavy, to be curled",JLPT JLPT_2,hDb2M|vgvf
+チップ,チップ,"gratuity, tip; chip",Intermediate_Japanese_Ln.6 JLPT_2 JLPT Intermediate_Japanese,I{J?rk;mEF
+地点,ちてん,"site, point on a map",JLPT JLPT_2,O67?;Qy2t6
+地名,ちめい,place name,JLPT JLPT_2,H}VgzK^n++
+茶色い,ちゃいろい,brown,JLPT JLPT_2,cPhF;RkRM7
+～着,～ちゃく,counter for clothes; finishing place,JLPT JLPT_2,LNy/i0~?h*
+着々,ちゃくちゃく,steadily,JLPT JLPT_2,o8gOx2+4-w
+中間,ちゅうかん,"middle, midway, interim",JLPT JLPT_2,db[p1gjS8r
+中旬,ちゅうじゅん,second third of a month,JLPT JLPT_2,w>eUJ_!p-%
+抽象,ちゅうしょう,abstract,JLPT JLPT_2,i(@XmP*tzX
+中世,ちゅうせい,"Middle Ages, medieval times",JLPT JLPT_2,"Lq!,3&y/Oc"
+中性,ちゅうせい,"neuter gender, neutral",JLPT JLPT_2,dr8B_U~r:p
+中途,ちゅうと,"in the middle, half-way",JLPT JLPT_2,qq^xMh<42g
+中年,ちゅうねん,middle-aged,JLPT JLPT_2 Intermediate_Japanese_Ln.1 Intermediate_Japanese,hO*P@Du`th
+長～,ちょう～,long ~,JLPT JLPT_2,neC33gMb3=
+～庁,～ちょう,"office, agency",JLPT JLPT_2,Nh*HbZ~CkX
+～兆,～ちょう,trillion,JLPT JLPT_2,jHeL$YV:ox
+～長,～ちょう,"leader, head",JLPT JLPT_2,i0hy<f%]dq
+～帳,～ちょう,"~ book, notebook",JLPT JLPT_2,e.I(|go>z(
+超過,ちょうか,"excess, being more than",JLPT JLPT_2,H)x}P>JSY6
+彫刻,ちょうこく,"carving, engraving, sculpture",JLPT JLPT_2,Mb[Y;T*X##
+長所,ちょうしょ,"strong point, merit; advantage",JLPT JLPT_2,r2Td3|X~d{
+長女,ちょうじょ,eldest daughter,JLPT JLPT_2,"t>?7,8swc^"
+調整,ちょうせい,"regulation, adjustment, tuning",JLPT JLPT_2,QE[mY6z/-y
+調節,ちょうせつ,"regulation, adjustment, control",JLPT JLPT_2,P0aU16*RZa
+長短,ちょうたん,"length, long and short, +-",JLPT JLPT_2,qq$=?zj3/o
+頂点,ちょうてん,"top, summit",JLPT JLPT_2,O=qNj-<h$g
+長男,ちょうなん,eldest son,JLPT JLPT_2,q&!C!n<?M%
+長方形,ちょうほうけい,"rectangle, oblong",JLPT JLPT_2,O?/Z!eS6c(
+調味料,ちょうみりょう,"condiment, seasoning",JLPT JLPT_2,K^{6&5|*9!
+～丁目,～ちょうめ,"~ district (of a town; city, block)",JLPT JLPT_2,z[Zeu>wor`
+チョーク,チョーク,chalk,JLPT JLPT_2,bDt1557lyK
+直後,ちょくご,immediately following,JLPT JLPT_2,CruP!C)gep
+直線,ちょくせん,straight line,JLPT JLPT_2,i)fGfpmLw~
+直前,ちょくぜん,just before,JLPT JLPT_2,"D>@!/){#.,"
+直通,ちょくつう,direct connection,JLPT JLPT_2,A~{UUj]Qek
+直流,ちょくりゅう,direct current,JLPT JLPT_2,d)k}co{r3d
+貯蔵,ちょぞう,"storage, preservation",JLPT JLPT_2,EL+(Z/@n_h
+直角,ちょっかく,right angle,JLPT JLPT_2,v`=zo2c&R/
+直径,ちょっけい,diameter,JLPT JLPT_2,"z!K&J,E<-?"
+散らかす,ちらかす,"to scatter around, to leave untidy",JLPT JLPT_2,GEl!43e%n;
+散らかる,ちらかる,to be in disorder,JLPT JLPT_2,K|3bz=nC90
+塵紙,ちりがみ,"tissue paper, toilet paper",JLPT JLPT_2,lS2l<%5|;:
+追加,ついか,"addition, supplement, appendix",JLPT JLPT_2,"tj?z]po,j$"
+ついで,ついで,"opportunity, occasion",JLPT JLPT_2,JV}]H[sMyJ
+～通,～つう,counter for letters,JLPT JLPT_2,gcs`gQZBri
+通ずる,つうずる,"to lead, to run, to open",JLPT JLPT_2,q$j6&`f[H8
+通知,つうち,"notice, notification",JLPT JLPT_2,cJFk/B/(}}
+通帳,つうちょう,bankbook,JLPT JLPT_2,A$T{G:y63&
+通用,つうよう,"popular use, circulation",JLPT JLPT_2,s?U_N>(p<4
+通路,つうろ,"passage, pathway",JLPT JLPT_2,tLtZ>BdE3q
+～遣い,～づかい,use of ~,JLPT JLPT_2,C?GOcbN8fi
+～付,～つき,with ~,JLPT JLPT_2,L%2+~L_:IY
+突き当たり,つきあたり,"end (e.g., of street)",JLPT JLPT_2,"E.b]g.X8,Q"
+突き当たる,つきあたる,"to run into, to collide with",JLPT JLPT_2,H/BcfsD4m>
+月日,つきひ,"time, years, days",JLPT JLPT_2,syFp2{x6+`
+～続く,～つづく,"follow, continue, go on",JLPT JLPT_2,u%o(or2@%{
+突っ込む,つっこむ,"to plunge into, to stick into",JLPT JLPT_2,mSeMf>i-8N
+務める,つとめる,"to serve, to act",JLPT JLPT_2,L>!8An;z|w
+努める,つとめる,"to try, to aim",JLPT JLPT_2,Hiy-GVpUzU
+綱,つな,rope,JLPT JLPT_2,Gw:F2@;*cm
+繋がり,つながり,"connection, link, relationship",JLPT JLPT_2,i]34S7eeuh
+粒,つぶ,grain,JLPT JLPT_2,cj>Qx50pst
+潰す,つぶす,"to smash, to waste",JLPT JLPT_2,fw$wS&e^q
+潰れる,つぶれる,"to be smashed, to go bankrupt",JLPT JLPT_2,KtRH@.KstT
+つまずく,つまずく,"to stumble, to trip",JLPT JLPT_2,HV>q|x:QCp
+詰まる,つまる,"to be blocked, to be packed",JLPT JLPT_2,i9f3IyL;o8
+爪,つめ,fingernail or toenail,JLPT JLPT_2,s#1=yTp.2S
+艶,つや,"gloss, glaze",JLPT JLPT_2,Q)oxH2VDV_
+強気,つよき,"firm, strong",JLPT JLPT_2,"P1FRp-!AG,"
+～辛い,～づらい,hard to do ~,JLPT JLPT_2,u@W}x:nhL8
+釣り合う,つりあう,"to balance, to be in harmony, to suit",JLPT JLPT_2,z[{YFjYjFo
+吊る,つる,to hang,JLPT JLPT_2,eBriDa`?h[
+吊す,つるす,to hang,JLPT JLPT_2,ux}URvOg@g
+手洗い,てあらい,"restroom, lavatory",JLPT JLPT_2,shNH8<_-bh
+低～,てい～,low ~,JLPT JLPT_2,qQ>QRC-XBo
+定員,ていいん,"fixed number of regular personnel, capacity (e.g., of boat)",JLPT JLPT_2,hHnudL9f]D
+定価,ていか,established price,JLPT JLPT_2,GWM}Nec!lL
+低下,ていか,"fall, decline",JLPT JLPT_2,uCyhw5D=m+
+定期券,ていきけん,"commuter pass, season ticket",JLPT JLPT_2,kM5$./::LV
+定休日,ていきゅうび,regular holiday,JLPT JLPT_2,GIBTjs]--C
+停止,ていし,"suspension, interruption, stoppage",JLPT JLPT_2,L@Y;}f5pt/
+停車,ていしゃ,"stopping (e.g., train)",JLPT JLPT_2,J9C>1^3Nnd
+出入り,でいり,"in and out, coming and going",JLPT JLPT_2,yl0fL{Q0pI
+出入口,でいりぐち,exit and entrance,JLPT JLPT_2,Eq1|~+1Qg4
+手入れ,ていれ,"repairs, maintenance",JLPT JLPT_2,rnU2HoMJ`m
+テーマ,テーマ,"theme, project, topic (GER: Thema)",JLPT_2 JLPT Intermediate_Japanese_Ln.15 Intermediate_Japanese,"gk7:?,j`-7"
+～滴,～てき,drop,JLPT JLPT_2,J%ti108Zf0
+出来上がり,できあがり,"be finished, ready",JLPT JLPT_2,"H,mU.Hzu4W"
+出来上がる,できあがる,"to be finished, to be ready",JLPT JLPT_2,d/)Gw/?OUZ
+的確,てきかく,"precise, accurate",JLPT JLPT_2,QsPEZIzu?w
+適確,てきかく,"precise, accurate",JLPT JLPT_2,f.CM.L/$:o
+手首,てくび,wrist,JLPT JLPT_2,Jk-$`y`Ik4
+凸凹,でこぼこ,"unevenness, roughness, ruggedness",JLPT JLPT_2,NK{S%hniXJ
+手頃,てごろ,"moderate, handy",JLPT JLPT_2,fokm:d$4ID
+弟子,でし,"pupil, disciple, apprentice",JLPT JLPT_2,xgs_S`YrNI
+でたらめ,でたらめ,"irresponsible utterance, nonsense; random",JLPT JLPT_2,o=WTZV3mV~
+手帳,てちょう,notebook,JLPT JLPT_2,sa)S+5Yc~m
+鉄橋,てっきょう,iron bridge,JLPT JLPT_2,ptqUB=+GwY
+手続き,てつづき,"procedure, (legal) process, formalities",JLPT JLPT_2,.%i6[1[$q
+鉄砲,てっぽう,gun,JLPT JLPT_2,jPGmB|kdN@
+テニスコート,テニスコート,tennis court,JLPT JLPT_2,I<8~`/$9/~
+手拭い,てぬぐい,(hand) towel,JLPT JLPT_2,qoag-^~LpA
+手前,てまえ,"before, this side",JLPT JLPT_2,"sUtM,w6Uoy"
+出迎え,でむかえ,"meeting, reception",JLPT JLPT_2,ty8z)H=LPz
+照らす,てらす,"to shine on, to illuminate",JLPT JLPT_2,NH<(nLZ8$8
+照る,てる,to shine,JLPT JLPT_2,3op!&nH<3
+～点,～てん,counter for scores,JLPT JLPT_2,Q=wx{JnD0/
+展開,てんかい,"develop, expansion (opposite of compression)",JLPT JLPT_2,civd_]-_la
+伝記,でんき,"biography, life story",JLPT JLPT_2,gEdK7vzpv5
+電球,でんきゅう,light bulb,JLPT JLPT_2,igr+WFj[j?
+点数,てんすう,"marks, points, score",JLPT JLPT_2,vc+IbB&=W`
+伝染,でんせん,contagion,JLPT JLPT_2,i$>Ffzmrg<
+電池,でんち,battery,Genki_Ln.15 JLPT_2 JLPT Genki,rtMf<[nw2h
+点々,てんてん,"here and there, little by little",JLPT JLPT_2,vIj65EZ[j(
+転々,てんてん,from one to another,JLPT JLPT_2,z<l%&cmA@h
+電柱,でんちゅう,"telephone pole, telegraph pole, light pole",JLPT JLPT_2,"gp>z=,YkpX"
+天皇,てんのう,Emperor of Japan,JLPT JLPT_2,BCTKLS7Bsq

--- a/src/n3.csv
+++ b/src/n3.csv
@@ -1,2140 +1,2140 @@
-expression,reading,meaning,tags
-作法,さほう,"manners, etiquette, propriety",JLPT JLPT_2 JLPT_3
-様々,さまざま,"varied, various",JLPT JLPT_2 JLPT_3
-冷ます,さます,"to cool, to let cool",JLPT JLPT_2 JLPT_3
-覚ます,さます,to awaken,JLPT JLPT_2 JLPT_3
-冷める,さめる,"to become cool, to wear off",JLPT JLPT_2 JLPT_3
-覚める,さめる,"to wake, to wake up",JLPT JLPT_2 JLPT_3
-左右,さゆう,left and right; influence,JLPT JLPT_2 JLPT_3
-皿,さら,"plate, dish",JLPT Genki_Ln.14 JLPT_3 JLPT_2 Genki
-更に,さらに,"furthermore, moreover",JLPT JLPT_2 JLPT_3
-去る,さる,"to leave, to go away",JLPT JLPT_2 JLPT_3
-猿,さる,monkey,JLPT JLPT_3 JLPT_2 Genki_Ln.22 Genki
-騒ぎ,さわぎ,"uproar, disturbance",JLPT JLPT_2 JLPT_3
-参加,さんか,participation,JLPT JLPT_2 JLPT_3
-参考,さんこう,"reference, consultation",JLPT JLPT_2 JLPT_3
-賛成,さんせい,"approval, agreement",JLPT JLPT_2 JLPT_3
-酸性,さんせい,acidity,JLPT JLPT_2 JLPT_3
-酸素,さんそ,oxygen,JLPT JLPT_2 JLPT_3
-氏,し,"family name, lineage",JLPT JLPT_2 JLPT_3
-詩,し,poem; poetry,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.13
-幸せ,しあわせ,"happiness, blessing",JLPT JLPT_2 JLPT_3
-ジーンズ,ジーンズ,jeans,JLPT JLPT_3 JLPT_2 Genki_Ln.2 Genki
-ジェット機,ジェットき,jet plane,JLPT JLPT_2 JLPT_3
-四角,しかく,square,JLPT JLPT_2 JLPT_3
-直に,じかに,"immediately, readily, directly",JLPT JLPT_2 JLPT_3
-しかも,しかも,"moreover, furthermore, besides, plus",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.9 Intermediate_Japanese_Ln.2
-四季,しき,four seasons,JLPT JLPT_2 JLPT_3
-直,じき,"immediately, soon, shortly",JLPT JLPT_2 JLPT_3
-時期,じき,"time, season, period",JLPT JLPT_2 JLPT_3
-支給,しきゅう,"payment, allowance",JLPT JLPT_2 JLPT_3
-至急,しきゅう,"urgent, pressing",JLPT JLPT_2 JLPT_3
-しきりに,しきりに,"frequently, repeatedly, eagerly",JLPT JLPT_2 JLPT_3
-刺激,しげき,"stimulus, impetus, incentive",JLPT JLPT_2 JLPT_3
-資源,しげん,resources,JLPT JLPT_2 JLPT_3
-事件,じけん,"event, affair, incident",JLPT JLPT_2 JLPT_3
-時刻,じこく,"time, hour",JLPT JLPT_2 JLPT_3
-自殺,じさつ,suicide,JLPT JLPT_2 JLPT_3
-事実,じじつ,"fact, truth, reality",JLPT JLPT_2 JLPT_3
-支出,ししゅつ,"expenditure, expenses",JLPT JLPT_2 JLPT_3
-事情,じじょう,"circumstances, situation, reasons",JLPT JLPT_2 JLPT_3
-詩人,しじん,poet,JLPT JLPT_2 JLPT_3
-自身,じしん,oneself,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14
-沈む,しずむ,to sink; to feel depressed,JLPT JLPT_2 JLPT_3
-自然,しぜん,"nature, spontaneous",JLPT JLPT_2 JLPT_3
-思想,しそう,"thought, idea",JLPT JLPT_2 JLPT_3
-舌,した,tongue,JLPT JLPT_2 JLPT_3
-次第,しだい,order; circumstances; immediate(ly),JLPT JLPT_2 JLPT_3
-従う,したがう,"to abide (by the rules), to obey",JLPT JLPT_2 JLPT_3
-したがって,したがって,"therefore, consequently",JLPT JLPT_2 JLPT_3
-親しい,したしい,"intimate, close (e.g., friend)",JLPT JLPT_2 JLPT_3
-質,しつ,"quality, nature (of person)",JLPT JLPT_2 JLPT_3
-失業,しつぎょう,unemployment,JLPT JLPT_2 JLPT_3
-湿気,しっけ,"moisture, humidity, dampness",JLPT JLPT_2 JLPT_3
-実験,じっけん,lab work; experiment,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.5
-実現,じつげん,"implementation, materialization, realization",JLPT JLPT_2 JLPT_3
-実行,じっこう,"practice, execution (e.g., program), realization",JLPT JLPT_2 JLPT_3
-実際,じっさい,in fact; in actuality,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.15
-実施,じっし,"enforcement, carry out, operation",JLPT JLPT_2 JLPT_3
-湿度,しつど,humidity,JLPT JLPT_2 JLPT_3
-じっと,じっと,"patiently, quietly",JLPT JLPT_2 JLPT_3
-実に,じつに,"indeed, truly, surely",JLPT JLPT_2 JLPT_3
-実は,じつは,actually; in fact,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.1
-失望,しつぼう,"disappointment, despair",JLPT JLPT_2 JLPT_3
-実力,じつりょく,ability; force,JLPT JLPT_2 JLPT_3
-支店,してん,branch store (office),JLPT JLPT_3 JLPT_2 Genki_Ln.20 Genki
-指導,しどう,"leadership, guidance, coaching",JLPT JLPT_2 JLPT_3
-自動,じどう,"automatic, self-motion",JLPT JLPT_2 JLPT_3
-児童,じどう,"children, juvenile",JLPT JLPT_2 JLPT_3
-品,しな,"thing, article, goods",JLPT JLPT_2 JLPT_3
-支配,しはい,"rule, control, direction",JLPT JLPT_2 JLPT_3
-芝居,しばい,"play, drama",JLPT JLPT_2 JLPT_3
-しばしば,しばしば,"often, again and again, frequently",JLPT JLPT_2 JLPT_3
-芝生,しばふ,lawn,JLPT JLPT_2 JLPT_3
-支払,しはらい,payment,JLPT JLPT_2 JLPT_3
-支払う,しはらう,to pay,JLPT JLPT_2 JLPT_3
-死亡,しぼう,death,JLPT JLPT_2 JLPT_3
-資本,しほん,"funds, capital",JLPT JLPT_2 JLPT_3
-姉妹,しまい,sisters,JLPT JLPT_2 JLPT_3
-しまった (かん),しまった (かん),Damn it!,JLPT JLPT_2 JLPT_3
-自慢,じまん,"pride, boast",JLPT JLPT_2 JLPT_3
-地味,じみ,"quiet, plain, conservative",JLPT JLPT_2 JLPT_3
-示す,しめす,"to show, to indicate",JLPT JLPT_2 JLPT_3
-占める,しめる,to take up; to account for,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14
-湿る,しめる,"to be wet, to be damp",JLPT JLPT_2 JLPT_3
-下,しも,"under, below, beneath",JLPT JLPT_2 JLPT_3
-霜,しも,frost,JLPT JLPT_2 JLPT_3
-借金,しゃっきん,"debt, loan, liabilities",JLPT JLPT_2 JLPT_3
-しゃべる,しゃべる,"to talk, to chat, to chatter (same as 話す (はなす))",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.8
-週,しゅう,week,JLPT JLPT_2 JLPT_3
-州,しゅう,"state, province",JLPT JLPT_2 JLPT_3
-銃,じゅう,gun,JLPT JLPT_2 JLPT_3
-周囲,しゅうい,"surroundings, circumference, environs",JLPT JLPT_2 JLPT_3
-収穫,しゅうかく,"harvest, crop, ingathering",JLPT JLPT_2 JLPT_3
-宗教,しゅうきょう,religion,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.3
-重視,じゅうし,"importance, stress",JLPT JLPT_2 JLPT_3
-就職,しゅうしょく,finding employment,JLPT JLPT_2 JLPT_3
-ジュース,ジュース,"juice, soft drink; deuce",JLPT Genki_Ln.12 JLPT_3 JLPT_2 Genki
-修正,しゅうせい,"amendment, correction",JLPT JLPT_2 JLPT_3
-重体,じゅうたい,"seriously ill, critical state",JLPT JLPT_2 JLPT_3
-渋滞,じゅうたい,"congestion (e.g., traffic), delay",JLPT JLPT_2 JLPT_3
-重大,じゅうだい,"serious, important",JLPT JLPT_2 JLPT_3
-住宅,じゅうたく,"resident, housing",JLPT JLPT_2 JLPT_3
-集団,しゅうだん,"group, mass",JLPT JLPT_2 JLPT_3
-集中,しゅうちゅう,"concentration, focusing the mind",JLPT JLPT_2 JLPT_3
-収入,しゅうにゅう,"income, revenue",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14
-住民,じゅうみん,"inhabitants, residents",JLPT JLPT_2 JLPT_3
-重要,じゅうよう,"important, essential",JLPT JLPT_2 JLPT_3
-修理,しゅうり,"repairing, mending",JLPT JLPT_2 JLPT_3
-主義,しゅぎ,"doctrine, cause, principle",JLPT JLPT_2 JLPT_3
-宿泊,しゅくはく,lodging,JLPT JLPT_2 JLPT_3
-手術,しゅじゅつ,surgical operation,JLPT JLPT_2 JLPT_3
-首相,しゅしょう,Prime Minister,JLPT JLPT_2 JLPT_3
-手段,しゅだん,"means, way, measure",JLPT JLPT_2 JLPT_3
-主張,しゅちょう,"claim, insistence, assertion",JLPT JLPT_2 JLPT_3
-出場,しゅつじょう,participation,JLPT JLPT_2 JLPT_3
-出身,しゅっしん,come from,JLPT JLPT_2 JLPT_3
-出版,しゅっぱん,publication,JLPT JLPT_2 JLPT_3
-首都,しゅと,capital city,JLPT JLPT_2 JLPT_3
-主婦,しゅふ,housewife,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.8 Genki_Ln.1 Genki
-主要,しゅよう,"chief, main",JLPT JLPT_2 JLPT_3
-需要,じゅよう,demand,JLPT JLPT_2 JLPT_3
-種類,しゅるい,"variety, kind",JLPT JLPT_2 JLPT_3
-順,じゅん,"order, turn",JLPT JLPT_2 JLPT_3
-瞬間,しゅんかん,"moment, second",JLPT JLPT_2 JLPT_3
-順調,じゅんちょう,doing well,JLPT JLPT_2 JLPT_3
-順番,じゅんばん,"turn (in line), order of things",JLPT JLPT_2 JLPT_3
-使用,しよう,"use (same as 使うこと (つかうこと)), application, employment, utilization",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.11
-小,しょう,small,JLPT JLPT_2 JLPT_3
-章,しょう,"chapter, section; medal",JLPT JLPT_2 JLPT_3
-賞,しょう,"prize, award",JLPT JLPT_2 JLPT_3
-上,じょう,first volume; superior quality; governmental,JLPT JLPT_2 JLPT_3
-障害,しょうがい,"obstacle, impediment",JLPT JLPT_2 JLPT_3
-奨学金,しょうがくきん,scholarship,Genki_Ln.16 JLPT JLPT_3 JLPT_2 Genki
-乗客,じょうきゃく,passenger,JLPT JLPT_2 JLPT_3
-上京,じょうきょう,proceeding to the capital (Tokyo),JLPT JLPT_2 JLPT_3
-状況,じょうきょう,"state of affairs, situation",JLPT JLPT_2 JLPT_3
-条件,じょうけん,"conditions, terms",JLPT JLPT_2 JLPT_3
-正午,しょうご,"noon, mid-day",JLPT JLPT_2 JLPT_3
-正直,しょうじき,"honesty, integrity, frankness",JLPT JLPT_2 JLPT_3
-常識,じょうしき,common sense,JLPT JLPT_2 JLPT_3
-少女,しょうじょ,young girl,JLPT JLPT_2 JLPT_3
-少々,しょうしょう,a little; short (time) (formal for 少し (すこし)),JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.8 Genki_Ln.20 Genki
-症状,しょうじょう,"symptoms, condition",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.12
-生じる,しょうじる,"to occur, to arise, to be generated",JLPT JLPT_2 JLPT_3
-状態,じょうたい,"condition, situation",JLPT JLPT_2 JLPT_3
-上達,じょうたつ,"improvement, advance",JLPT JLPT_2 JLPT_3
-冗談,じょうだん,a joke,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.10
-上等,じょうとう,"first class, very good",JLPT JLPT_2 JLPT_3
-衝突,しょうとつ,"collision, conflict",JLPT JLPT_2 JLPT_3
-商人,しょうにん,"trader, shopkeeper, merchant",JLPT JLPT_2 JLPT_3
-承認,しょうにん,"recognition, approval",JLPT JLPT_2 JLPT_3
-少年,しょうねん,"boys, juveniles",JLPT JLPT_2 JLPT_3
-商売,しょうばい,"trade, business, commerce",JLPT JLPT_2 JLPT_3
-消費,しょうひ,"consumption, expenditure",JLPT JLPT_2 JLPT_3
-商品,しょうひん,"commodity, merchandise",JLPT JLPT_2 JLPT_3
-賞品,しょうひん,"prize, trophy",JLPT JLPT_2 JLPT_3
-消防,しょうぼう,"fire fighting, fire department",JLPT JLPT_2 JLPT_3
-情報,じょうほう,"information, (military) intelligence",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.3
-証明,しょうめい,"proof, verification",JLPT JLPT_2 JLPT_3
-省略,しょうりゃく,"omission, abbreviation, abridgment",JLPT JLPT_2 JLPT_3
-女王,じょおう,queen,JLPT JLPT_2 JLPT_3
-職,しょく,employment,JLPT JLPT_2 JLPT_3
-職業,しょくぎょう,"occupation, business",JLPT JLPT_2 JLPT_3
-食卓,しょくたく,dining table,JLPT JLPT_2 JLPT_3
-食品,しょくひん,foodstuff,JLPT JLPT_2 JLPT_3
-植物,しょくぶつ,"plant, vegetation",JLPT JLPT_2 JLPT_3
-食物,しょくもつ,"food, foodstuff",JLPT JLPT_2 JLPT_3
-食欲,しょくよく,appetite (for food),JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.12
-食料,しょくりょう,food,JLPT JLPT_2 JLPT_3
-食糧,しょくりょう,"provisions, rations",JLPT JLPT_2 JLPT_3
-書斎,しょさい,"study, den",JLPT JLPT_2 JLPT_3
-女子,じょし,"woman, girl",JLPT JLPT_2 JLPT_3
-助手,じょしゅ,"helper, assistant",JLPT JLPT_2 JLPT_3
-徐々に,じょじょに,"slowly, little by little",JLPT JLPT_2 JLPT_3
-署名,しょめい,signature,JLPT JLPT_2 JLPT_3
-書物,しょもつ,books,JLPT JLPT_2 JLPT_3
-女優,じょゆう,actress,JLPT JLPT_2 JLPT_3
-処理,しょり,"processing, treatment, disposition",JLPT JLPT_2 JLPT_3
-書類,しょるい,"documents, official papers",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14 Genki_Ln.22 Genki
-知らせ,しらせ,notice,JLPT JLPT_2 JLPT_3
-尻,しり,"buttocks, bottom",JLPT JLPT_2 JLPT_3
-知合い,しりあい,acquaintance,JLPT JLPT_2 JLPT_3
-印,しるし,mark; symbol; evidence,JLPT JLPT_2 JLPT_3
-城,しろ,castle,JLPT JLPT_2 JLPT_3
-進学,しんがく,going on to university,JLPT JLPT_2 JLPT_3
-神経,しんけい,"nerve, sensitivity",JLPT JLPT_2 JLPT_3
-真剣,しんけん,"seriousness, earnestness",JLPT JLPT_2 JLPT_3
-信仰,しんこう,"(religious) faith, belief",JLPT JLPT_2 JLPT_3
-信号,しんごう,"traffic lights, signal, semaphore",JLPT JLPT_3 JLPT_2 Genki_Ln.20 Genki
-人工,じんこう,"artificial, man made, human work,",JLPT JLPT_2 JLPT_3
-深刻,しんこく,serious,JLPT JLPT_2 JLPT_3
-診察,しんさつ,medical examination (of a patient),JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.12
-人種,じんしゅ,race (of people),JLPT JLPT_2 JLPT_3
-信じる,しんじる,to believe,JLPT JLPT_2 JLPT_3
-人生,じんせい,"(human) life (e.g., conception to death)",JLPT JLPT_2 JLPT_3
-親戚,しんせき,relative(s),Genki_Ln.16 JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.9 Genki
-新鮮,しんせん,fresh,JLPT JLPT_2 JLPT_3
-心臓,しんぞう,heart,JLPT JLPT_2 JLPT_3
-身体,しんたい,the body,JLPT JLPT_2 JLPT_3
-身長,しんちょう,"height (of body), stature",JLPT JLPT_2 JLPT_3
-慎重,しんちょう,"careful, prudent, cautious",JLPT JLPT_2 JLPT_3
-審判,しんぱん,"umpire, referee, judgment",JLPT JLPT_2 JLPT_3
-人物,じんぶつ,"character, personality, talented man",JLPT JLPT_2 JLPT_3
-進歩,しんぽ,"improvement, progress, development",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.13
-親友,しんゆう,"close friend, buddy",JLPT JLPT_2 JLPT_3
-信用,しんよう,"confidence, dependence",JLPT JLPT_2 JLPT_3
-信頼,しんらい,"reliance, trust, confidence",JLPT JLPT_2 JLPT_3
-心理,しんり,mentality,JLPT JLPT_2 JLPT_3
-人類,じんるい,"mankind, humanity",JLPT JLPT_2 JLPT_3
-巣,す,"nest, breeding place",JLPT JLPT_2 JLPT_3
-酢,す,vinegar,JLPT JLPT_2 JLPT_3
-図,ず,"figure, drawing, illustration",JLPT JLPT_2 JLPT_3
-水準,すいじゅん,"level, standard",JLPT JLPT_2 JLPT_3
-推薦,すいせん,recommendation,JLPT JLPT_2 JLPT_3
-スイッチ,スイッチ,switch,JLPT Genki_Ln.18 JLPT_3 JLPT_2 Genki
-睡眠,すいみん,sleep,JLPT JLPT_2 JLPT_3
-数,すう,"number, figure",JLPT JLPT_2 JLPT_3
-数字,すうじ,"numeral, figure",JLPT JLPT_2 JLPT_3
-スープ,スープ,(Western) soup,JLPT JLPT_2 JLPT_3
-末,すえ,"the end of, powder",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.4
-姿,すがた,"figure, shape, appearance",JLPT JLPT_2 JLPT_3
-スキー,スキー,ski,JLPT JLPT_3 JLPT_2 Genki_Ln.9 Genki
-救う,すくう,"to rescue from, to help out of",JLPT JLPT_2 JLPT_3
-すくなくとも,すくなくとも,at least,JLPT JLPT_2 JLPT_3
-優れる,すぐれる,"to surpass, to outstrip, to excel",JLPT JLPT_2 JLPT_3
-スケート,スケート,"skate(s), skating",JLPT JLPT_2 JLPT_3
-スケジュール,スケジュール,schedule,JLPT JLPT_2 JLPT_3
-少しも,すこしも,"anything of, not one bit",JLPT JLPT_2 JLPT_3
-過ごす,すごす,"to pass, to spend (time)",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.11
-筋,すじ,"muscle, string, line",JLPT JLPT_2 JLPT_3
-進める,すすめる,"to advance, to promote, to hasten",JLPT JLPT_2 JLPT_3
-勧める,すすめる,"to urge (someone) to do (something), to recommend",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.13
-スター,スター,star,JLPT JLPT_2 JLPT_3
-スタイル,スタイル,style,JLPT JLPT_2 JLPT_3
-スタンド,スタンド,stand,JLPT JLPT_2 JLPT_3
-頭痛,ずつう,headache,JLPT JLPT_2 JLPT_3
-ずっと,ずっと,for a long time; all the time; consecutively,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.5 Genki_Ln.22 Genki
-すっぱい,すっぱい,"sour, acid",JLPT JLPT_2 JLPT_3
-すてき,すてき,"lovely, great",JLPT JLPT_2 JLPT_3
-既に,すでに,already (same as もう),JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.13
-すなわち,すなわち,"that is, namely, e.g.",JLPT JLPT_2 JLPT_3
-スピーチ,スピーチ,speech,JLPT JLPT_3 JLPT_2 Genki Genki_Ln.21
-全て,すべて,"all, the whole, entirely",JLPT JLPT_2 JLPT_3
-済ませる,すませる,to be finished,JLPT JLPT_2 JLPT_3
-角,すみ,corner,JLPT JLPT_2 JLPT_3
-墨,すみ,ink,JLPT JLPT_2 JLPT_3
-すみません (かん),すみません (かん),"sorry, excuse me",JLPT JLPT_2 JLPT_3
-澄む,すむ,"to clear (e.g., weather), to become transparent",JLPT JLPT_2 JLPT_3
-清む,すむ,"to clear (e.g., weather), to become transparent",JLPT JLPT_2 JLPT_3
-刷る,する,to print,JLPT JLPT_2 JLPT_3
-為る,する,"to do, to attempt",JLPT JLPT_2 JLPT_3
-鋭い,するどい,"pointed, sharp",JLPT JLPT_2 JLPT_3
-すれ違う,すれちがう,to pass by one another,JLPT JLPT_2 JLPT_3
-ずれる,ずれる,"move, off the point",JLPT JLPT_2 JLPT_3
-正,せい,"(logical) true, regular",JLPT JLPT_2 JLPT_3
-生,せい,birth,JLPT JLPT_2 JLPT_3
-性,せい,"sex, gender",JLPT JLPT_2 JLPT_3
-姓,せい,"surname, family name",JLPT JLPT_2 JLPT_3
-所為,せい,"cause, reason, fault",JLPT JLPT_2 JLPT_3
-税,ぜい,tax,JLPT JLPT_2 JLPT_3
-性格,せいかく,"character, personality",JLPT Intermediate_Japanese Genki_Ln.19 JLPT_3 JLPT_2 Genki Intermediate_Japanese_Ln.3
-正確,せいかく,"accurate, punctuality, exact",JLPT JLPT_2 JLPT_3
-世紀,せいき,century,JLPT JLPT_2 JLPT_3
-請求,せいきゅう,"claim, demand, request",JLPT JLPT_2 JLPT_3
-税金,ぜいきん,"tax, duty",Genki_Ln.15 JLPT JLPT_3 JLPT_2 Genki
-清潔,せいけつ,clean,JLPT JLPT_2 JLPT_3
-制限,せいげん,"restriction, restraint, limitation",JLPT JLPT_2 JLPT_3
-成功,せいこう,"success, hit",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.12
-正式,せいしき,"official, formal",JLPT JLPT_2 JLPT_3
-性質,せいしつ,"nature, property, disposition",JLPT JLPT_2 JLPT_3
-精神,せいしん,"mind, soul, spirit",JLPT JLPT_2 JLPT_3
-成人,せいじん,adult,JLPT JLPT_2 JLPT_3
-精々,せいぜい,"at the most, at best",JLPT JLPT_2 JLPT_3
-成績,せいせき,"grade (i.e., on a test), academic record",JLPT Genki_Ln.12 Intermediate_Japanese JLPT_3 JLPT_2 Genki Intermediate_Japanese_Ln.3
-製造,せいぞう,"manufacture, production",JLPT JLPT_2 JLPT_3
-贅沢,ぜいたく,"luxury, extravagance",JLPT JLPT_2 JLPT_3
-成長,せいちょう,growth,JLPT JLPT_2 JLPT_3
-生長,せいちょう,growth,JLPT JLPT_2 JLPT_3
-制度,せいど,"system, institution",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14
-青年,せいねん,"youth, young man",JLPT JLPT_2 JLPT_3
-生年月日,せいねんがっぴ,birth date,JLPT JLPT_2 JLPT_3
-製品,せいひん,"manufactured goods, finished goods",JLPT JLPT_2 JLPT_3
-政府,せいふ,"government, administration",JLPT Intermediate_Japanese Genki JLPT_3 JLPT_2 Intermediate_Japanese_Ln.15 Genki_Ln.21
-生物,せいぶつ,"living thing, organism",JLPT JLPT_2 JLPT_3
-生命,せいめい,life,JLPT JLPT_2 JLPT_3
-整理,せいり,"sorting, arrangement",JLPT JLPT_2 JLPT_3
-咳,せき,cough,JLPT Genki_Ln.12 JLPT_3 JLPT_2 Genki
-石炭,せきたん,coal,JLPT JLPT_2 JLPT_3
-責任,せきにん,"duty, responsibility",JLPT JLPT_2 JLPT_3
-石油,せきゆ,"oil, petroleum, kerosene",JLPT JLPT_2 JLPT_3
-世間,せけん,"world, society",JLPT JLPT_2 JLPT_3
-説,せつ,theory,JLPT JLPT_2 JLPT_3
-積極的,せっきょくてき,"positive, active, proactive",JLPT JLPT_2 JLPT_3
-設計,せっけい,"plan, design",JLPT JLPT_2 JLPT_3
-絶対,ぜったい,"definitely, without fail, absoluteness",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.7
-セット,セット,set,JLPT JLPT_2 JLPT_3
-愛,あい,love,JLPT JLPT_2 JLPT_3
-相変わらず,あいかわらず,"as ever, as usual",JLPT JLPT_2 JLPT_3
-愛情,あいじょう,"love, affection",JLPT JLPT_2 JLPT_3
-合図,あいず,"sign, signal",JLPT JLPT_2 JLPT_3
-アイスクリーム,アイスクリーム,ice cream,JLPT JLPT_2 JLPT_3
-愛する,あいする,to love,JLPT JLPT_2 JLPT_3
-相手,あいて,partner; addressee; the person you are talking to,Genki Genki_Ln.22 Intermediate_Japanese Intermediate_Japanese_Ln.2 JLPT JLPT_2 JLPT_3
-あいにく,あいにく,unfortunately,JLPT JLPT_2 JLPT_3
-遭う,あう,"to meet, to encounter (undesirable nuance)",JLPT JLPT_2 JLPT_3
-アウト,アウト,out,JLPT JLPT_2 JLPT_3
-明かり,あかり,"lamplight, light (in general)",JLPT JLPT_2 JLPT_3
-空き,あき,"vacancy, opening, space",JLPT JLPT_2 JLPT_3
-明らか,あきらか,"obvious, clear",JLPT JLPT_2 JLPT_3
-諦める,あきらめる,"to give up, to abandon",Genki Genki_Ln.14 Intermediate_Japanese Intermediate_Japanese_Ln.13 JLPT JLPT_2 JLPT_3
-飽きる,あきる,"to get tired of, to lose interest in",JLPT JLPT_2 JLPT_3
-握手,あくしゅ,handshake,JLPT JLPT_2 JLPT_3
-悪魔,あくま,"devil, demon, evil spirit",JLPT JLPT_2 JLPT_3
-明ける,あける,"to dawn, to become daylight",JLPT JLPT_2 JLPT_3
-揚げる,あげる,"to lift, to fry",JLPT JLPT_2 JLPT_3
-挙げる,あげる,"to raise; to list, to cite",JLPT JLPT_2 JLPT_3
-預かる,あずかる,to keep (something) for (someone),Intermediate_Japanese Intermediate_Japanese_Ln.10 JLPT JLPT_2 JLPT_3
-預ける,あずける,"to give into custody, to deposit",JLPT JLPT_2 JLPT_3
-汗,あせ,"sweat, perspiration",JLPT JLPT_2 JLPT_3
-与える,あたえる,to give,Intermediate_Japanese Intermediate_Japanese_Ln.5 JLPT JLPT_2 JLPT_3
-温かい,あたたかい,warm,JLPT JLPT_2 JLPT_3
-暖まる,あたたまる,to warm up,JLPT JLPT_2 JLPT_3
-温まる,あたたまる,"to warm oneself, to get warm",JLPT JLPT_2 JLPT_3
-暖める,あたためる,"to warm (up to someone/something), to heat (up to someone/something)",JLPT JLPT_2 JLPT_3
-温める,あたためる,"to warm, to heat",JLPT JLPT_2 JLPT_3
-辺り,あたり,"vicinity, nearby",Intermediate_Japanese Intermediate_Japanese_Ln.6 JLPT JLPT_2 JLPT_3
-当たり前,あたりまえ,"usual, common, obvious",JLPT JLPT_2 JLPT_3
-当たる,あたる,"to be hit, to be successful",JLPT JLPT_2 JLPT_3
-あちこち,あちこち,here and there,JLPT JLPT_2 JLPT_3
-扱う,あつかう,"to treat, to handle, to deal with",Intermediate_Japanese Intermediate_Japanese_Ln.14 JLPT JLPT_2 JLPT_3
-集まり,あつまり,"gathering, meeting, collection",JLPT JLPT_2 JLPT_3
-当てる,あてる,to hit; to apply to,JLPT JLPT_2 JLPT_3
-跡,あと,trace; remains; scar,JLPT JLPT_2 JLPT_3
-穴,あな,hole,JLPT JLPT_2 JLPT_3
-油,あぶら,oil,JLPT JLPT_2 JLPT_3
-脂,あぶら,fat,JLPT JLPT_2 JLPT_3
-誤り,あやまり,error,JLPT JLPT_2 JLPT_3
-粗,あら,"defect, flaw, fault",JLPT JLPT_2 JLPT_3
-嵐,あらし,storm,JLPT JLPT_2 JLPT_3
-争う,あらそう,"to dispute, to argue, to fight",JLPT JLPT_2 JLPT_3
-新た,あらた,"new, fresh",JLPT JLPT_2 JLPT_3
-あらゆる,あらゆる,"all, every",JLPT JLPT_2 JLPT_3
-表す,あらわす,"to express, to show",JLPT JLPT_2 JLPT_3
-現す,あらわす,"to show, to appear, to reveal",JLPT JLPT_2 JLPT_3
-著す,あらわす,"to write, to publish",JLPT JLPT_2 JLPT_3
-現れ,あらわれ,"expression, indication, sign",JLPT JLPT_2 JLPT_3
-現れる,あらわれる,"to appear (v.i.), to become visible; to express",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.8
-ありがとう,ありがとう,Thank you,JLPT JLPT_2 JLPT_3
-在る; 有る,ある,"to live, to be, to exist",JLPT JLPT_2 JLPT_3
-或,ある,"a certain..., some...",JLPT JLPT_2 JLPT_3
-あるいは,あるいは,"or, perhaps",JLPT JLPT_2 JLPT_3
-アルバム,アルバム,album,JLPT JLPT_2 JLPT_3
-泡,あわ,"bubble, foam",JLPT JLPT_2 JLPT_3
-合わせる,あわせる,to combine,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14
-慌てる,あわてる,to become confused、to panic,JLPT JLPT_2 JLPT_3
-哀れ,あわれ,"helpless, pity, pathetic",JLPT JLPT_2 JLPT_3
-案,あん,"plan, scheme, proposal",JLPT JLPT_2 JLPT_3
-案外,あんがい,unexpectedly,JLPT JLPT_2 JLPT_3
-暗記,あんき,"memorization, learning by heart",JLPT JLPT_2 JLPT_3
-安定,あんてい,"stability, equilibrium",JLPT JLPT_2 JLPT_3
-あんなに,あんなに,"to that extent, to that degree",JLPT JLPT_2 JLPT_3
-あんまり,あんまり,"not very, not much",JLPT JLPT_2 JLPT_3
-胃,い,stomach,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.12
-委員,いいん,committee member,JLPT JLPT_2 JLPT_3
-意外,いがい,"unexpected, surprising",JLPT JLPT_2 JLPT_3
-行き,いき,going,JLPT JLPT_2 JLPT_3
-行き,ゆき,going,JLPT JLPT_2 JLPT_3
-息,いき,breath,JLPT JLPT_2 JLPT_3
-勢い,いきおい,"force, vigor, momentum",JLPT JLPT_2 JLPT_3
-生き物,いきもの,"living thing, creature",JLPT JLPT_2 JLPT_3
-いけない,いけない,"must not do, bad, wrong",JLPT JLPT_2 JLPT_3
-医師,いし,"doctor, physician",JLPT JLPT_2 JLPT_3
-意思,いし,"intention, purpose",JLPT JLPT_2 JLPT_3
-意志,いし,"will, volition",JLPT JLPT_2 JLPT_3
-維持,いじ,"maintenance, preservation",JLPT JLPT_2 JLPT_3
-意識,いしき,"consciousness, senses",JLPT JLPT_2 JLPT_3
-異常,いじょう,"strangeness, abnormality, disorder",JLPT JLPT_2 JLPT_3
-意地悪,いじわる,"malicious, mean, unkind",JLPT JLPT_2 JLPT_3
-泉,いずみ,"spring, fountain",JLPT JLPT_2 JLPT_3
-いずれ,いずれ,"where, which, who",JLPT JLPT_2 JLPT_3
-以前,いぜん,in the past; before,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.15
-板,いた,"board, plank",JLPT JLPT_2 JLPT_3
-偉大,いだい,greatness,JLPT JLPT_2 JLPT_3
-抱く,いだく,"to hold (v.t.) (written expression), to embrace, to harbor",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.8
-いたずら,いたずら,"trick, practical joke",JLPT JLPT_2 JLPT_3
-いただきます,いただきます,expression of gratitude before meals,JLPT JLPT_2 JLPT_3
-痛み,いたみ,"pain, ache, sore",JLPT JLPT_2 JLPT_3
-至る,いたる,"to come, to arrive",JLPT JLPT_2 JLPT_3
-市,いち,"market, fair",JLPT_1 JLPT JLPT_2 JLPT_3
-位置,いち,"place, position",JLPT JLPT_2 JLPT_3
-一時,いちじ,"for a time, temporarily",JLPT JLPT_2 JLPT_3
-一度に,いちどに,all at once,JLPT JLPT_2 JLPT_3
-市場,いちば,"market, bazaar",JLPT JLPT_2 JLPT_3
-いつか,いつか,"sometime, one day",JLPT JLPT_2 JLPT_3
-一家,いっか,"family, clan",JLPT JLPT_2 JLPT_3
-一種,いっしゅ,"a species, a kind, a variety",JLPT JLPT_2 JLPT_3
-一瞬,いっしゅん,"a moment, an instant",JLPT JLPT_2 JLPT_3
-一生,いっしょう,throughout (one's) life,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.8
-一層,いっそう,"much more, still more",JLPT JLPT_2 JLPT_3
-一体,いったい,one object; body; what on earth?; generally,JLPT JLPT_2 JLPT_3
-一致,いっち,agreement; conformity,JLPT JLPT_2 JLPT_3
-いつでも,いつでも,"(at) any time, always",JLPT JLPT_2 JLPT_3
-いつのまにか,いつのまにか,before one knows,JLPT JLPT_2 JLPT_3
-一般,いっぱん,"general, average",JLPT JLPT_2 JLPT_3
-一方,いっぽう,on the other hand; meanwhile,JLPT JLPT_2 JLPT_3
-いつまでも,いつまでも,"forever, for good, eternally",JLPT JLPT_2 JLPT_3
-移動,いどう,"migration, movement",JLPT JLPT_2 JLPT_3
-従兄弟,いとこ,cousin (male),JLPT JLPT_2 JLPT_3
-従姉妹,いとこ,cousin (female),JLPT JLPT_2 JLPT_3
-稲,いね,rice-plant,JLPT JLPT_2 JLPT_3
-居眠り,いねむり,"dozing, nodding off",JLPT JLPT_2 JLPT_3
-命,いのち,life,JLPT JLPT_2 JLPT_3
-違反,いはん,"violation (of law), infringement",JLPT JLPT_2 JLPT_3
-衣服,いふく,clothes,JLPT JLPT_2 JLPT_3
-居間,いま,living room,JLPT JLPT_2 JLPT_3
-今に,いまに,"before long, soon",JLPT JLPT_2 JLPT_3
-今にも,いまにも,"at any time, soon",JLPT JLPT_2 JLPT_3
-イメージ,イメージ,one's image,JLPT JLPT_2 JLPT_3
-否,いや,"no, the noes",JLPT JLPT_2 JLPT_3
-以来,いらい,"since, henceforth",JLPT JLPT_2 JLPT_3
-依頼,いらい,request; dependence,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.15
-いらいら,いらいら,"getting nervous, irritation",JLPT JLPT_2 JLPT_3
-いらっしゃい,いらっしゃい,welcome,JLPT JLPT_2 JLPT_3
-医療,いりょう,"medical care, medical treatment",JLPT JLPT_2 JLPT_3
-岩,いわ,rock,JLPT JLPT_2 JLPT_3
-祝い,いわい,"celebration, festival",JLPT JLPT_2 JLPT_3
-祝う,いわう,"to congratulate, to celebrate",JLPT JLPT_2 JLPT_3
-言わば,いわば,so to speak,JLPT JLPT_2 JLPT_3
-いわゆる,いわゆる,"the so-called, so-to-speak",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14
-インク,インク,ink,JLPT JLPT_2 JLPT_3
-印刷,いんさつ,printing,JLPT JLPT_2 JLPT_3
-印象,いんしょう,impression,JLPT JLPT_2 JLPT_3
-引退,いんたい,retirement,JLPT JLPT_2 JLPT_3
-インタビュー,インタビュー,interview,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.15
-引用,いんよう,"quotation, citation",JLPT JLPT_2 JLPT_3
-ウイスキー,ウイスキー,whiskey,JLPT JLPT_2 JLPT_3
-上,うわ,"upper, outer, surface",JLPT JLPT_2 JLPT_3
-魚,うお,fish,JLPT JLPT_2 JLPT_3
-うがい,うがい,gargling,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.12
-受け取る,うけとる,"to receive, to get, to accept",JLPT JLPT_2 JLPT_3
-動かす,うごかす,"to move, to shift",JLPT JLPT_2 JLPT_3
-兎,うさぎ,"rabbit, hare",JLPT JLPT_2 JLPT_3
-牛,うし,"cattle, cow",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.10
-失う,うしなう,"to lose, to part with",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14
-疑う,うたがう,"to doubt, to distrust",JLPT JLPT_2 JLPT_3
-宇宙,うちゅう,"universe, cosmos, space",JLPT JLPT_2 JLPT_3
-討つ,うつ,"to attack, to avenge",JLPT JLPT_2 JLPT_3
-撃つ,うつ,"to attack, to shoot",JLPT JLPT_2 JLPT_3
-うっかり,うっかり,carelessly; inadvertently,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.15
-映す,うつす,"to project, to reflect, to cast (shadow)",JLPT JLPT_2 JLPT_3
-訴える,うったえる,"to complain, to appeal, to sue (a person)",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.12
-写る,うつる,"to be photographed, to be projected",JLPT JLPT_2 JLPT_3
-映る,うつる,"to be reflected, to come out (photo)",JLPT JLPT_2 JLPT_3
-うなる,うなる,"to groan, to moan",JLPT JLPT_2 JLPT_3
-奪う,うばう,"to rob, to deprive",JLPT JLPT_2 JLPT_3
-馬,うま,horse; promoted bishop (in Japanese chess known as shogi),JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.10
-生まれ,うまれ,"birth, birth-place",JLPT JLPT_2 JLPT_3
-有無,うむ,"yes or no, presence or absence",JLPT JLPT_2 JLPT_3
-梅,うめ,"plum, lowest (of a three-tier ranking system)",JLPT JLPT_2 JLPT_3
-埋める,うめる,"to bury, to fill up, to fill (a seat, a vacant position)",JLPT JLPT_2 JLPT_3
-裏切る,うらぎる,"to betray, to turn traitor",JLPT JLPT_2 JLPT_3
-羨ましい,うらやましい,"envious, enviable",JLPT JLPT_2 JLPT_3
-売れる,うれる,to be sold,JLPT JLPT_2 JLPT_3
-噂,うわさ,"rumor, gossip",JLPT JLPT_2 JLPT_3
-運,うん,"fortune, luck",JLPT JLPT_2 JLPT_3
-運転,うんてん,"operation, driving",JLPT JLPT_2 JLPT_3
-柄,え,"handle (of a sword, dagger, etc.), grip",JLPT_1 JLPT JLPT_2 JLPT_3
-永遠,えいえん,"eternity, perpetuity, immortality",JLPT JLPT_2 JLPT_3
-永久,えいきゅう,"eternity, perpetuity, immortality",JLPT JLPT_2 JLPT_3
-影響,えいきょう,"influence, effect",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.9
-営業,えいぎょう,"business, trade, management",JLPT JLPT_2 JLPT_3
-衛星,えいせい,satellite,JLPT_1 JLPT JLPT_2 JLPT_3
-栄養,えいよう,"nutrition, nourishment",JLPT JLPT_2 JLPT_3
-笑顔,えがお,smile (on one's face),JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.11
-描く,えがく,"to draw, to depict, to describe",JLPT JLPT_2 JLPT_3
-餌,えさ,"feed, bait",JLPT JLPT_2 JLPT_3
-エネルギー,エネルギー,energy (GER: energie),JLPT JLPT_2 JLPT_3
-得る,える,"to get, to gain, to win, to learn",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.11
-得る,うる,"to get, to gain, to win",JLPT JLPT_2 JLPT_3
-円,えん,"circle, yen",JLPT JLPT_2 JLPT_3
-延期,えんき,"postponement, adjournment",JLPT JLPT_2 JLPT_3
-演技,えんぎ,"acting, performance",JLPT JLPT_2 JLPT_3
-援助,えんじょ,"assistance, aid, support",JLPT JLPT_2 JLPT_3
-エンジン,エンジン,engine,JLPT JLPT_2 JLPT_3
-演説,えんぜつ,"speech, address",JLPT JLPT_2 JLPT_3
-演奏,えんそう,musical performance,JLPT JLPT_2 JLPT_3
-老い,おい,"old age, the aged",JLPT JLPT_2 JLPT_3
-追い付く,おいつく,"to overtake, to catch up (with)",JLPT JLPT_2 JLPT_3
-王,おう,king,JLPT JLPT_2 JLPT_3
-追う,おう,"to chase, to run after",JLPT JLPT_2 JLPT_3
-応援,おうえん,"aid, assistance, help",JLPT JLPT_2 JLPT_3
-王様,おうさま,king,JLPT JLPT_2 JLPT_3
-王子,おうじ,prince,JLPT JLPT_2 JLPT_3
-応じる,おうじる,"to adapt, to respond, to comply with",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14
-横断,おうだん,crossing,JLPT JLPT_2 JLPT_3
-終える,おえる,to finish,JLPT JLPT_2 JLPT_3
-大いに,おおいに,"much, considerably (same as 大変 (たいへん)), greatly",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.13
-覆う,おおう,"to cover, to hide, to conceal",JLPT JLPT_2 JLPT_3
-大家,おおや,landlord,JLPT JLPT_2 JLPT_3
-丘,おか,"hill, height",JLPT JLPT_2 JLPT_3
-沖,おき,open sea,JLPT JLPT_2 JLPT_3
-奥,おく,"interior, inner part",JLPT JLPT_2 JLPT_3
-贈る,おくる,"to present, to give to, to award to",JLPT JLPT_2 JLPT_3
-起こる,おこる,"to occur, to happen",JLPT JLPT_2 JLPT_3
-押える,おさえる,"to stop, to restrain, to press down",JLPT JLPT_2 JLPT_3
-幼い,おさない,"very young, childish",JLPT JLPT_2 JLPT_3
-収める,おさめる,"to store to pay, to supply",JLPT JLPT_2 JLPT_3
-納める,おさめる,"to store to pay, to supply",JLPT JLPT_2 JLPT_3
-治める,おさめる,"to govern, to manage; to subdue",JLPT JLPT_2 JLPT_3
-お辞儀,おじぎ,bow,JLPT JLPT_2 JLPT_3
-お洒落,おしゃれ,"smartly dressed, fashion-conscious",JLPT JLPT_2 JLPT_3
-お喋り,おしゃべり,"chattering, talk",JLPT JLPT_2 JLPT_3
-汚染,おせん,"pollution, contamination",JLPT JLPT_2 JLPT_3
-恐らく,おそらく,perhaps,JLPT JLPT_2 JLPT_3
-恐れる,おそれる,"to fear, to be afraid of",JLPT JLPT_2 JLPT_3
-恐ろしい,おそろしい,"terrible, dreadful",JLPT JLPT_2 JLPT_3
-教わる,おそわる,to be taught,JLPT JLPT_2 JLPT_3
-お互い,おたがい,"mutual, reciprocal, each other",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.1
-穏やか,おだやか,"calm, gentle, quiet",JLPT JLPT_2 JLPT_3
-男の人,おとこのひと,man,JLPT JLPT_3 JLPT_2 Genki_Ln.7 Genki
-大人しい,おとなしい,"obedient, docile, quiet",JLPT JLPT_2 JLPT_3
-劣る,おとる,"to fall behind, to be inferior to",JLPT JLPT_2 JLPT_3
-鬼,おに,"ogre, demon, 'it' (e.g.,in a game of tag)",JLPT JLPT_2 JLPT_3
-帯,おび,"band, sash",JLPT JLPT_2 JLPT_3
-お昼,おひる,"lunch, noon",JLPT JLPT_2 JLPT_3
-オフィス,オフィス,office,JLPT JLPT_2 JLPT_3
-溺れる,おぼれる,"to be drowned, to indulge in",JLPT JLPT_2 JLPT_3
-お前,おまえ,"you (sing), presence (of a high personage)",JLPT JLPT_2 JLPT_3
-おめでとう,おめでとう,"Congratulations!, an auspicious occasion!",JLPT JLPT_2 JLPT_3
-お目に掛かる,おめにかかる,"meet ~, see ~",JLPT JLPT_2 JLPT_3
-思い付く,おもいつく,"to think of, to hit upon",JLPT JLPT_2 JLPT_3
-思い出,おもいで,"memories, recollections, reminiscence",JLPT JLPT_3 JLPT_2 Genki_Ln.23 Genki
-主に,おもに,"mainly, primarily",JLPT JLPT_2 JLPT_3
-思わず,おもわず,"unintentional, spontaneous",JLPT JLPT_2 JLPT_3
-泳ぎ,およぎ,swimming,JLPT JLPT_2 JLPT_3
-およそ,およそ,"about, roughly, approximately",JLPT JLPT_2 JLPT_3
-及ぼす,およぼす,"to exert, to cause, to exercise",JLPT JLPT_2 JLPT_3
-下す,おろす,"to lower, to let go down",JLPT JLPT_2 JLPT_3
-降ろす,おろす,"to take down, to launch, to drop",JLPT JLPT_2 JLPT_3
-卸す,おろす,"to sell wholesale, grated (vegetables)",JLPT JLPT_2 JLPT_3
-音,おん,"sound, note",JLPT JLPT_2 JLPT_3
-恩,おん,"favor, obligation, debt of gratitude",JLPT JLPT_2 JLPT_3
-温暖,おんだん,warmth,JLPT JLPT_2 JLPT_3
-温度,おんど,temperature,JLPT JLPT_2 JLPT_3
-可,か,passable,JLPT JLPT_2 JLPT_3
-蚊,か,mosquito,JLPT JLPT_3 JLPT_2 Genki Genki_Ln.21
-課,か,"department, division",JLPT JLPT_2 JLPT_3
-カー,カー,car,JLPT JLPT_2 JLPT_3
-カード,カード,"card, curd",JLPT JLPT_2 JLPT_3
-貝,かい,"shell, shellfish",JLPT JLPT_2 JLPT_3
-害,がい,"harm, damage",JLPT JLPT_2 JLPT_3
-会員,かいいん,"member, the membership",JLPT JLPT_2 JLPT_3
-絵画,かいが,"picture, painting",JLPT JLPT_2 JLPT_3
-海外,かいがい,"foreign, abroad, overseas",JLPT JLPT_2 JLPT_3
-会計,かいけい,"account, finance",JLPT JLPT_2 JLPT_3
-解決,かいけつ,"settlement, solution, resolution",JLPT JLPT_2 JLPT_3
-会合,かいごう,"meeting, assembly",JLPT JLPT_2 JLPT_3
-外交,がいこう,diplomacy,JLPT JLPT_2 JLPT_3
-開始,かいし,"start, commencement, beginning",JLPT JLPT_2 JLPT_3
-解釈,かいしゃく,"explanation, interpretation",JLPT JLPT_2 JLPT_3
-外出,がいしゅつ,"outing, going out",JLPT JLPT_2 JLPT_3
-改善,かいぜん,"betterment, improvement",JLPT JLPT_2 JLPT_3
-快適,かいてき,"pleasant, agreeable",JLPT JLPT_2 JLPT_3
-回復,かいふく,"recovery (from illness), rehabilitation, restoration",JLPT JLPT_2 JLPT_3
-飼う,かう,to keep; to own (a pet); to raise; to feed,JLPT Genki_Ln.11 JLPT_3 JLPT_2 Genki
-帰す,かえす,to send back,JLPT JLPT_2 JLPT_3
-代える,かえる,"to exchange, to interchange, to substitute",JLPT JLPT_2 JLPT_3
-替える,かえる,"to exchange, to interchange, to substitute",JLPT JLPT_2 JLPT_3
-換える,かえる,"to exchange, to interchange, to substitute",JLPT JLPT_3 JLPT_2 Genki_Ln.23 Genki
-反る,かえる,"to warp, to be warped, to curve",JLPT JLPT_2 JLPT_3
-香り,かおり,"aroma, fragrance",JLPT JLPT_2 JLPT_3
-画家,がか,painter,JLPT JLPT_2 JLPT_3
-抱える,かかえる,to hold or carry under or in the arms,JLPT JLPT_2 JLPT_3
-価格,かかく,"price, value",JLPT JLPT_2 JLPT_3
-化学,かがく,chemistry,JLPT JLPT_2 JLPT_3
-輝く,かがやく,"to shine, to glitter, to sparkle",JLPT JLPT_2 JLPT_3
-係,かかり,person in charge,JLPT JLPT_2 JLPT_3
-罹る,かかる,to suffer from,JLPT JLPT_2 JLPT_3
-限る,かぎる,"to restrict, to limit, to confine",JLPT JLPT_2 JLPT_3
-掻く,かく,to scratch,JLPT JLPT_2 JLPT_3
-描く,かく,"to draw, to depict, to describe",JLPT JLPT_2 JLPT_3
-嗅ぐ,かぐ,"to sniff, to smell",JLPT JLPT_2 JLPT_3
-家具,かぐ,furniture,Genki_Ln.15 JLPT JLPT_3 JLPT_2 Genki
-学,がく,"learning, knowledge",JLPT JLPT_2 JLPT_3
-額,がく,amount; frame,JLPT JLPT_2 JLPT_3
-覚悟,かくご,"resolution, resignation, readiness",JLPT JLPT_2 JLPT_3
-確実,かくじつ,"certainty, reliability, soundness",JLPT JLPT_2 JLPT_3
-学者,がくしゃ,scholar,JLPT JLPT_2 JLPT_3
-学習,がくしゅう,"study, learning",JLPT JLPT_2 JLPT_3
-隠す,かくす,"to hide, to conceal",JLPT JLPT_2 JLPT_3
-拡大,かくだい,"magnification, enlargement",JLPT JLPT_2 JLPT_3
-確認,かくにん,"affirmation, confirmation",JLPT JLPT_2 JLPT_3
-学問,がくもん,"scholarship, study, learning",JLPT JLPT_2 JLPT_3
-隠れる,かくれる,"to hide, to be hidden",JLPT JLPT_2 JLPT_3
-影,かげ,"shade, shadow, other side",JLPT JLPT_2 JLPT_3
-陰,かげ,"shade, shadow, other side",JLPT JLPT_2 JLPT_3
-欠ける,かける,to be lacking,JLPT JLPT_2 JLPT_3
-加減,かげん,adjustment; addition and subtraction,JLPT JLPT_2 JLPT_3
-過去,かこ,past,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.13
-籠,かご,"basket, cage",JLPT JLPT_2 JLPT_3
-囲む,かこむ,"to surround, to encircle",JLPT JLPT_2 JLPT_3
-火災,かさい,"conflagration, fire",JLPT JLPT_2 JLPT_3
-重なる,かさなる,"to be piled up, lie on top of one another",JLPT JLPT_2 JLPT_3
-重ねる,かさねる,"to pile up, to put something on another, to heap up",JLPT JLPT_2 JLPT_3
-飾り,かざり,decoration,JLPT JLPT_2 JLPT_3
-貸し,かし,"loan, lending",JLPT JLPT_2 JLPT_3
-菓子,かし,"confectionery, sweet",JLPT JLPT_2 JLPT_3
-家事,かじ,household matters; housework (same as 家の仕事 (いえのしごと)),JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14 Genki_Ln.22 Genki
-賢い,かしこい,"wise, clever, smart",JLPT JLPT_2 JLPT_3
-歌手,かしゅ,singer,JLPT Genki_Ln.11 JLPT_3 JLPT_2 Genki
-数,かず,"number, figure, amount",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.3
-稼ぐ,かせぐ,"to earn income, to labor",JLPT JLPT_2 JLPT_3
-数える,かぞえる,to count,JLPT JLPT_2 JLPT_3
-型,かた,"mold, model, style",JLPT JLPT_2 JLPT_3
-肩,かた,shoulder,JLPT JLPT_2 JLPT_3
-堅い,かたい,"hard, firm, solid",JLPT JLPT_2 JLPT_3
-硬い,かたい,"hard, firm, solid",JLPT JLPT_2 JLPT_3
-方々,かたがた,persons,JLPT JLPT_2 JLPT_3
-片付く,かたづく,"to put in order, to solve",JLPT JLPT_2 JLPT_3
-刀,かたな,"sword, saber",JLPT JLPT_2 JLPT_3
-語る,かたる,"to talk, to tell, to recite",JLPT JLPT_2 JLPT_3
-勝ち,かち,"win, victory",JLPT JLPT_2 JLPT_3
-価値,かち,"value, worth, merit",JLPT JLPT_2 JLPT_3
-がっかり,がっかり,"feel disappointed, be dejected, lose heart",JLPT JLPT_2 JLPT_3
-活気,かっき,vigor; liveliness; vitality; energy,JLPT Intermediate_Japanese JLPT_1 JLPT_3 JLPT_2 Intermediate_Japanese_Ln.10
-楽器,がっき,musical instrument,JLPT Genki_Ln.13 JLPT_3 JLPT_2 Genki
-学期,がっき,term (school),JLPT JLPT_2 JLPT_3
-活動,かつどう,"action, activity",JLPT JLPT_2 JLPT_3
-活躍,かつやく,activity,JLPT JLPT_2 JLPT_3
-活用,かつよう,conjugation; practical use,JLPT JLPT_2 JLPT_3
-仮定,かてい,"assumption, supposition, hypothesis",JLPT JLPT_2 JLPT_3
-過程,かてい,process,JLPT JLPT_2 JLPT_3
-課程,かてい,"course, curriculum",JLPT JLPT_2 JLPT_3
-悲しむ,かなしむ,"to be sad, to mourn for, to regret",JLPT JLPT_2 JLPT_3
-必ずしも,かならずしも,"(not) always, (not) necessarily",JLPT JLPT_2 JLPT_3
-かなり,かなり,"considerably, fairly, quite",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.7
-金,かね,"gold, metal; money",JLPT JLPT_2 JLPT_3
-鐘,かね,"bell, chime",JLPT JLPT_2 JLPT_3
-可能,かのう,"possible, practicable, feasible",JLPT JLPT_2 JLPT_3
-株,かぶ,stock; stump (of tree),JLPT JLPT_2 JLPT_3
-被る,かぶる,to wear; to be covered with,JLPT JLPT_2 JLPT_3
-我慢,がまん,"patience, endurance, perseverance",JLPT JLPT_2 JLPT_3
-上,かみ,first volume; superior quality; governmental,JLPT JLPT_2 JLPT_3
-神,かみ,god,JLPT JLPT_2 JLPT_3
-雷,かみなり,thunder,JLPT JLPT_2 JLPT_3
-髪の毛,かみのけ,hair (head),JLPT JLPT_2 JLPT_3
-科目,かもく,"(school) subject, curriculum, course",JLPT JLPT_2 JLPT_3
-かもしれない,かもしれない,"maybe, perhaps",JLPT JLPT_2 JLPT_3
-かゆい,かゆい,"itchy, itching",JLPT JLPT_2 JLPT_3
-歌謡,かよう,"song, ballad",JLPT JLPT_2 JLPT_3
-空,から,empty,JLPT JLPT_2 JLPT_3
-殻,から,"shell, husk, hull",JLPT JLPT_2 JLPT_3
-柄,がら,pattern; build; character,JLPT JLPT_2 JLPT_3
-刈る,かる,"to cut (hair), to mow (grass), to harvest",JLPT JLPT_2 JLPT_3
-河,かわ,"river, stream",JLPT JLPT_2 JLPT_3
-皮,かわ,"skin, hide, leather",JLPT JLPT_2 JLPT_3
-革,かわ,leather,JLPT JLPT_2 JLPT_3
-可愛そう,かわいそう,"poor, pitiable, pathetic",JLPT JLPT_2 JLPT_3
-可愛らしい,かわいらしい,"lovely, sweet",JLPT JLPT_2 JLPT_3
-乾かす,かわかす,to dry,JLPT JLPT_2 JLPT_3
-渇く,かわく,to be thirsty,JLPT JLPT_2 JLPT_3
-代る,かわる,"to take the place of, to relieve, to be substituted for",JLPT JLPT_2 JLPT_3
-缶,かん,"can, tin",JLPT_1 JLPT JLPT_2 JLPT_3
-勘,かん,"perception, intuition, the sixth sense",JLPT JLPT_2 JLPT_3
-考え,かんがえ,"thinking, thought, ideas",JLPT JLPT_2 JLPT_3
-感覚,かんかく,"sense, sensation",JLPT JLPT_2 JLPT_3
-間隔,かんかく,"space, interval, SPC",JLPT JLPT_2 JLPT_3
-観客,かんきゃく,"audience, spectator(s)",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.7
-環境,かんきょう,"environment, circumstance",JLPT JLPT_3 JLPT_2 Genki Genki_Ln.21
-歓迎,かんげい,"welcome, reception",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.5
-観光,かんこう,sightseeing,Genki_Ln.15 JLPT JLPT_3 JLPT_2 Genki
-観察,かんさつ,"observation, survey",JLPT JLPT_2 JLPT_3
-感じ,かんじ,"feeling, sense, impression",JLPT JLPT_2 JLPT_3
-感謝,かんしゃ,"thanks, gratitude",JLPT JLPT_2 JLPT_3
-患者,かんじゃ,patient,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.12
-勘定,かんじょう,"calculation, counting, consideration",JLPT JLPT_2 JLPT_3
-感情,かんじょう,"emotion(s), feeling(s), sentiment",JLPT JLPT_2 JLPT_3
-感じる,かんじる,"to feel, to sense",JLPT JLPT_2 JLPT_3
-感心,かんしん,admiration,JLPT JLPT_2 JLPT_3
-関心,かんしん,"concern, interest",JLPT JLPT_2 JLPT_3
-関する,かんする,"to concern, to be related",JLPT JLPT_2 JLPT_3
-完成,かんせい,"complete, completion; perfection",JLPT JLPT_2 JLPT_3
-完全,かんぜん,"perfection, completeness",JLPT JLPT_2 JLPT_3
-乾燥,かんそう,"dry, arid, dehydrated",JLPT JLPT_2 JLPT_3
-感想,かんそう,"(one's) impressions, (one's) thoughts",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.11
-感動,かんどう,"being deeply moved, excitement",JLPT JLPT_2 JLPT_3
-監督,かんとく,"supervision, control, (movie) director",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.7
-管理,かんり,"control, management (e.g., of a business)",JLPT JLPT_2 JLPT_3
-完了,かんりょう,"completion, conclusion",JLPT JLPT_2 JLPT_3
-関連,かんれん,"relation, connection, relevance",JLPT JLPT_2 JLPT_3
-議員,ぎいん,"member of the Diet, congress, or parliament",JLPT JLPT_2 JLPT_3
-記憶,きおく,"memory, recollection, remembrance",JLPT JLPT_2 JLPT_3
-気温,きおん,temperature (weather - not used for things),JLPT Genki_Ln.12 JLPT_3 JLPT_2 Genki
-機械,きかい,"machine, machinery",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14
-器械,きかい,instrument,JLPT JLPT_2 JLPT_3
-議会,ぎかい,"Diet, congress, parliament",JLPT JLPT_2 JLPT_3
-期間,きかん,"period, term",JLPT JLPT_2 JLPT_3
-機関,きかん,"engine; institution, organization",JLPT JLPT_2 JLPT_3
-企業,きぎょう,"industry, business, undertaking",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14
-効く,きく,to be effective,JLPT JLPT_2 JLPT_3
-期限,きげん,"deadline, term",JLPT JLPT_2 JLPT_3
-機嫌,きげん,"humor, temper, mood",JLPT JLPT_2 JLPT_3
-気候,きこう,climate,JLPT JLPT_2 JLPT_3
-岸,きし,"bank, coast, shore",JLPT JLPT_2 JLPT_3
-生地,きじ,fabric; dough,JLPT JLPT_2 JLPT_3
-記事,きじ,"article, news story",JLPT JLPT_2 JLPT_3
-技師,ぎし,"engineer, technician",JLPT JLPT_2 JLPT_3
-記者,きしゃ,reporter,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.15
-傷,きず,"wound, injury, hurt",JLPT JLPT_2 JLPT_3
-期待,きたい,"expectation, anticipation, hope",JLPT JLPT_2 JLPT_3
-気体,きたい,"vapor, gas",JLPT JLPT_2 JLPT_3
-帰宅,きたく,returning home,JLPT JLPT_2 JLPT_3
-貴重,きちょう,"precious, valuable",JLPT JLPT_2 JLPT_3
-議長,ぎちょう,chairman,JLPT JLPT_2 JLPT_3
-きちんと,きちんと,"precisely, accurately",JLPT JLPT_2 JLPT_3
-きつい,きつい,"tight, close, intense",JLPT JLPT_2 JLPT_3
-気付く,きづく,"to notice, to recognize, to become aware of",JLPT JLPT_2 JLPT_3
-気に入る,きにいる,"to like, to be please",JLPT JLPT_2 JLPT_3
-記入,きにゅう,"entry, filling in of forms",JLPT JLPT_2 JLPT_3
-記念,きねん,"commemoration, memory",JLPT JLPT_2 JLPT_3
-機能,きのう,"function, faculty",JLPT JLPT_2 JLPT_3
-気の毒,きのどく,"pitiful, a pity",JLPT JLPT_2 JLPT_3
-寄付,きふ,"contribution, donation",JLPT JLPT_2 JLPT_3
-希望,きぼう,"hope, wish, aspiration",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.3
-基本,きほん,"basic, basis",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.15
-決まり,きまり,"settlement, conclusion, rule",JLPT JLPT_2 JLPT_3
-気味,きみ,"-like, -looking, -looked",JLPT JLPT_2 JLPT_3
-奇妙,きみょう,"strange, queer, curious",JLPT JLPT_2 JLPT_3
-義務,ぎむ,"duty, obligation, responsibility",JLPT JLPT_2 JLPT_3
-疑問,ぎもん,"question, problem, doubt",JLPT JLPT_2 JLPT_3
-逆,ぎゃく,"reverse, opposite",JLPT JLPT_2 JLPT_3
-キャプテン,キャプテン,captain,JLPT JLPT_2 JLPT_3
-キャンプ,キャンプ,camp,JLPT Genki_Ln.11 JLPT_3 JLPT_2 Genki
-旧,きゅう,ex-,JLPT JLPT_2 JLPT_3
-級,きゅう,"class, grade, rank",JLPT JLPT_2 JLPT_3
-球,きゅう,"globe, sphere, ball",JLPT JLPT_2 JLPT_3
-休暇,きゅうか,"vacation, holiday, day off",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.1
-休憩,きゅうけい,"rest, break, intermission",JLPT JLPT_2 JLPT_3
-急激,きゅうげき,"sudden, precipitous, radical",JLPT JLPT_2 JLPT_3
-吸収,きゅうしゅう,"absorption, suction",JLPT JLPT_2 JLPT_3
-救助,きゅうじょ,"relief, aid, rescue",JLPT JLPT_2 JLPT_3
-急速,きゅうそく,"rapid (e.g., progress)",JLPT JLPT_2 JLPT_3
-休息,きゅうそく,"rest, relief, relaxation",JLPT JLPT_2 JLPT_3
-急に,きゅうに,suddenly,JLPT JLPT_2 JLPT_3
-給料,きゅうりょう,"salary, wages",Genki_Ln.17 JLPT JLPT_3 JLPT_2 Genki
-器用,きよう,"skillful, handy",JLPT JLPT_2 JLPT_3
-教科書,きょうかしょ,textbook,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Genki_Ln.6 Intermediate_Japanese_Ln.13 Genki
-競技,きょうぎ,"game, match, contest",JLPT JLPT_2 JLPT_3
-行儀,ぎょうぎ,manners,JLPT JLPT_2 JLPT_3
-供給,きょうきゅう,"supply, provision",JLPT JLPT_2 JLPT_3
-教授,きょうじゅ,"teaching, instruction; professor",JLPT JLPT_2 JLPT_3
-強調,きょうちょう,"emphasis, stress, stressed point",JLPT JLPT_2 JLPT_3
-共通,きょうつう,"commonness, mutual",JLPT JLPT_2 JLPT_3
-共同,きょうどう,"cooperation, association, collaboration",JLPT JLPT_2 JLPT_3
-恐怖,きょうふ,"fear, terror",JLPT JLPT_2 JLPT_3
-協力,きょうりょく,"cooperation, collaboration",JLPT JLPT_2 JLPT_3
-強力,きょうりょく,"powerful, strong",JLPT JLPT_2 JLPT_3
-許可,きょか,"permission, approval",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.4
-局,きょく,"office, bureau, station(TV, radio)",JLPT JLPT_2 JLPT_3
-巨大,きょだい,"huge, gigantic, enormous",JLPT JLPT_2 JLPT_3
-嫌う,きらう,"to hate, to dislike, to loathe",JLPT JLPT_2 JLPT_3
-霧,きり,"fog, mist",JLPT JLPT_2 JLPT_3
-切れ,きれ,"cloth, piece, cut",JLPT JLPT_2 JLPT_3
-切れる,きれる,"to cut well, to be sharp; to break (off)",JLPT JLPT_2 JLPT_3
-記録,きろく,"record, minutes, document",JLPT JLPT_2 JLPT_3
-議論,ぎろん,"argument, discussion, dispute",JLPT JLPT_2 JLPT_3
-金,きん,"gold, metal; money",JLPT JLPT_2 JLPT_3
-銀,ぎん,silver,JLPT JLPT_2 JLPT_3
-禁煙,きんえん,No Smoking,JLPT JLPT_2 JLPT_3
-金額,きんがく,amount of money,JLPT JLPT_2 JLPT_3
-金庫,きんこ,"safe, vault",JLPT JLPT_2 JLPT_3
-禁止,きんし,"prohibition, ban",JLPT JLPT_2 JLPT_3
-金銭,きんせん,"money, cash",JLPT JLPT_2 JLPT_3
-金属,きんぞく,metal,JLPT JLPT_2 JLPT_3
-近代,きんだい,modern times,JLPT JLPT_2 JLPT_3
-緊張,きんちょう,"tension, mental strain, nervousness",JLPT JLPT_2 JLPT_3
-筋肉,きんにく,"muscle, sinews",JLPT JLPT_2 JLPT_3
-金融,きんゆう,"finance, money and banking",JLPT JLPT_2 JLPT_3
-句,く,phrase,JLPT JLPT_2 JLPT_3
-食う,くう,(male) (vulg.) to eat,JLPT JLPT_2 JLPT_3
-偶然,ぐうぜん,"(by) chance, unexpectedly",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.4
-臭い,くさい,"stinky, smelly, bad-smelling",JLPT JLPT_2 JLPT_3
-鎖,くさり,chain,JLPT JLPT_2 JLPT_3
-腐る,くさる,"to rot, to go bad",JLPT JLPT_2 JLPT_3
-癖,くせ,"a habit (often a bad habit), peculiarity",JLPT JLPT_2 JLPT_3
-管,くだ,"pipe, tube",JLPT JLPT_2 JLPT_3
-具体,ぐたい,"concrete, tangible, material",JLPT JLPT_2 JLPT_3
-下り,くだり,down-train (going away from Tokyo),JLPT JLPT_2 JLPT_3
-下る,くだる,"to get down, to descend",JLPT JLPT_2 JLPT_3
-苦痛,くつう,"pain, agony",JLPT JLPT_2 JLPT_3
-ぐっすり,ぐっすり,"sound asleep, fast asleep",JLPT JLPT_2 JLPT_3
-区別,くべつ,"distinction, differentiation, classification",JLPT JLPT_2 JLPT_3
-組,くみ,"class, team, set",JLPT JLPT_2 JLPT_3
-組合,くみあい,"association, union",JLPT JLPT_2 JLPT_3
-組む,くむ,to put together,JLPT JLPT_2 JLPT_3
-汲む,くむ,"to draw, to scoop, to pump",JLPT JLPT_2 JLPT_3
-酌む,くむ,to serve sake,JLPT JLPT_2 JLPT_3
-悔しい,くやしい,"regrettable, mortifying, vexing",JLPT JLPT_2 JLPT_3
-位,くらい,"grade, rank, about",JLPT JLPT_2 JLPT_3
-暮らし,くらし,living; life style,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.13
-クラシック,クラシック,classic(s),JLPT JLPT_2 JLPT_3
-暮らす,くらす,"to live, to get along",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.11
-グラス,グラス,glass; grass,JLPT JLPT_2 JLPT_3
-グランド,グランド,"gland, grand, (electrical) ground",JLPT JLPT_2 JLPT_3
-クリーム,クリーム,cream,JLPT JLPT_2 JLPT_3
-繰り返す,くりかえす,"to repeat, to do something over again",JLPT JLPT_2 JLPT_3
-クリスマス,クリスマス,Christmas,JLPT Genki_Ln.14 JLPT_3 JLPT_2 Genki
-狂う,くるう,"to go mad, to get out of order",JLPT JLPT_2 JLPT_3
-グループ,グループ,group,JLPT JLPT_2 JLPT_3
-苦しい,くるしい,tough; physically strenuous,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.15
-苦しむ,くるしむ,"to suffer, to groan, to be worried",JLPT JLPT_2 JLPT_3
-暮れ,くれ,"year end,",JLPT JLPT_2 JLPT_3
-苦労,くろう,hardship; suffering,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14
-加える,くわえる,"to append, to sum up, to add (up)",JLPT JLPT_2 JLPT_3
-咥える,くわえる,to hold something in the mouth,JLPT JLPT_2 JLPT_3
-詳しい,くわしい,detailed; full; accurate,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.8
-加わる,くわわる,"to join in, to accede to",JLPT JLPT_2 JLPT_3
-訓,くん,native Japanese reading of a Chinese character,JLPT JLPT_2 JLPT_3
-軍,ぐん,"army, force, troops",JLPT JLPT_2 JLPT_3
-郡,ぐん,"country, district",JLPT JLPT_2 JLPT_3
-軍隊,ぐんたい,"army, troops",JLPT JLPT_2 JLPT_3
-訓練,くんれん,"practice, training",JLPT JLPT_2 JLPT_3
-下,げ,"under, below, beneath",JLPT JLPT_2 JLPT_3
-計,けい,"plan; sum, total",JLPT JLPT_2 JLPT_3
-敬意,けいい,"respect, honor",JLPT JLPT_2 JLPT_3
-経営,けいえい,"management, administration",JLPT JLPT_2 JLPT_3
-景気,けいき,"condition, state, business (condition)",JLPT JLPT_2 JLPT_3
-傾向,けいこう,"tendency, trend, inclination",JLPT JLPT_2 JLPT_3
-警告,けいこく,warning,JLPT JLPT_2 JLPT_3
-計算,けいさん,"calculation, reckoning",JLPT JLPT_2 JLPT_3
-掲示,けいじ,"notice, bulletin",JLPT JLPT_2 JLPT_3
-刑事,けいじ,"criminal case, (police) detective",JLPT JLPT_2 JLPT_3
-芸術,げいじゅつ,"(fine) art, the arts",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.10
-契約,けいやく,"contract, compact, agreement",JLPT JLPT_2 JLPT_3
-経由,けいゆ,"go by the way, via",JLPT JLPT_2 JLPT_3
-ケース,ケース,case,JLPT_1 JLPT JLPT_2 JLPT_3
-ゲーム,ゲーム,game,JLPT JLPT_2 JLPT_3
-劇,げき,"drama, play",JLPT JLPT_2 JLPT_3
-劇場,げきじょう,"theater, playhouse",JLPT JLPT_2 JLPT_3
-化粧,けしょう,make-up (cosmetic),JLPT JLPT_2 JLPT_3
-けち,けち,"stinginess, miser",JLPT JLPT_2 JLPT_3
-血液,けつえき,blood,JLPT JLPT_2 JLPT_3
-結果,けっか,"result, consequence",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.5
-欠陥,けっかん,"defect, fault, deficiency",JLPT JLPT_2 JLPT_3
-結局,けっきょく,"after all, eventually",JLPT JLPT_2 JLPT_3
-決心,けっしん,"determination, resolution",JLPT JLPT_2 JLPT_3
-欠席,けっせき,"absence, non-attendance",JLPT JLPT_2 JLPT_3
-決定,けってい,"decision, determination",JLPT JLPT_2 JLPT_3
-欠点,けってん,"faults, defect, weakness",JLPT JLPT_2 JLPT_3
-結論,けつろん,conclusion,JLPT JLPT_2 JLPT_3
-煙,けむり,"smoke, fumes",JLPT JLPT_2 JLPT_3
-蹴る,ける,to kick,JLPT JLPT_3 JLPT_2 Genki Genki_Ln.21
-券,けん,"ticket, certificate",JLPT JLPT_2 JLPT_3
-県,けん,prefecture,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.7
-見解,けんかい,"opinion, point of view",JLPT JLPT_2 JLPT_3
-限界,げんかい,"limit, bound",JLPT JLPT_2 JLPT_3
-現金,げんきん,cash,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.9
-言語,げんご,language,JLPT JLPT_2 JLPT_3
-健康,けんこう,health(y),JLPT JLPT_2 JLPT_3
-検査,けんさ,"inspection, examination",JLPT JLPT_2 JLPT_3
-現在,げんざい,"now (same as 今 (いま)), present, current",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.12
-現実,げんじつ,reality,JLPT JLPT_2 JLPT_3
-現象,げんしょう,phenomenon,JLPT JLPT_2 JLPT_3
-現状,げんじょう,"present condition, status quo",JLPT JLPT_2 JLPT_3
-建設,けんせつ,"construction, foundation",JLPT JLPT_2 JLPT_3
-現代,げんだい,"today, present-day",JLPT JLPT_2 JLPT_3
-建築,けんちく,"construction, architecture",JLPT JLPT_2 JLPT_3
-見当,けんとう,"estimate, guess",JLPT JLPT_2 JLPT_3
-検討,けんとう,"consideration, examination, investigation",JLPT JLPT_2 JLPT_3
-現場,げんば,"actual spot, scene, field",JLPT JLPT_2 JLPT_3
-憲法,けんぽう,constitution,JLPT JLPT_2 JLPT_3
-権利,けんり,"right, privilege",JLPT JLPT_2 JLPT_3
-後,ご,"afterwards, since then",JLPT JLPT_2 JLPT_3
-碁,ご,Go (board game of capturing territory),JLPT JLPT_2 JLPT_3
-恋,こい,"love, tender passion",JLPT JLPT_2 JLPT_3
-濃い,こい,"thick (as of color, liquid), dense, strong",JLPT JLPT_2 JLPT_3
-恋人,こいびと,lover; sweetheart; girlfriend,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.9
-幸運,こううん,"good luck, fortune",JLPT JLPT_2 JLPT_3
-講演,こうえん,"lecture, talk",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.15
-効果,こうか,"effect, result",JLPT JLPT_2 JLPT_3
-硬貨,こうか,coin,JLPT JLPT_2 JLPT_3
-高価,こうか,high price,JLPT JLPT_2 JLPT_3
-豪華,ごうか,"luxurious, gorgeous, extravagance",JLPT JLPT_2 JLPT_3
-合格,ごうかく,"success, passing (e.g., exam)",JLPT JLPT_2 JLPT_3
-交換,こうかん,"exchange, swap",JLPT JLPT_2 JLPT_3
-航空,こうくう,"aviation, flying",JLPT JLPT_2 JLPT_3
-光景,こうけい,"scene, spectacle",JLPT JLPT_2 JLPT_3
-合計,ごうけい,"sum total, total amount",JLPT JLPT_2 JLPT_3
-攻撃,こうげき,"attack, strike, offensive",JLPT JLPT_2 JLPT_3
-貢献,こうけん,"contribution, services",JLPT JLPT_2 JLPT_3
-広告,こうこく,advertisement,JLPT Genki_Ln.13 Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.15 Genki
-交際,こうさい,"friendship, association, acquaintance",JLPT JLPT_2 JLPT_3
-校舎,こうしゃ,school building,JLPT JLPT_2 JLPT_3
-後者,こうしゃ,the latter,JLPT JLPT_2 JLPT_3
-工場,こうば,"factory, plant",JLPT JLPT_2 JLPT_3
-公正,こうせい,"justice, fairness, impartiality",JLPT JLPT_2 JLPT_3
-構成,こうせい,"organization, composition",JLPT JLPT_2 JLPT_3
-高速,こうそく,"high speed, high gear",JLPT JLPT_2 JLPT_3
-行動,こうどう,"action, conduct, behavior",JLPT JLPT_2 JLPT_3
-強盗,ごうとう,"robbery, burglary",JLPT JLPT_2 JLPT_3
-後輩,こうはい,junior members of a group,JLPT JLPT_3 JLPT_2 Genki_Ln.22 Genki
-幸福,こうふく,"happiness, blessedness",JLPT JLPT_2 JLPT_3
-公平,こうへい,"fairness, impartial, justice",JLPT JLPT_2 JLPT_3
-候補,こうほ,candidacy,JLPT JLPT_2 JLPT_3
-考慮,こうりょ,"consideration, taking into account",JLPT JLPT_2 JLPT_3
-越える,こえる,"to exceed, to cross over, to cross",JLPT JLPT_2 JLPT_3
-超える,こえる,"to exceed, to cross over, to cross",JLPT JLPT_2 JLPT_3
-コーチ,コーチ,coach,JLPT JLPT_2 JLPT_3
-コード,コード,code; cord; chord,JLPT JLPT_2 JLPT_3
-氷,こおり,"ice, hail",JLPT JLPT_2 JLPT_3
-凍る,こおる,"to freeze, to be frozen over, to congeal",JLPT JLPT_2 JLPT_3
-ゴール,ゴール,goal,JLPT JLPT_2 JLPT_3
-誤解,ごかい,misunderstanding,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.15
-語学,ごがく,language study,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.8
-呼吸,こきゅう,"breath, respiration",JLPT JLPT_2 JLPT_3
-故郷,こきょう,hometown,JLPT JLPT_2 JLPT_3
-極,ごく,"quite, very",JLPT JLPT_2 JLPT_3
-国語,こくご,national language,JLPT JLPT_2 JLPT_3
-国籍,こくせき,nationality,JLPT JLPT_2 JLPT_3
-黒板,こくばん,blackboard,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.13
-克服,こくふく,"conquest, overcome",JLPT JLPT_2 JLPT_3
-国民,こくみん,"national, people, citizen",JLPT JLPT_2 JLPT_3
-穀物,こくもつ,"grain, cereal, corn",JLPT JLPT_2 JLPT_3
-腰,こし,"hip, waist",JLPT JLPT_2 JLPT_3
-胡椒,こしょう,pepper,JLPT JLPT_2 JLPT_3
-個人,こじん,"individual, private person",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14
-越す,こす,"to go over (e.g., with audience)",JLPT JLPT_2 JLPT_3
-超す,こす,"to cross, to pass, to tide over",JLPT JLPT_2 JLPT_3
-国家,こっか,"state, country, nation",JLPT JLPT_2 JLPT_3
-国会,こっかい,"National Diet, parliament, congress",JLPT JLPT_2 JLPT_3
-国境,こっきょう,national or state border,JLPT JLPT_2 JLPT_3
-骨折,こっせつ,bone fracture,JLPT JLPT_2 JLPT_3
-小包,こづつみ,"parcel, package",JLPT JLPT_2 JLPT_3
-琴,こと,Japanese harp,JLPT JLPT_2 JLPT_3
-異なる,ことなる,"to differ, to vary",JLPT JLPT_2 JLPT_3
-諺,ことわざ,"proverb, saying",JLPT JLPT_2 JLPT_3
-断る,ことわる,"to refuse, to decline, to dismiss",JLPT JLPT_2 JLPT_3
-粉,こな,"flour, powder",JLPT JLPT_2 JLPT_3
-好み,このみ,"liking, taste, choice",JLPT JLPT_2 JLPT_3
-好む,このむ,"to like, to prefer",JLPT JLPT_2 JLPT_3
-こぼす,こぼす,to spill,JLPT JLPT_2 JLPT_3
-こぼれる,こぼれる,"to overflow, to spill",JLPT JLPT_2 JLPT_3
-塵,ごみ,"garbage, litter",JLPT JLPT_2 JLPT_3
-小麦,こむぎ,wheat,JLPT JLPT_2 JLPT_3
-ごめんなさい,ごめんなさい,"I beg your pardon, excuse me, I'm sorry",JLPT JLPT_3 JLPT_2 Genki_Ln.4 Genki
-小屋,こや,"hut, cabin, shed",JLPT JLPT_2 JLPT_3
-これら,これら,these,JLPT JLPT_2 JLPT_3
-殺す,ころす,to kill,JLPT JLPT_2 JLPT_3
-転ぶ,ころぶ,"to fall down, to fall over",JLPT Genki_Ln.18 JLPT_3 JLPT_2 Genki
-今回,こんかい,"now, this time, lately",JLPT JLPT_2 JLPT_3
-今後,こんご,"from now on, hereafter",JLPT JLPT_2 JLPT_3
-混雑,こんざつ,"confusion, congestion",JLPT JLPT_2 JLPT_3
-こんなに,こんなに,"so, like this, in this way",JLPT JLPT_2 JLPT_3
-困難,こんなん,"difficulty, distress",JLPT JLPT_2 JLPT_3
-今日,こんにち,"today, this day",JLPT JLPT_2 JLPT_3
-こんにちは,こんにちは,"hello, good day (daytime greeting)",JLPT JLPT_2 JLPT_3
-婚約,こんやく,"engagement, betrothal",JLPT JLPT_2 JLPT_3
-混乱,こんらん,"chaos, confusion, mayhem",JLPT JLPT_2 JLPT_3
-差,さ,"difference, variation",JLPT JLPT_2 JLPT_3
-サービス,サービス,"service, support system; goods or services without charge",JLPT JLPT_2 JLPT_3
-際,さい,"on the occasion of, circumstances",JLPT JLPT_2 JLPT_3
-最高,さいこう,"highest, supreme, the most",JLPT JLPT_2 JLPT_3
-財産,ざいさん,"property, fortune, assets",JLPT JLPT_2 JLPT_3
-最終,さいしゅう,"last, closing",JLPT JLPT_2 JLPT_3
-最中,さいちゅう,in the middle of,JLPT JLPT_2 JLPT_3
-最低,さいてい,"least, lowest, worst",Genki_Ln.17 JLPT JLPT_3 JLPT_2 Genki
-才能,さいのう,"talent, ability",JLPT JLPT_2 JLPT_3
-裁判,さいばん,"trial, judgment",JLPT JLPT_2 JLPT_3
-材料,ざいりょう,"ingredients, material",JLPT JLPT_2 JLPT_3
-幸い,さいわい,fortunately; luckily,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.8
-サイン,サイン,autograph; sign; sine,JLPT JLPT_2 JLPT_3
-境,さかい,"border, boundary, mental state",JLPT JLPT_2 JLPT_3
-逆らう,さからう,"to go against, to oppose, to disobey",JLPT JLPT_2 JLPT_3
-盛り,さかり,"helping, serving",JLPT JLPT_2 JLPT_3
-作業,さぎょう,"work, operation, manufacturing",JLPT JLPT_2 JLPT_3
-裂く,さく,"to tear, to split",JLPT JLPT_2 JLPT_3
-昨,さく,"last (year), yesterday",JLPT JLPT_2 JLPT_3
-作品,さくひん,"work, opus, production",JLPT JLPT_2 JLPT_3
-作物,さくもつ,"produce (e.g., agricultural), crops",JLPT JLPT_2 JLPT_3
-桜,さくら,"cherry blossom, cherry tree",JLPT JLPT_2 JLPT_3
-酒,さけ,"alcohol, sake",JLPT JLPT_2 JLPT_3
-叫ぶ,さけぶ,"to shout, to cry",JLPT JLPT_2 JLPT_3
-避ける,さける,"to avoid (physical contact); to ward off, to avert",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.15
-支える,ささえる,"support, hold, sustain",JLPT JLPT_2 JLPT_3
-刺さる,ささる,"to stick, to be stuck",JLPT JLPT_2 JLPT_3
-刺す,さす,"to sting, to bite (e.g., bug), to prick, to stab",JLPT JLPT_3 JLPT_2 Genki Genki_Ln.21
-指す,さす,"to point,",JLPT JLPT_2 JLPT_3
-挿す,さす,"to insert, to put in, to graft",JLPT JLPT_2 JLPT_3
-注す,さす,"to pour (drink), to serve (drinks)",JLPT JLPT_2 JLPT_3
-射す,さす,"to shine, to strike",JLPT JLPT_2 JLPT_3
-座席,ざせき,seat,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.10
-誘う,さそう,"to invite (someone to do something with you); to tempt, to lure",Genki_Ln.15 Intermediate_Japanese JLPT JLPT_3 JLPT_2 Intermediate_Japanese_Ln.7 Genki
-札,さつ,"bill, note",JLPT JLPT_2 JLPT_3
-作家,さっか,"author, writer, novelist",JLPT JLPT_2 JLPT_3
-作曲,さっきょく,composition (of music),JLPT JLPT_2 JLPT_3
-ざっと,ざっと,"roughly, in round numbers",JLPT JLPT_2 JLPT_3
-さっぱり,さっぱり,"feeling refreshed, neat",JLPT JLPT_2 JLPT_3
-さて,さて,"well; now (typically used when switching to a new, usually more important topic)",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.12
-砂漠,さばく,desert,JLPT JLPT_2 JLPT_3
-差別,さべつ,"discrimination, differentiation",JLPT JLPT_2 JLPT_3
-ママ,ママ,Mama,JLPT JLPT_2 JLPT_3
-豆,まめ,"beans, peas",JLPT JLPT_2 JLPT_3
-守る,まもる,to protect; to abide (by the rules),JLPT JLPT_2 JLPT_3
-迷う,まよう,"to be puzzled, to be perplexed, to lose one's way",JLPT JLPT_2 JLPT_3
-丸,まる,"circle, full (month)",JLPT JLPT_2 JLPT_3
-円,まる,circle,JLPT JLPT_2 JLPT_3
-まるで,まるで,just like,JLPT JLPT_2 JLPT_3
-万一,まんいち,"by some chance, if by any chance",JLPT JLPT_2 JLPT_3
-満足,まんぞく,satisfaction,JLPT JLPT_2 JLPT_3
-身,み,"body, main part",JLPT JLPT_2 JLPT_3
-実,み,"fruit, seed, good result",JLPT JLPT_2 JLPT_3
-見送り,みおくり,seeing one off,JLPT JLPT_2 JLPT_3
-味方,みかた,"ally, supporter",JLPT JLPT_2 JLPT_3
-見事,みごと,"splendid, magnificent",JLPT JLPT_2 JLPT_3
-ミス,ミス,"miss (mistake, error, failure), Miss",JLPT_1 JLPT JLPT_2 JLPT_3
-満ちる,みちる,"to be full, to mature",JLPT JLPT_2 JLPT_3
-密,みつ,"thick, close",JLPT JLPT_2 JLPT_3
-認める,みとめる,"to recognize, to notice; to approve",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.13 Intermediate_Japanese_Ln.3
-見舞い,みまい,"expression of sympathy, expression of concern",JLPT JLPT_2 JLPT_3
-土産,みやげ,souvenir,JLPT JLPT_2 JLPT_3
-都,みやこ,city; capital,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.10
-妙,みょう,"strange, unusual",JLPT JLPT_2 JLPT_3
-明後日,みょうごにち,day after tomorrow,JLPT JLPT_2 JLPT_3
-未来,みらい,future (life tense),JLPT JLPT_2 JLPT_3
-魅力,みりょく,"charm, fascination, appeal",JLPT JLPT_2 JLPT_3
-診る,みる,to examine (a patient),JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.12
-ミルク,ミルク,milk,JLPT JLPT_2 JLPT_3
-無,む,"nothing, naught, zero",JLPT JLPT_2 JLPT_3
-向かい,むかい,"facing, opposite, across",JLPT JLPT_2 JLPT_3
-迎え,むかえ,"meeting, person sent to pick up an arrival",JLPT JLPT_2 JLPT_3
-向く,むく,to face,JLPT JLPT_2 JLPT_3
-剥く,むく,"to peel, to skin",JLPT JLPT_2 JLPT_3
-向ける,むける,"to turn towards, to point",JLPT JLPT_2 JLPT_3
-無視,むし,"disregard, ignore",JLPT JLPT_2 JLPT_3
-蒸し暑い,むしあつい,"humid, sultry",JLPT JLPT_2 JLPT_3
-虫歯,むしば,"cavity, tooth decay",JLPT JLPT_2 JLPT_3
-寧ろ,むしろ,"rather, better, instead",JLPT JLPT_2 JLPT_3
-蒸す,むす,"to steam, to poultice, to be sultry",JLPT JLPT_2 JLPT_3
-結ぶ,むすぶ,"to tie, to bind, to link",JLPT JLPT_2 JLPT_3
-無駄,むだ,"futility, uselessness",JLPT JLPT_2 JLPT_3
-夢中,むちゅう,"crush, crazy, be hooked on",JLPT JLPT_2 JLPT_3
-胸,むね,"breast, chest",JLPT JLPT_2 JLPT_3
-無料,むりょう,"free, no charge",JLPT JLPT_2 JLPT_3
-芽,め,sprout,JLPT JLPT_2 JLPT_3
-明確,めいかく,"clear, definite",JLPT JLPT_2 JLPT_3
-名刺,めいし,(name) card; business card,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.1
-名詞,めいし,noun,JLPT JLPT_2 JLPT_3
-命じる,めいじる,"to order, to command, to appoint",JLPT JLPT_2 JLPT_3
-名人,めいじん,"master, expert",JLPT JLPT_2 JLPT_3
-命令,めいれい,"order, command, decree",JLPT JLPT_2 JLPT_3
-迷惑,めいわく,"trouble, bother, annoyance",JLPT JLPT_2 JLPT_3
-目上,めうえ,person of higher status; one's senior,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.2
-飯,めし,"meals, food",JLPT JLPT_2 JLPT_3
-滅多に,めったに,"rarely (with neg. verb), seldom",JLPT JLPT_2 JLPT_3
-メモ,メモ,"memorandum, note",JLPT JLPT_2 JLPT_3
-面,めん,"face, mug, surface, side or facet, corner, page",JLPT JLPT_2 JLPT_3
-綿,めん,cotton,JLPT JLPT_2 JLPT_3
-免許,めんきょ,"license, permit, certificate",JLPT JLPT_3 JLPT_2 Genki_Ln.22 Genki
-面接,めんせつ,interview,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Genki Genki_Ln.23 Intermediate_Japanese_Ln.3
-面倒,めんどう,"trouble, attention",JLPT JLPT_2 JLPT_3
-メンバー,メンバー,member,JLPT JLPT_2 JLPT_3
-申し込む,もうしこむ,"to apply for, to make an application",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.3
-申し訳,もうしわけ,"apology, excuse",JLPT JLPT_2 JLPT_3
-毛布,もうふ,blanket,JLPT JLPT_2 JLPT_3
-燃える,もえる,to burn,JLPT JLPT_2 JLPT_3
-目的,もくてき,"purpose, goal, aim",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.3
-目標,もくひょう,"mark, objective, target",JLPT JLPT_2 JLPT_3
-文字,もじ,"letter (of alphabet), character",JLPT JLPT_2 JLPT_3
-文字,もんじ,"letter (of alphabet), character",JLPT JLPT_2 JLPT_3
-もしかすると,もしかすると,"perhaps, maybe, by some chance",JLPT JLPT_2 JLPT_3
-もしも,もしも,if,JLPT JLPT_2 JLPT_3
-持ち上げる,もちあげる,"to raise, to lift up, to flatter",JLPT JLPT_2 JLPT_3
-用いる,もちいる,"to use, to make use of",JLPT JLPT_2 JLPT_3
-もったいない,もったいない,"wasteful; more than one deserves, unworthy of",JLPT JLPT_2 JLPT_3
-尤も,もっとも,"quite right, plausible, natural",JLPT JLPT_2 JLPT_3
-元,もと,"origin, original; former",JLPT JLPT_2 JLPT_3
-基,もと,basis,JLPT JLPT_2 JLPT_3
-素,もと,prime,JLPT JLPT_2 JLPT_3
-戻す,もどす,"to restore, to put back, to return",JLPT JLPT_2 JLPT_3
-基づく,もとづく,"to be grounded on, to be based on",JLPT JLPT_2 JLPT_3
-求める,もとめる,"to request, to ask for; to seek, to search for",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.4
-者,もの,person (same as 人 (ひと)),JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.3
-物音,ものおと,sounds,JLPT JLPT_2 JLPT_3
-物語,ものがたり,"tale, story, legend",JLPT JLPT_2 JLPT_3
-物事,ものごと,"things, everything",JLPT JLPT_2 JLPT_3
-燃やす,もやす,to burn,JLPT JLPT_2 JLPT_3
-模様,もよう,"pattern, figure, design",JLPT JLPT_2 JLPT_3
-文句,もんく,a complaint,JLPT Intermediate_Japanese Genki JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14 Genki_Ln.21 Intermediate_Japanese_Ln.11
-やがて,やがて,"before long, soon, at length",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.8
-役,やく,"role, position",JLPT JLPT_2 JLPT_3
-約,やく,"approximately, about, some",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.11
-訳,やく,translation,JLPT JLPT_2 JLPT_3
-訳す,やくす,to translate,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.2
-役割,やくわり,"assigning (allotment of) parts, role, duties",JLPT JLPT_2 JLPT_3
-家賃,やちん,rent,JLPT Genki_Ln.18 JLPT_3 JLPT_2 Genki
-厄介,やっかい,"trouble, burden, care",JLPT JLPT_2 JLPT_3
-宿,やど,"inn, lodging",JLPT JLPT_2 JLPT_3
-雇う,やとう,"to employ, to hire",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.8
-屋根,やね,roof,JLPT JLPT_2 JLPT_3
-破る,やぶる,to tear; to violate; to defeat,JLPT JLPT_2 JLPT_3
-破れる,やぶれる,"to get torn, to wear out",JLPT JLPT_2 JLPT_3
-辞める,やめる,to retire,JLPT JLPT_2 JLPT_3
-やや,やや,"a little, partially, somewhat",JLPT JLPT_2 JLPT_3
-唯一,ゆいいつ,"only, sole, unique",JLPT JLPT_2 JLPT_3
-勇気,ゆうき,"courage, bravery, boldness",JLPT JLPT_2 JLPT_3
-友好,ゆうこう,friendship,JLPT JLPT_2 JLPT_3
-有効,ゆうこう,"valid, effectual",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.10
-優秀,ゆうしゅう,"superiority, excellence",JLPT JLPT_2 JLPT_3
-優勝,ゆうしょう,"overall victory, championship",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.7
-友情,ゆうじょう,"friendship, fellowship",JLPT JLPT_2 JLPT_3
-友人,ゆうじん,friend (formal),JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.15 Intermediate_Japanese_Ln.2
-有能,ゆうのう,"able, capable, efficient",JLPT JLPT_2 JLPT_3
-郵便,ゆうびん,"mail, postal service",JLPT JLPT_2 JLPT_3
-ユーモア,ユーモア,humor,JLPT JLPT_2 JLPT_3
-有利,ゆうり,"advantageous, better",JLPT JLPT_2 JLPT_3
-床,ゆか,floor,JLPT JLPT_2 JLPT_3
-愉快,ゆかい,"pleasant, happy",JLPT JLPT_2 JLPT_3
-譲る,ゆずる,"to turn over, to assign, to hand over",JLPT JLPT_2 JLPT_3
-豊か,ゆたか,"abundant, wealthy, plentiful, rich",JLPT JLPT_2 JLPT_3
-茹でる,ゆでる,to boil,JLPT JLPT_2 JLPT_3
-許す,ゆるす,"to permit, to allow, to approve",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.8
-夜,よ,"evening, night",JLPT JLPT_2 JLPT_3
-夜明け,よあけ,"dawn, daybreak",JLPT JLPT_2 JLPT_3
-酔う,よう,to get drunk,JLPT JLPT_2 JLPT_3
-容易,ようい,"easy, simple, plain",JLPT JLPT_2 JLPT_3
-容器,ようき,"container, vessel",JLPT JLPT_2 JLPT_3
-陽気,ようき,"season, weather, cheerfulness",JLPT JLPT_2 JLPT_3
-要求,ようきゅう,"request, demand",JLPT JLPT_2 JLPT_3
-用心,ようじん,"care, precaution, caution",JLPT JLPT_2 JLPT_3
-様子,ようす,"aspect, state, appearance",JLPT JLPT_2 JLPT_3
-要するに,ようするに,"in a word, after all, in short …",JLPT JLPT_2 JLPT_3
-要素,ようそ,element,JLPT JLPT_2 JLPT_3
-要点,ようてん,"gist, main point",JLPT JLPT_2 JLPT_3
-曜日,ようび,day of the week,JLPT JLPT_2 JLPT_3
-ヨーロッパ,ヨーロッパ,Europe,JLPT JLPT_2 JLPT_3
-予期,よき,"expectation, forecast",JLPT JLPT_2 JLPT_3
-横切る,よこぎる,"to cross (e.g., arms), to traverse",JLPT JLPT_2 JLPT_3
-汚す,よごす,"to pollute, to make dirty",JLPT JLPT_2 JLPT_3
-予算,よさん,"estimate, budget",JLPT JLPT_2 JLPT_3
-止す,よす,"to cease, to give up",JLPT JLPT_2 JLPT_3
-寄せる,よせる,"to collect, to gather, to put aside",JLPT JLPT_2 JLPT_3
-予測,よそく,"prediction, estimation",JLPT JLPT_2 JLPT_3
-ヨット,ヨット,yacht,JLPT JLPT_2 JLPT_3
-夜中,よなか,"midnight, dead of night",JLPT JLPT_2 JLPT_3
-世の中,よのなか,"society, the world",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14
-余分,よぶん,"extra, excess, surplus",JLPT JLPT_2 JLPT_3
-予報,よほう,"forecast, prediction",JLPT JLPT_2 JLPT_3
-予防,よぼう,"prevention, protection against",JLPT JLPT_2 JLPT_3
-読み,よみ,reading,JLPT JLPT_2 JLPT_3
-嫁,よめ,"bride, daughter-in-law",JLPT JLPT_2 JLPT_3
-余裕,よゆう,excess; surplus,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.15
-より,より,"twist, ply",JLPT JLPT_2 JLPT_3
-因る,よる,to come from,JLPT JLPT_2 JLPT_3
-喜び,よろこび,"joy, pleasure, rejoicing",JLPT JLPT_2 JLPT_3
-よろしく (かん),よろしく (かん),"best regards, please remember me",JLPT JLPT_2 JLPT_3
-四,よん,four,JLPT JLPT_2 JLPT_3
-来,らい～,next ~,JLPT JLPT_2 JLPT_3
-ライター,ライター,lighter; writer,JLPT JLPT_2 JLPT_3
-楽,らく,"comfort, ease",JLPT JLPT_2 JLPT_3
-ラケット,ラケット,racket,JLPT JLPT_2 JLPT_3
-利益,りえき,"profits, gains",JLPT JLPT_2 JLPT_3
-理解,りかい,"understanding, comprehension",JLPT JLPT_2 JLPT_3
-陸,りく,"land, shore",JLPT JLPT_2 JLPT_3
-利口,りこう,"clever, shrewd, bright",JLPT JLPT_2 JLPT_3
-離婚,りこん,divorce,JLPT JLPT_2 JLPT_3
-理想,りそう,ideal,JLPT JLPT_3 JLPT_2 Genki_Ln.23 Genki
-率,りつ,"rate, ratio, percentage",JLPT JLPT_2 JLPT_3
-留学,りゅうがく,studying abroad,JLPT JLPT_2 JLPT_3
-流行,りゅうこう,"fashionable, fad, prevailing",JLPT JLPT_2 JLPT_3
-量,りょう,"quantity, amount",JLPT JLPT_2 JLPT_3
-寮,りょう,"hostel, dormitory",Genki_Ln.17 JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.2 Genki
-両替,りょうがえ,"change, money exchange",JLPT JLPT_2 JLPT_3
-料金,りょうきん,"fee, charge, fare",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.10
-例,れい,"instance, example, case",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.2
-礼,れい,expression of gratitude; bow,JLPT JLPT_2 JLPT_3
-例外,れいがい,exception,JLPT JLPT_2 JLPT_3
-礼儀,れいぎ,"manners, courtesy, etiquette",JLPT JLPT_2 JLPT_3
-冷静,れいせい,"calm, coolness",JLPT JLPT_2 JLPT_3
-列,れつ,"queue, line, row",JLPT JLPT_2 JLPT_3
-列車,れっしゃ,train (ordinary),JLPT JLPT_2 JLPT_3
-レベル,レベル,level,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.5
-連想,れんそう,"association (of ideas), suggestion",JLPT JLPT_2 JLPT_3
-連続,れんぞく,"consecutive, continuity, continuing",JLPT JLPT_2 JLPT_3
-老人,ろうじん,"the aged, old person",JLPT JLPT_2 JLPT_3
-労働,ろうどう,"labor, work",JLPT JLPT_2 JLPT_3
-ロケット,ロケット,"locket, rocket",JLPT JLPT_2 JLPT_3
-論じる,ろんじる,"to argue, to discuss",JLPT JLPT_2 JLPT_3
-論争,ろんそう,"controversy, dispute",JLPT JLPT_2 JLPT_3
-論文,ろんぶん,"thesis, paper",JLPT JLPT_2 JLPT_3
-輪,わ,"ring, hoop, circle",JLPT JLPT_2 JLPT_3
-ワイン,ワイン,wine,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.9
-わがまま,わがまま,"selfishness, egoism, willfulness",JLPT JLPT_2 JLPT_3
-別れ,わかれ,"parting, separation, farewell",JLPT JLPT_2 JLPT_3
-分かれる,わかれる,"to branch off, to diverge from",JLPT JLPT_2 JLPT_3
-脇,わき,side,JLPT JLPT_2 JLPT_3
-湧く,わく,"to boil, to grow hot",JLPT JLPT_2 JLPT_3
-分ける,わける,"to divide, to separate",JLPT JLPT_2 JLPT_3
-わざと,わざと,on purpose,JLPT JLPT_2 JLPT_3
-僅か,わずか,"only, merely, a little",JLPT JLPT_2 JLPT_3
-綿,わた,cotton,JLPT JLPT_2 JLPT_3
-話題,わだい,"topic, subject",JLPT JLPT_2 JLPT_3
-笑い,わらい,"laugh, laughter, smile",JLPT JLPT_2 JLPT_3
-割る,わる,"to divide, to break",JLPT JLPT_2 JLPT_3
-悪口,わるくち,"abuse, insult",JLPT JLPT_2 JLPT_3
-我々,われわれ,we,JLPT JLPT_2 JLPT_3
-湾,わん,"bay, gulf, inlet",JLPT JLPT_2 JLPT_3
-椀,わん,bowl,JLPT JLPT_2 JLPT_3
-碗,わん,bowl,JLPT JLPT_2 JLPT_3
-悪,あく,"evil, vice",JLPT_1 JLPT JLPT_3
-当り,あたり,"hit, success, reaching the mark",JLPT_1 JLPT JLPT_3
-アップ,アップ,up,JLPT_1 JLPT JLPT_3
-宛てる,あてる,"to address, to put",JLPT_1 JLPT JLPT_3
-アンケート,アンケート,"questionnaire (FRE: enquete), survey",JLPT_1 JLPT JLPT_3
-異,い,difference (of opinion),JLPT_1 JLPT JLPT_3
-意,い,will,JLPT_1 JLPT JLPT_3
-医院,いいん,"doctor's office (surgery), clinic",JLPT_1 JLPT JLPT_3
-怒り,いかり,anger,JLPT_1 JLPT JLPT_3
-粋,いき,"chic, style, purity",JLPT_1 JLPT JLPT_3
-意地,いじ,"disposition, spirit, obstinacy, appetite",JLPT_1 JLPT JLPT_3
-依然,いぜん,"still, as yet",JLPT_1 JLPT JLPT_3
-傷める,いためる,"to damage, to impair, to spoil",JLPT_1 JLPT JLPT_3
-炒める,いためる,to stir-fry,JLPT_1 JLPT JLPT_3
-一帯,いったい,"a region, the whole place",JLPT_1 JLPT JLPT_3
-異動,いどう,"a change, transfer",JLPT_1 JLPT JLPT_3
-衣料,いりょう,clothing,JLPT_1 JLPT JLPT_3
-渦,うず,swirl,JLPT_1 JLPT JLPT_3
-埋まる,うまる,"to be buried, to be filled",JLPT_1 JLPT JLPT_3
-産む,うむ,"to give birth (v.t.), to deliver, to produce",JLPT Intermediate_Japanese JLPT_1 JLPT_3 Intermediate_Japanese_Ln.14
-縁,えん,"chance, tie, relationship",JLPT_1 JLPT JLPT_3
-尾,お,"tail, ridge",JLPT_1 JLPT JLPT_3
-負う,おう,"to bear, to owe",JLPT_1 JLPT JLPT_3
-遅れ,おくれ,"delay, lag",JLPT Intermediate_Japanese JLPT_1 JLPT_3 Intermediate_Japanese_Ln.14
-教え,おしえ,"teachings, doctrine",JLPT_1 JLPT JLPT_3
-驚き,おどろき,"surprise, astonishment, wonder",JLPT_1 JLPT JLPT_3
-織る,おる,to weave,JLPT_1 JLPT JLPT_3
-欠く,かく,"to lack, to crack",JLPT_1 JLPT JLPT_3
-角,かく,angle,JLPT_1 JLPT JLPT_3
-核,かく,"nucleus, kernel",JLPT_1 JLPT JLPT_3
-格,かく,"status, character, case",JLPT_1 JLPT JLPT_3
-学歴,がくれき,academic background,JLPT_1 JLPT JLPT_3
-駆ける,かける,to run,JLPT_1 JLPT JLPT_3
-賭ける,かける,"to bet, to risk, to gamble",JLPT_1 JLPT JLPT_3
-課題,かだい,"subject, theme, task",JLPT_1 JLPT JLPT_3
-片付け,かたづけ,"tidying up, finishing",JLPT_1 JLPT JLPT_3
-加味,かみ,"seasoning, flavoring",JLPT_1 JLPT JLPT_3
-借り,かり,"borrowing, debt, loan",JLPT_1 JLPT JLPT_3
-狩り,かり,hunting,JLPT_1 JLPT JLPT_3
-管,かん,"pipe, tube",JLPT_1 JLPT JLPT_3
-～観,かん,"feeling, view",JLPT_1 JLPT JLPT_3
-癌,がん,cancer,JLPT_1 JLPT JLPT_3
-刊行,かんこう,"publication, issue",JLPT_1 JLPT JLPT_3
-慣行,かんこう,"customary practice, habit, traditional event",JLPT_1 JLPT JLPT_3
-歓声,かんせい,"cheer, shout of joy",JLPT_1 JLPT JLPT_3
-官僚,かんりょう,"bureaucrat, bureaucracy",JLPT_1 JLPT JLPT_3
-器官,きかん,"organ (of body, instrument)",JLPT_1 JLPT JLPT_3
-季刊,きかん,"quarterly (e.g., magazine)",JLPT_1 JLPT JLPT_3
-起源,きげん,"origin, beginning, rise",JLPT_1 JLPT JLPT_3
-機構,きこう,"mechanism, organization",JLPT_1 JLPT JLPT_3
-築く,きずく,"to build, to establish",JLPT_1 JLPT JLPT_3
-規制,きせい,regulation,JLPT_1 JLPT JLPT_3
-丘陵,きゅうりょう,hill,JLPT_1 JLPT JLPT_3
-協議,きょうぎ,"conference, discussion, negotiation",JLPT_1 JLPT JLPT_3
-享受,きょうじゅ,"enjoyment, being given",JLPT_1 JLPT JLPT_3
-協調,きょうちょう,"co-operation, conciliation, harmony",JLPT_1 JLPT JLPT_3
-切り,きり,"limits, place to leave off",JLPT_1 JLPT JLPT_3
-菌,きん,"germ, bacterium",JLPT_1 JLPT JLPT_3
-近視,きんし,nearsightedness,JLPT_1 JLPT JLPT_3
-苦,く,"trouble, worry, difficulty",JLPT_1 JLPT JLPT_3
-群,ぐん,group,JLPT_1 JLPT JLPT_3
-刑,けい,"penalty, sentence, punishment",JLPT_1 JLPT JLPT_3
-経緯,けいい,"sequence of events, course",JLPT_1 JLPT JLPT_3
-計器,けいき,"meter, gauge",JLPT_1 JLPT JLPT_3
-契機,けいき,"opportunity, chance",JLPT_1 JLPT JLPT_3
-携帯,けいたい,carrying something; mobile telephone,JLPT_1 JLPT JLPT_3
-形態,けいたい,"form, shape, figure",JLPT_1 JLPT JLPT_3
-血管,けっかん,blood vessel,JLPT_1 JLPT JLPT_3
-決行,けっこう,"doing (with resolve), carrying out (e.g., a plan)",JLPT_1 JLPT JLPT_3
-件,けん,"matter, case, item",JLPT_1 JLPT JLPT_3
-減少,げんしょう,"decrease, reduction, decline",JLPT_1 JLPT JLPT_3
-公演,こうえん,public performance,JLPT_1 JLPT JLPT_3
-後悔,こうかい,"regret, repentance",JLPT_1 JLPT JLPT_3
-航海,こうかい,"sail, voyage",JLPT_1 JLPT JLPT_3
-拘束,こうそく,"restriction, restraint",JLPT_1 JLPT JLPT_3
-荒廃,こうはい,ruin,JLPT_1 JLPT JLPT_3
-降伏,こうふく,"capitulation, surrender, submission",JLPT_1 JLPT JLPT_3
-興奮,こうふん,"excitement, stimulation",JLPT_1 JLPT JLPT_3
-語句,ごく,"words, phrases",JLPT_1 JLPT JLPT_3
-個々,ここ,"individual, one by one",JLPT_1 JLPT JLPT_3
-故人,こじん,the deceased,JLPT_1 JLPT JLPT_3
-小銭,こぜに,"coins, small change",JLPT_1 JLPT JLPT_3
-ことによると,ことによると,(depending on the circumstances),JLPT_1 JLPT JLPT_3
-コンテスト,コンテスト,contest,JLPT_1 JLPT JLPT_3
-採集,さいしゅう,"collecting, gathering",JLPT_1 JLPT JLPT_3
-作,さく,"a work, a harvest",JLPT_1 JLPT JLPT_3
-策,さく,"plan, policy",JLPT_1 JLPT JLPT_3
-設備,せつび,"equipment, device, facilities",JLPT JLPT_2 JLPT_3
-絶滅,ぜつめつ,"destruction, extinction",JLPT JLPT_2 JLPT_3
-節約,せつやく,"economizing, saving",JLPT JLPT_2 JLPT_3
-攻める,せめる,"to attack, to assault",JLPT JLPT_2 JLPT_3
-責める,せめる,"to condemn, to blame, to criticize",JLPT JLPT_2 JLPT_3
-善,ぜん,"good, virtue",JLPT JLPT_2 JLPT_3
-全,ぜん,"all, whole, entire",JLPT JLPT_2 JLPT_3
-全員,ぜんいん,all members,JLPT JLPT_2 JLPT_3
-専攻,せんこう,"major subject, special study",JLPT JLPT_2 JLPT_3
-全国,ぜんこく,"the entire nation, country-wide, nation-wide",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.7
-洗剤,せんざい,detergent,JLPT JLPT_2 JLPT_3
-先日,せんじつ,"the other day, a few days ago",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.2
-前者,ぜんしゃ,the former,JLPT JLPT_2 JLPT_3
-選手,せんしゅ,player selected for a team (usually athletic),JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.7
-全身,ぜんしん,"the whole body, full-length (portrait)",JLPT JLPT_2 JLPT_3
-前進,ぜんしん,"advance, drive, progress",JLPT JLPT_2 JLPT_3
-センター,センター,center,JLPT JLPT_2 JLPT_3
-全体,ぜんたい,"whole, entirety, whatever (is the matter)",JLPT JLPT_2 JLPT_3
-選択,せんたく,"selection, choice",JLPT JLPT_2 JLPT_3
-宣伝,せんでん,"advertisement, publicity",JLPT JLPT_2 JLPT_3
-象,ぞう,elephant,JLPT Genki_Ln.13 JLPT_3 JLPT_2 Genki
-騒音,そうおん,noise,JLPT JLPT_2 JLPT_3
-増加,ぞうか,"increase, addition",JLPT JLPT_2 JLPT_3
-操作,そうさ,"operation, management, processing",JLPT JLPT_2 JLPT_3
-想像,そうぞう,"imagination, guess",JLPT JLPT_2 JLPT_3
-相続,そうぞく,"succession, inheritance",JLPT JLPT_2 JLPT_3
-装置,そうち,"equipment, installation, apparatus",JLPT JLPT_2 JLPT_3
-相当,そうとう,"considerably, fairly; worth ~",JLPT JLPT_2 JLPT_3
-速度,そくど,"speed, velocity, rate",JLPT JLPT_2 JLPT_3
-底,そこ,"bottom, sole",JLPT JLPT_2 JLPT_3
-そこで,そこで,"so (conj.), accordingly",JLPT JLPT_2 JLPT_3
-組織,そしき,organization; structure; tissue,JLPT JLPT_2 JLPT_3
-そして,そして,and then,JLPT Genki_Ln.11 JLPT_3 JLPT_2 Genki
-注ぐ,そそぐ,to pour (into),JLPT JLPT_2 JLPT_3
-育つ,そだつ,"to be brought up, to grow (up)",JLPT JLPT_2 JLPT_3
-そっくり,そっくり,the splitting image of; entirely,JLPT JLPT_2 JLPT_3
-そっと,そっと,"softly, gently",JLPT JLPT_2 JLPT_3
-袖,そで,sleeve,JLPT JLPT_2 JLPT_3
-備える,そなえる,"to prepare, to furnish, to store",JLPT JLPT_2 JLPT_3
-具える,そなえる,to be furnished with,JLPT JLPT_2 JLPT_3
-そのうえ,そのうえ,"in addition, furthermore",JLPT JLPT_2 JLPT_3
-そのうち,そのうち,"before long, eventually, sooner or later",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.1
-そのまま,そのまま,"without change, as it is (e.g., now)",JLPT JLPT_2 JLPT_3
-蕎麦,そば,soba (buckwheat noodles),JLPT JLPT_2 JLPT_3
-ソファー,ソファー,"sofa, couch",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.12
-粗末,そまつ,"humble, miserable, crude",JLPT JLPT_2 JLPT_3
-それぞれ,それぞれ,"each, every, respectively",JLPT JLPT_2 JLPT_3
-それでも,それでも,"but (still), and yet, nevertheless",JLPT JLPT_2 JLPT_3
-それと,それと,and,JLPT JLPT_2 JLPT_3
-それとも,それとも,"or, or else",JLPT JLPT_2 JLPT_3
-揃う,そろう,"to become complete, to be equal",JLPT JLPT_2 JLPT_3
-揃える,そろえる,"to put things in order, to arrange",JLPT JLPT_2 JLPT_3
-損,そん,"loss, disadvantage",JLPT JLPT_2 JLPT_3
-損害,そんがい,"damage, loss",JLPT JLPT_2 JLPT_3
-尊敬,そんけい,"respect, reverence, honor",JLPT JLPT_2 JLPT_3
-存在,そんざい,"existence, being",JLPT JLPT_2 JLPT_3
-尊重,そんちょう,"respect, esteem, regard",JLPT JLPT_2 JLPT_3
-田,た,rice field,JLPT JLPT_2 JLPT_3
-他,た,other (esp. places and things),JLPT JLPT_2 JLPT_3
-対,たい,"pair, couple, set",JLPT JLPT_2 JLPT_3
-大,だい,"big, great",JLPT JLPT_2 JLPT_3
-題,だい,"title, subject, theme",JLPT JLPT_2 JLPT_3
-体育,たいいく,"physical education, gymnastics, athletics",JLPT JLPT_2 JLPT_3
-体温,たいおん,temperature (body),JLPT JLPT_2 JLPT_3
-大会,たいかい,"convention, (big) tournament, mass meeting",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.7
-大気,たいき,atmosphere,JLPT JLPT_2 JLPT_3
-代金,だいきん,"price, cost",JLPT JLPT_2 JLPT_3
-退屈,たいくつ,"tedium, boring",JLPT JLPT_2 JLPT_3
-滞在,たいざい,"stay, sojourn",JLPT JLPT_2 JLPT_3
-大使,たいし,ambassador,JLPT JLPT_2 JLPT_3
-大した,たいした,"significant, great, considerable",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.13
-体重,たいじゅう,(body) weight,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.4
-対象,たいしょう,"target; object (of worship, study, etc.); subject (i.e., of taxation)",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.8
-対照,たいしょう,"contrast, antithesis, comparison",JLPT JLPT_2 JLPT_3
-大臣,だいじん,cabinet minister,JLPT JLPT_2 JLPT_3
-対する,たいする,"to face, to confront, to oppose",JLPT JLPT_2 JLPT_3
-大戦,たいせん,"great war, great battle",JLPT JLPT_2 JLPT_3
-態度,たいど,"attitude, manner",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.3
-大統領,だいとうりょう,president,JLPT JLPT_2 JLPT_3
-大半,たいはん,"most of, majority, mostly",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.13
-代表,だいひょう,"representative, delegation",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.7
-大部分,だいぶぶん,"most part, majority",JLPT JLPT_2 JLPT_3
-タイプライター,タイプライター,typewriter,JLPT JLPT_2 JLPT_3
-逮捕,たいほ,"arrest, apprehension, capture",JLPT JLPT_2 JLPT_3
-題名,だいめい,title,JLPT JLPT_2 JLPT_3
-ダイヤ,ダイヤ,(railway) schedule; diamond,JLPT JLPT_2 JLPT_3
-太陽,たいよう,sun,JLPT JLPT_2 JLPT_3
-平ら,たいら,"flatness, level, smooth",JLPT JLPT_2 JLPT_3
-代理,だいり,"representation, proxy, deputy",JLPT JLPT_2 JLPT_3
-大陸,たいりく,continent,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.8
-倒す,たおす,"to throw down, to beat",JLPT JLPT_2 JLPT_3
-タオル,タオル,(hand) towel,JLPT Genki_Ln.18 JLPT_3 JLPT_2 Genki
-だが,だが,"but, however",JLPT JLPT_2 JLPT_3
-互い,たがい,"mutual, each other",JLPT JLPT_2 JLPT_3
-高める,たかめる,"to raise, to lift, to boost",JLPT JLPT_2 JLPT_3
-宝,たから,treasure,JLPT JLPT_2 JLPT_3
-宅,たく,"house, home",JLPT JLPT_2 JLPT_3
-炊く,たく,"to boil, to cook",JLPT JLPT_2 JLPT_3
-焚く,たく,"to burn, to kindle, to build a fire",JLPT JLPT_2 JLPT_3
-抱く,だく,"to embrace, to hug",JLPT JLPT_2 JLPT_3
-だけど,だけど,however,JLPT JLPT_2 JLPT_3
-たしか,たしか,"certain, sure, if I remember correctly",JLPT JLPT_2 JLPT_3
-確かめる,たしかめる,"to ascertain, to make sure",JLPT JLPT_2 JLPT_3
-多少,たしょう,a little (same as 少し (すこし)),JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.13
-助かる,たすかる,to be saved; (something) helps (v.i.),JLPT Intermediate_Japanese Genki_Ln.18 JLPT_3 JLPT_2 Intermediate_Japanese_Ln.4 Genki
-助ける,たすける,"to help (v.t.), to save, to rescue",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Genki Genki_Ln.22 Intermediate_Japanese_Ln.3
-ただ,ただ,free of charge; just (~); only (~),JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.9 Genki_Ln.23 Genki
-只,ただ,"free of charge, mere, only",JLPT JLPT_2 JLPT_3
-唯,ただ,"mere, sole, plain",JLPT JLPT_2 JLPT_3
-戦い,たたかい,"battle, fight",JLPT JLPT_2 JLPT_3
-戦う,たたかう,"to fight, to compete, to battle",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.7
-叩く,たたく,"to strike, to beat",JLPT JLPT_2 JLPT_3
-直ちに,ただちに,"at once, immediately",JLPT JLPT_2 JLPT_3
-畳む,たたむ,to fold (clothes),JLPT JLPT_2 JLPT_3
-立ち上がる,たちあがる,to stand up,JLPT JLPT_2 JLPT_3
-立場,たちば,"standpoint, position, situation",JLPT JLPT_2 JLPT_3
-建つ,たつ,"to stand; to be built (v.i.), to erect, to be erected",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.10
-経つ,たつ,(time) passes,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.4
-達する,たっする,"to reach, to get to",JLPT JLPT_2 JLPT_3
-唯,たった,"only, just",JLPT JLPT_2 JLPT_3
-だって,だって,"but, because, even",JLPT JLPT_2 JLPT_3
-たっぷり,たっぷり,"full, in plenty, ample",JLPT JLPT_2 JLPT_3
-たとえ,たとえ,"even if, no matter, though",JLPT JLPT_2 JLPT_3
-谷,たに,valley,JLPT JLPT_2 JLPT_3
-他人,たにん,"unrelated person, stranger",JLPT JLPT_2 JLPT_3
-種,たね,seed; material; cause,JLPT JLPT_2 JLPT_3
-束,たば,"bunch, bundle",JLPT JLPT_2 JLPT_3
-足袋,たび,Japanese socks (with split toe),JLPT JLPT_2 JLPT_3
-度,たび,counter for occurrences,JLPT JLPT_2 JLPT_3
-旅,たび,"travel, trip, journey",JLPT JLPT_2 JLPT_3
-たびたび,たびたび,"often, repeatedly, frequently",JLPT JLPT_2 JLPT_3
-玉,たま,"ball, sphere, coin",JLPT JLPT_2 JLPT_3
-球,たま,"globe, sphere, ball",JLPT JLPT_2 JLPT_3
-弾,たま,"bullet, shot",JLPT JLPT_2 JLPT_3
-偶,たま,"even number, couple, friend",JLPT JLPT_2 JLPT_3
-騙す,だます,"to trick, to cheat, to deceive",JLPT JLPT_2 JLPT_3
-偶々,たまたま,"unexpectedly, accidentally, by chance",JLPT JLPT_2 JLPT_3
-たまらない,たまらない,"intolerable, unbearable, unendurable",JLPT JLPT_2 JLPT_3
-溜まる,たまる,"to collect, to gather, to accumulate",JLPT JLPT_2 JLPT_3
-黙る,だまる,to be silent,JLPT JLPT_2 JLPT_3
-試し,ためし,"trial, test",JLPT JLPT_2 JLPT_3
-試す,ためす,"to attempt, to test",JLPT JLPT_2 JLPT_3
-溜める,ためる,"to accumulate, to collect",JLPT JLPT_2 JLPT_3
-便り,たより,"news, correspondence, letter",JLPT JLPT_2 JLPT_3
-頼る,たよる,"to rely on, to have recourse to, to depend on",JLPT JLPT_2 JLPT_3
-段,だん,"step, stair, grade",JLPT JLPT_2 JLPT_3
-単位,たんい,"credit (for a course in school); unit, denomination",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.3
-単語,たんご,word; vocabulary,JLPT JLPT_3 JLPT_2 Genki_Ln.9 Genki
-男子,だんし,young man,JLPT JLPT_2 JLPT_3
-単純,たんじゅん,simplicity,JLPT JLPT_2 JLPT_3
-誕生,たんじょう,birth,JLPT JLPT_2 JLPT_3
-ダンス,ダンス,dance,JLPT JLPT_2 JLPT_3
-団体,だんたい,"organization, association",JLPT JLPT_2 JLPT_3
-担当,たんとう,(in) charge,JLPT JLPT_2 JLPT_3
-単なる,たんなる,"mere, simple, sheer",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.15
-単に,たんに,"simply, merely",JLPT JLPT_2 JLPT_3
-地,ち,earth,JLPT JLPT_2 JLPT_3
-地位,ちい,"(social) position, status",JLPT JLPT_2 JLPT_3
-地域,ちいき,"area, region",JLPT JLPT_2 JLPT_3
-チーズ,チーズ,cheese,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.9
-チーム,チーム,team,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.7
-知恵,ちえ,"wisdom, wit, intelligence",JLPT JLPT_2 JLPT_3
-地下,ちか,"basement, underground",JLPT JLPT_2 JLPT_3
-違い,ちがい,"difference, discrepancy",Genki_Ln.17 JLPT JLPT_3 JLPT_2 Genki
-違いない,ちがいない,"(phrase) sure, no mistaking it, for certain",JLPT JLPT_2 JLPT_3
-近頃,ちかごろ,"lately, recently, nowadays",JLPT JLPT_2 JLPT_3
-地球,ちきゅう,the earth,JLPT JLPT_2 JLPT_3
-地区,ちく,"district, section",JLPT JLPT_2 JLPT_3
-遅刻,ちこく,"lateness, late coming",JLPT JLPT_2 JLPT_3
-知事,ちじ,prefectural governor,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.4
-知識,ちしき,"knowledge, information",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.1
-父親,ちちおや,father,JLPT JLPT_2 JLPT_3
-知能,ちのう,"intelligence, brains",JLPT JLPT_2 JLPT_3
-地平線,ちへいせん,horizon,JLPT JLPT_2 JLPT_3
-地方,ちほう,"area, locality, region",JLPT JLPT_2 JLPT_3
-茶,ちゃ,tea,JLPT JLPT_2 JLPT_3
-チャンス,チャンス,"chance, opportunity",JLPT JLPT_2 JLPT_3
-ちゃんと,ちゃんと,"perfectly, properly, exactly",JLPT JLPT_2 JLPT_3
-中,ちゅう,"inside, middle, among",JLPT JLPT_2 JLPT_3
-注,ちゅう,"annotation, explanatory note",JLPT JLPT_2 JLPT_3
-中央,ちゅうおう,"central, center, middle",JLPT JLPT_2 JLPT_3
-中学,ちゅうがく,"middle school, junior high school",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.1
-中古,ちゅうこ,"used, second-hand",JLPT JLPT_2 JLPT_3
-中止,ちゅうし,"suspension, stoppage, discontinuance",JLPT JLPT_2 JLPT_3
-駐車,ちゅうしゃ,"parking (e.g., car)",JLPT JLPT_2 JLPT_3
-昼食,ちゅうしょく,lunch (same as 昼ご飯 (ひるごはん)),JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.6
-中心,ちゅうしん,"center, core",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.10
-注目,ちゅうもく,"notice, attention, observation",JLPT JLPT_2 JLPT_3
-注文,ちゅうもん,"order, request",JLPT JLPT_2 JLPT_3
-長期,ちょうき,long time period,JLPT JLPT_2 JLPT_3
-調査,ちょうさ,survey; investigation,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.5
-調子,ちょうし,"condition, state, tune, tone",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.5
-頂上,ちょうじょう,"top, summit, peak",JLPT JLPT_2 JLPT_3
-ちょうだい,ちょうだい,-- colloquial form of ください; typically used by children or women --,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.11
-貯金,ちょきん,(bank) savings,JLPT JLPT_2 JLPT_3
-直接,ちょくせつ,"direct, immediate, firsthand",JLPT JLPT_2 JLPT_3
-著者,ちょしゃ,"author, writer",JLPT JLPT_2 JLPT_3
-散らす,ちらす,"to scatter, to disperse, to distribute",JLPT JLPT_2 JLPT_3
-散る,ちる,"to fall, to scatter (e.g., blossoms)",JLPT JLPT_2 JLPT_3
-遂に,ついに,"finally, at last",JLPT JLPT_2 JLPT_3
-通過,つうか,"passage through, passing",JLPT JLPT_2 JLPT_3
-通貨,つうか,currency,JLPT JLPT_2 JLPT_3
-通学,つうがく,commuting to school,JLPT JLPT_2 JLPT_3
-通勤,つうきん,commuting to work,JLPT JLPT_2 JLPT_3
-通行,つうこう,"passage, passing",JLPT JLPT_2 JLPT_3
-通じる,つうじる,"to run to, to lead to, to communicate",JLPT JLPT_2 JLPT_3
-通信,つうしん,"correspondence, communications",JLPT JLPT_2 JLPT_3
-通訳,つうやく,interpretation; interpreter,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.8
-捕まる,つかまる,to be arrested; to be caught,JLPT JLPT_3 JLPT_2 Genki Genki_Ln.21
-掴む,つかむ,"to seize, to catch, to grasp",JLPT JLPT_2 JLPT_3
-疲れ,つかれ,"tiredness, fatigue",JLPT JLPT_2 JLPT_3
-付き合い,つきあい,socialization; friendship; association,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.5
-付合う,つきあう,"to associate with, to keep company with, to get on with",JLPT JLPT_2 JLPT_3
-次々,つぎつぎ,"in succession, one by one",JLPT JLPT_2 JLPT_3
-付く,つく,"to adjoin, to be attached, to adhere",JLPT JLPT_2 JLPT_3
-就く,つく,"to settle in (place), to take (seat position), to study (under teacher)",JLPT JLPT_2 JLPT_3
-突く,つく,"to thrust, to strike; to poke",JLPT JLPT_2 JLPT_3
-次ぐ,つぐ,"to rank next to, to come after",JLPT JLPT_2 JLPT_3
-注ぐ,つぐ,to pour (into),JLPT JLPT_2 JLPT_3
-付ける,つける,"to attach, to join, to add",JLPT JLPT_2 JLPT_3
-着ける,つける,"to put on, to wear; to draw up",JLPT JLPT_2 JLPT_3
-伝わる,つたわる,"to be handed down, to be transmitted",JLPT JLPT_2 JLPT_3
-土,つち,"earth, soil",JLPT JLPT_2 JLPT_3
-続き,つづき,"sequel, continuation",JLPT JLPT_2 JLPT_3
-包み,つつみ,"bundle, package",JLPT JLPT_2 JLPT_3
-勤め,つとめ,"work, employment",JLPT JLPT_2 JLPT_3
-務め,つとめ,duty,JLPT JLPT_2 JLPT_3
-繋がる,つながる,"to be connected to, to be related to",JLPT JLPT_2 JLPT_3
-繋ぐ,つなぐ,"to tie, to fasten, to connect",JLPT JLPT_2 JLPT_3
-繋げる,つなげる,to connect,JLPT JLPT_2 JLPT_3
-常に,つねに,always (same as いつも) (written expression),JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.11
-翼,つばさ,wings,JLPT JLPT_2 JLPT_3
-つまり,つまり,namely; in other words; in short,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.2
-罪,つみ,"crime, fault, indiscretion",JLPT JLPT_2 JLPT_3
-積む,つむ,"to pile up, to stack",JLPT JLPT_2 JLPT_3
-詰める,つめる,"to pack, to shorten, to work out (details)",JLPT JLPT_2 JLPT_3
-積もる,つもる,to pile up,JLPT JLPT_2 JLPT_3
-梅雨,つゆ,rainy season,JLPT JLPT_2 JLPT_3
-辛い,つらい,"painful, heart-breaking",JLPT JLPT_2 JLPT_3
-釣,つり,fishing,JLPT JLPT_2 JLPT_3
-連れ,つれ,"companion, company",JLPT JLPT_2 JLPT_3
-出,で,"outflow, coming (going) out, graduate (of)",JLPT JLPT_2 JLPT_3
-出会い,であい,"meeting, rendezvous, encounter",JLPT JLPT_2 JLPT_3
-出合い,であい,an encounter,JLPT JLPT_2 JLPT_3
-出会う,であう,"to meet by chance, to come across, to happen to encounter",JLPT JLPT_2 JLPT_3
-提案,ていあん,"proposal, proposition, suggestion",JLPT JLPT_2 JLPT_3
-定期,ていき,fixed term,JLPT JLPT_2 JLPT_3
-抵抗,ていこう,"resistance, opposition",JLPT JLPT_2 JLPT_3
-提出,ていしゅつ,"presentation, submission, filing",JLPT JLPT_2 JLPT_3
-停電,ていでん,failure of electricity,JLPT JLPT_2 JLPT_3
-程度,ていど,"degree, amount, level",JLPT JLPT_2 JLPT_3
-停留所,ていりゅうじょ,bus or tram stop,JLPT JLPT_2 JLPT_3
-デート,デート,date (in the sense of 'social engagement' only),JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.5 Genki_Ln.3 Genki
-敵,てき,"enemy, rival",JLPT JLPT_2 JLPT_3
-出来事,できごと,"incident happening, event",JLPT JLPT_2 JLPT_3
-適する,てきする,"to fit, to suit",JLPT JLPT_2 JLPT_3
-適切,てきせつ,"appropriate, adequate, relevance",JLPT JLPT_2 JLPT_3
-適度,てきど,moderate,JLPT JLPT_2 JLPT_3
-適用,てきよう,applying,JLPT JLPT_2 JLPT_3
-できれば,できれば,if possible…,JLPT JLPT_2 JLPT_3
-手品,てじな,"conjuring trick, magic",JLPT JLPT_2 JLPT_3
-ですから,ですから,therefore,JLPT JLPT_2 JLPT_3
-鉄,てつ,iron,JLPT JLPT_2 JLPT_3
-哲学,てつがく,philosophy,JLPT JLPT_2 JLPT_3
-手伝い,てつだい,"help, helper, assistant",JLPT JLPT_2 JLPT_3
-徹底,てってい,"thoroughness, completeness",JLPT JLPT_2 JLPT_3
-鉄道,てつどう,railway; railroad,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.10
-徹夜,てつや,"staying up all night, sleepless night",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.7
-手間,てま,"time, labor",JLPT JLPT_2 JLPT_3
-デモ,デモ,"demo, demonstration",JLPT JLPT_2 JLPT_3
-典型,てんけい,"type, pattern, archetypal",JLPT JLPT_2 JLPT_3
-天候,てんこう,weather,JLPT JLPT_2 JLPT_3
-電子,でんし,electron; electronic,JLPT JLPT_2 JLPT_3
-テント,テント,tent,JLPT JLPT_2 JLPT_3
-伝統,でんとう,"tradition, convention",JLPT JLPT_2 JLPT_3
-天然,てんねん,"nature, spontaneity",JLPT JLPT_2 JLPT_3
-問い,とい,"question, query",JLPT JLPT_2 JLPT_3
-党,とう,party (political),JLPT JLPT_2 JLPT_3
-塔,とう,"tower, pagoda",JLPT JLPT_2 JLPT_3
-答案,とうあん,"examination paper, examination script",JLPT JLPT_2 JLPT_3
-同一,どういつ,"identity, sameness, similarity",JLPT JLPT_2 JLPT_3
-銅貨,どうか,copper coin,JLPT JLPT_2 JLPT_3
-当時,とうじ,"at that time, in those days (same as そのころ)",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.13
-動詞,どうし,verb,JLPT JLPT_2 JLPT_3
-同時,どうじ,"simultaneous(ly), same time",JLPT JLPT_2 JLPT_3
-どうしても,どうしても,"at any cost, no matter what, no matter how hard one tries",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.11
-どうぞよろしく,どうぞよろしく,pleased to meet you,JLPT JLPT_2 JLPT_3
-到着,とうちゃく,arrival,JLPT JLPT_2 JLPT_3
-道徳,どうとく,morals,JLPT JLPT_2 JLPT_3
-投票,とうひょう,"voting, poll",JLPT JLPT_2 JLPT_3
-東洋,とうよう,Orient,JLPT JLPT_2 JLPT_3
-同様,どうよう,"identical, same (kind), like",JLPT JLPT_2 JLPT_3
-童謡,どうよう,"children's song, nursery rhyme",JLPT JLPT_2 JLPT_3
-同僚,どうりょう,colleague; co-worker,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.6 Genki Genki_Ln.21
-道路,どうろ,road,JLPT JLPT_2 JLPT_3
-通す,とおす,"to let pass, to overlook, to continue",JLPT JLPT_2 JLPT_3
-通り過ぎる,とおりすぎる,"to pass, to pass through",JLPT JLPT_2 JLPT_3
-都会,とかい,city,JLPT JLPT_2 JLPT_3
-溶く,とく,to dissolve (paint),JLPT JLPT_2 JLPT_3
-解く,とく,"to unfasten; answer, solve",JLPT JLPT_2 JLPT_3
-退く,どく,"to retreat, to recede, to withdraw",JLPT JLPT_2 JLPT_3
-毒,どく,"poison, toxicant",JLPT JLPT_2 JLPT_3
-得意,とくい,"pride, triumph, prosperity",JLPT JLPT_2 JLPT_3
-読書,どくしょ,reading,JLPT JLPT_2 JLPT_3
-独身,どくしん,"single, unmarried",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14
-特徴,とくちょう,characteristic(s); feature(s); trait(s),JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.10
-特長,とくちょう,"forte, merit",JLPT JLPT_2 JLPT_3
-独特,どくとく,"peculiarity, uniqueness, characteristic",JLPT JLPT_2 JLPT_3
-独立,どくりつ,"independence (e.g., Ind. Day), self-support",JLPT JLPT_2 JLPT_3
-溶ける,とける,"to melt, to thaw, to dissolve",JLPT JLPT_2 JLPT_3
-解ける,とける,"to come untied, to come apart",JLPT JLPT_2 JLPT_3
-どこか,どこか,"somewhere, anywhere",JLPT JLPT_2 JLPT_3
-ところが,ところが,"however, while, even if",JLPT JLPT_2 JLPT_3
-ところで,ところで,by the way; even if,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.1
-登山,とざん,mountain-climbing,JLPT JLPT_2 JLPT_3
-都市,とし,"town, city, urban",JLPT JLPT_2 JLPT_3
-年月,としつき,months and years,JLPT JLPT_2 JLPT_3
-図書,としょ,books,JLPT JLPT_2 JLPT_3
-年寄,としより,"old people, the aged",JLPT JLPT_2 JLPT_3
-閉じる,とじる,"to close (e.g., book, eyes), to shut",JLPT JLPT_2 JLPT_3
-途端,とたん,"just (now, at the moment, etc.)",JLPT JLPT_2 JLPT_3
-土地,とち,"plot of land, lot, soil",JLPT JLPT_2 JLPT_3
-突然,とつぜん,"abruptly, suddenly, unexpectedly",JLPT JLPT_2 JLPT_3
-トップ,トップ,top,JLPT JLPT_2 JLPT_3
-届く,とどく,to reach,JLPT JLPT_2 JLPT_3
-とにかく,とにかく,"anyhow, at any rate, anyway",JLPT JLPT_3 JLPT_2 Genki Genki_Ln.21
-飛ばす,とばす,"to skip over, to omit",JLPT JLPT_2 JLPT_3
-飛び出す,とびだす,"to jump out, to rush out, to fly out",JLPT JLPT_2 JLPT_3
-留める,とめる,"to fasten, to turn off, to detain",JLPT JLPT_2 JLPT_3
-泊める,とめる,to have someone stay (over night) (v.t.),JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.1
-友,とも,"friend, companion, pal",JLPT JLPT_2 JLPT_3
-共に,ともに,"sharing with, participate in",JLPT JLPT_2 JLPT_3
-虎,とら,tiger,JLPT JLPT_2 JLPT_3
-ドライブ,ドライブ,"drive, driving",JLPT Genki_Ln.11 JLPT_3 JLPT_2 Genki
-トラック,トラック,truck; (running) track,JLPT JLPT_2 JLPT_3
-ドラマ,ドラマ,drama,JLPT JLPT_2 JLPT_3
-トランプ,トランプ,playing cards (lit: trump),JLPT JLPT_2 JLPT_3
-取り上げる,とりあげる,"to take up, to pick up; to confiscate",JLPT JLPT_2 JLPT_3
-努力,どりょく,"great effort, exertion, endeavor",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14
-トレーニング,トレーニング,training,JLPT JLPT_2 JLPT_3
-ドレス,ドレス,dress,JLPT JLPT_2 JLPT_3
-取れる,とれる,"to come off, to be taken off",JLPT JLPT_2 JLPT_3
-泥,どろ,mud,JLPT JLPT_2 JLPT_3
-トン,トン,ton (1000 lbs.),JLPT JLPT_2 JLPT_3
-とんでもない,とんでもない,"outrageous, No way!",JLPT JLPT_2 JLPT_3
-どんなに,どんなに,"how, how much",JLPT JLPT_2 JLPT_3
-トンネル,トンネル,tunnel,JLPT JLPT_2 JLPT_3
-名,な,"name, reputation",JLPT JLPT_2 JLPT_3
-内容,ないよう,"subject, contents, detail",JLPT JLPT_2 JLPT_3
-なお,なお,"still, yet",JLPT JLPT_2 JLPT_3
-仲,なか,"relation, relationship",JLPT JLPT_2 JLPT_3
-流す,ながす,"to drain, to float, to shed (e.g., blood, tears)",JLPT JLPT_2 JLPT_3
-半ば,なかば,"middle, halfway",JLPT JLPT_2 JLPT_3
-仲間,なかま,"company, fellow, colleague, associate",JLPT JLPT_2 JLPT_3
-中身,なかみ,content(s); substance,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.13
-中味,なかみ,"contents, interior, filling",JLPT JLPT_2 JLPT_3
-眺め,ながめ,scene; view; prospect; outlook,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.10
-眺める,ながめる,"to view, to gaze at",JLPT JLPT_2 JLPT_3
-流れ,ながれ,"stream, current",JLPT JLPT_2 JLPT_3
-流れる,ながれる,"to flow, to be washed away",JLPT JLPT_2 JLPT_3
-亡くす,なくす,to lose someone,JLPT JLPT_2 JLPT_3
-殴る,なぐる,to strike; to hit; to punch,JLPT JLPT_3 JLPT_2 Genki Genki_Ln.21
-無し,なし,without,JLPT JLPT_2 JLPT_3
-なぜなら,なぜなら,because,JLPT JLPT_2 JLPT_3
-謎,なぞ,"riddle, puzzle, enigma",JLPT JLPT_2 JLPT_3
-納得,なっとく,"consent, assent, understanding",JLPT JLPT_2 JLPT_3
-何か,なにか,something,JLPT JLPT_3 JLPT_2 Genki_Ln.8 Genki
-なにも,なにも,nothing,JLPT JLPT_2 JLPT_3
-鍋,なべ,"saucepan, pot",JLPT JLPT_2 JLPT_3
-生,なま,"raw, unprocessed",JLPT JLPT_2 JLPT_3
-怠ける,なまける,"to be idle, to neglect",JLPT JLPT_2 JLPT_3
-波,なみ,wave,JLPT JLPT_2 JLPT_3
-涙,なみだ,tear,JLPT JLPT_2 JLPT_3
-悩む,なやむ,"to agonize, to be troubled",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14
-鳴らす,ならす,"to ring, to sound",JLPT JLPT_2 JLPT_3
-為る,なる,"to change, to be of use, to reach to",JLPT JLPT_2 JLPT_3
-生る,なる,to bear fruit,JLPT JLPT_2 JLPT_3
-馴れる,なれる,"to become domesticated, to become tame",JLPT JLPT_2 JLPT_3
-縄,なわ,rope,JLPT JLPT_2 JLPT_3
-何で,なんで,"Why, What for",JLPT JLPT_2 JLPT_3
-何でも,なんでも,"by all means, everything",JLPT JLPT_2 JLPT_3
-何とか,なんとか,"somehow, anyhow, one way or another",JLPT JLPT_2 JLPT_3
-似合う,にあう,"to suit (a person), to match (clothing), (something) becomes (someone)",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.11
-煮える,にえる,"to boil, to cook, to be cooked",JLPT JLPT_2 JLPT_3
-苦手,にがて,"poor (at), weak (in), dislike (of)",JLPT JLPT_2 JLPT_3
-握る,にぎる,"to grasp, to seize, to mold sushi",JLPT JLPT_2 JLPT_3
-日,にち,day,JLPT JLPT_2 JLPT_3
-日常,にちじょう,"ordinary, regular, everyday",JLPT JLPT_2 JLPT_3
-日光,にっこう,sunlight,JLPT JLPT_2 JLPT_3
-日中,にっちゅう,"daytime, broad daylight",JLPT JLPT_2 JLPT_3
-にっこり,にっこり,"smile sweetly, smile, grin",JLPT JLPT_2 JLPT_3
-日本,にっぽん,Japan,JLPT JLPT_2 JLPT_3
-日本,にほん,Japan,JLPT JLPT_3 JLPT_2 Genki_Ln.1 Genki
-入場,にゅうじょう,"entrance, admission, entering",JLPT JLPT_2 JLPT_3
-煮る,にる,"to boil, to cook",JLPT JLPT_2 JLPT_3
-人気,にんき,popularity,JLPT JLPT_2 JLPT_3
-人間,にんげん,"human being, person",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.11
-抜く,ぬく,"to extract, to omit, to unplug",JLPT JLPT_2 JLPT_3
-抜ける,ぬける,"to come out, to fall out, to be omitted",JLPT JLPT_2 JLPT_3
-布,ぬの,cloth,JLPT JLPT_2 JLPT_3
-濡らす,ぬらす,"to wet, to soak",JLPT JLPT_2 JLPT_3
-根,ね,root,JLPT JLPT_2 JLPT_3
-値,ね,"value, price, cost",JLPT JLPT_2 JLPT_3
-願い,ねがい,"desire, wish, request",JLPT JLPT_2 JLPT_3
-願う,ねがう,"to desire, to wish, to request",JLPT JLPT_2 JLPT_3
-鼠,ねずみ,"mouse, rat",JLPT JLPT_2 JLPT_3
-熱帯,ねったい,tropics,JLPT JLPT_2 JLPT_3
-熱中,ねっちゅう,"enthusiasm, zeal, mania",JLPT JLPT_2 JLPT_3
-年間,ねんかん,year,JLPT JLPT_2 JLPT_3
-年月,ねんげつ,months and years,JLPT JLPT_2 JLPT_3
-年中,ねんじゅう,"whole year, always, everyday",JLPT JLPT_2 JLPT_3
-年代,ねんだい,"age, era, period",JLPT JLPT_2 JLPT_3
-年齢,ねんれい,"age, years",JLPT JLPT_2 JLPT_3
-野,の,field,JLPT JLPT_2 JLPT_3
-能,のう,"being skilled in, nicely, properly",JLPT JLPT_2 JLPT_3
-農家,のうか,"farmer, farm family",JLPT JLPT_2 JLPT_3
-農業,のうぎょう,agriculture,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.10
-農民,のうみん,"farmers, peasants",JLPT JLPT_2 JLPT_3
-能力,のうりょく,"ability, faculty",JLPT JLPT_2 JLPT_3
-ノー,ノー,no,JLPT JLPT_2 JLPT_3
-軒,のき,eaves,JLPT JLPT_2 JLPT_3
-残す,のこす,"to leave (behind, over), to save, to reserve",JLPT JLPT_2 JLPT_3
-残り,のこり,"remaining, left-over",JLPT JLPT_2 JLPT_3
-乗せる,のせる,"to place on (something), to take on board",JLPT JLPT_2 JLPT_3
-載せる,のせる,to place on (something); to publish,JLPT JLPT_2 JLPT_3
-覗く,のぞく,"to peek in, to look in",JLPT JLPT_2 JLPT_3
-除く,のぞく,"to remove, to exclude, to except",JLPT JLPT_2 JLPT_3
-望み,のぞみ,"wish, desire, (a) hope",JLPT JLPT_2 JLPT_3
-望む,のぞむ,"to desire, to wish for; to view",JLPT JLPT_2 JLPT_3
-後,のち,"afterwards, since then",JLPT JLPT_2 JLPT_3
-ノック,ノック,knock; fungo (baseball),JLPT JLPT_2 JLPT_3
-伸ばす,のばす,"to extend, to stretch, to reach out",JLPT JLPT_2 JLPT_3
-延ばす,のばす,"to extend, to stretch, to reach out",JLPT JLPT_2 JLPT_3
-伸びる,のびる,"to extend, to make progress, to grow",JLPT JLPT_2 JLPT_3
-延びる,のびる,to be prolonged,JLPT JLPT_2 JLPT_3
-述べる,のべる,"to state, to express, to mention",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.13
-上る,のぼる,"to ascend, to go up, to climb",JLPT JLPT_2 JLPT_3
-昇る,のぼる,"to arise, to ascend, to go up",JLPT JLPT_2 JLPT_3
-載る,のる,"to appear (in print), to be recorded",JLPT JLPT_2 JLPT_3
-のんびり,のんびり,"carefree, at leisure",JLPT JLPT_3 JLPT_2 Genki_Ln.22 Genki
-場,ば,"place, field (physics)",JLPT JLPT_2 JLPT_3
-はあ (かん),はあ (かん),(sigh),JLPT JLPT_2 JLPT_3
-パーセント,パーセント,percent,JLPT JLPT_2 JLPT_3
-灰,はい,ash,JLPT JLPT_2 JLPT_3
-梅雨,ばいう,rainy season,JLPT JLPT_2 JLPT_3
-バイオリン,バイオリン,violin,JLPT Genki_Ln.13 JLPT_3 JLPT_2 Genki
-ハイキング,ハイキング,hiking,JLPT JLPT_2 JLPT_3
-配達,はいたつ,"delivery, distribution",JLPT JLPT_2 JLPT_3
-パイプ,パイプ,pipe; channels official or otherwise,JLPT JLPT_2 JLPT_3
-俳優,はいゆう,"actor, actress, performer",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.13
-パイロット,パイロット,pilot,JLPT JLPT_2 JLPT_3
-生える,はえる,"to grow, to spring up; to cut (teeth)",JLPT JLPT_2 JLPT_3
-墓,はか,"grave, tomb",JLPT JLPT_2 JLPT_3
-馬鹿,ばか,"fool, idiot",JLPT JLPT_2 JLPT_3
-博士,はかせ,"doctorate, PhD., doctor",JLPT JLPT_2 JLPT_3
-計る,はかる,"to measure, to weigh, to survey",JLPT JLPT_2 JLPT_3
-量る,はかる,"to measure, to weigh, to survey",JLPT JLPT_2 JLPT_3
-測る,はかる,"to measure, to weigh, to survey",JLPT JLPT_2 JLPT_3
-掃く,はく,"to sweep, to brush, to gather up",JLPT JLPT_2 JLPT_3
-吐く,はく,"to throw up, to vomit",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.12
-拍手,はくしゅ,"clapping hands, applause",JLPT JLPT_2 JLPT_3
-莫大,ばくだい,"enormous, vast",JLPT JLPT_2 JLPT_3
-爆発,ばくはつ,"explosion, detonation, eruption",JLPT JLPT_2 JLPT_3
-博物館,はくぶつかん,museum,JLPT JLPT_2 JLPT_3
-激しい,はげしい,"violent, vehement, intense",JLPT JLPT_2 JLPT_3
-はさみ,はさみ,scissors,JLPT JLPT_2 JLPT_3
-破産,はさん,(personal) bankruptcy,JLPT JLPT_2 JLPT_3
-端,はし,"end (e.g., of street), edge, margin",JLPT JLPT_2 JLPT_3
-始まり,はじまり,"origin, beginning",JLPT JLPT_2 JLPT_3
-パス,パス,"path, pass (in games)",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.10
-外す,はずす,"to unfasten, to remove",JLPT JLPT_2 JLPT_3
-パスポート,パスポート,passport,JLPT JLPT_2 JLPT_3
-外れる,はずれる,"to be disconnected, to be out (e.g., of gear)",JLPT JLPT_2 JLPT_3
-旗,はた,flag,JLPT JLPT_2 JLPT_3
-肌,はだ,skin,JLPT JLPT_2 JLPT_3
-裸,はだか,"naked, nude",JLPT JLPT_2 JLPT_3
-畑,はたけ,"field, patch",JLPT JLPT_2 JLPT_3
-働き,はたらき,"work, labor",JLPT JLPT_2 JLPT_3
-バッグ,バッグ,bag,JLPT JLPT_2 JLPT_3
-発見,はっけん,"discovery, detection, finding",JLPT JLPT_2 JLPT_3
-発行,はっこう,issue (publications),JLPT JLPT_2 JLPT_3
-発車,はっしゃ,departure of a vehicle,JLPT JLPT_2 JLPT_3
-発射,はっしゃ,"firing, shooting, discharge",JLPT JLPT_2 JLPT_3
-罰する,ばっする,"to punish, to penalize",JLPT JLPT_2 JLPT_3
-発達,はったつ,"development, growth",JLPT JLPT_2 JLPT_3
-ばったり,ばったり,(to meet) by chance,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.11
-発展,はってん,"development, growth, progress",JLPT JLPT_2 JLPT_3
-発表,はっぴょう,announcement; publication; presentation,Genki_Ln.15 JLPT JLPT_3 JLPT_2 Genki
-発明,はつめい,invention,JLPT JLPT_2 JLPT_3
-派手,はで,"showy, flashy, gaudy",JLPT JLPT_2 JLPT_3
-話し合う,はなしあう,"to discuss, to talk together",JLPT JLPT_2 JLPT_3
-離す,はなす,"to part, to separate",JLPT JLPT_2 JLPT_3
-放す,はなす,"to separate, to set free",JLPT JLPT_2 JLPT_3
-離れる,はなれる,"(something, someone) separates; parts from; to be apart",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.15 Genki_Ln.23 Genki
-放れる,はなれる,"to leave, to get free, to cut oneself off",JLPT JLPT_2 JLPT_3
-羽,はね,wing,JLPT JLPT_2 JLPT_3
-羽根,はね,feather,JLPT JLPT_2 JLPT_3
-幅,はば,"width, breadth",JLPT JLPT_2 JLPT_3
-母親,ははおや,mother,JLPT JLPT_2 JLPT_3
-省く,はぶく,"to omit, to eliminate",JLPT JLPT_2 JLPT_3
-場面,ばめん,"scene, setting (e.g., of novel)",JLPT JLPT_2 JLPT_3
-流行る,はやる,"to be popular, to come into fashion",JLPT JLPT_2 JLPT_3
-腹,はら,"abdomen, belly, stomach",JLPT JLPT_2 JLPT_3
-原,はら,"field, plain",JLPT JLPT_2 JLPT_3
-バランス,バランス,balance,JLPT JLPT_2 JLPT_3
-針,はり,"needle, hand (e.g., clock)",JLPT JLPT_2 JLPT_3
-範囲,はんい,"extent, scope, range",JLPT JLPT_2 JLPT_3
-反抗,はんこう,"opposition, resistance",JLPT JLPT_2 JLPT_3
-犯罪,はんざい,crime,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.10
-ハンサム,ハンサム,handsome,JLPT JLPT_2 JLPT_3
-反省,はんせい,"reflection, reconsideration, regret",JLPT JLPT_2 JLPT_3
-判断,はんだん,"judgment, decision",JLPT JLPT_2 JLPT_3
-犯人,はんにん,"offender, criminal",JLPT JLPT_3 JLPT_2 Genki Genki_Ln.21
-販売,はんばい,"sale, selling, marketing",JLPT JLPT_2 JLPT_3
-灯,ひ,light,JLPT JLPT_2 JLPT_3
-ビール,ビール,beer,JLPT Genki_Ln.11 JLPT_3 JLPT_2 Genki
-被害,ひがい,damage,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.10
-比較,ひかく,comparison,JLPT JLPT_2 JLPT_3
-ピクニック,ピクニック,picnic,JLPT JLPT_2 JLPT_3
-悲劇,ひげき,tragedy,JLPT JLPT_2 JLPT_3
-飛行,ひこう,"aviation, flight",JLPT JLPT_2 JLPT_3
-膝,ひざ,"knee, lap",JLPT JLPT_2 JLPT_3
-非常,ひじょう,"emergency, extraordinary, unusual",JLPT JLPT_2 JLPT_3
-美人,びじん,beautiful person (woman),JLPT JLPT_2 JLPT_3
-額,ひたい,"forehead, brow",JLPT JLPT_2 JLPT_3
-日付,ひづけ,"date, dating",JLPT JLPT_2 JLPT_3
-引越し,ひっこし,"moving, changing residence",JLPT JLPT_2 JLPT_3
-必死,ひっし,"desperation, frantic, inevitable result",JLPT JLPT_2 JLPT_3
-ぴったり,ぴったり,"exactly, neatly, sharp",JLPT JLPT_2 JLPT_3
-引っ張る,ひっぱる,"to pull, to stretch, to drag",JLPT JLPT_2 JLPT_3
-否定,ひてい,"negation, denial",JLPT JLPT_2 JLPT_3
-ビデオ,ビデオ,video tape; VCR,JLPT JLPT_3 JLPT_2 Genki_Ln.3 Genki
-一言,ひとこと,one word,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.12
-人込み,ひとごみ,crowd of people,JLPT JLPT_2 JLPT_3
-等しい,ひとしい,equal,JLPT JLPT_2 JLPT_3
-独り,ひとり,"alone, unmarried",JLPT JLPT_2 JLPT_3
-一人一人,ひとりひとり,"one by one, each",JLPT JLPT_2 JLPT_3
-批判,ひはん,criticism,JLPT JLPT_2 JLPT_3
-批評,ひひょう,"criticism, review, commentary",JLPT JLPT_2 JLPT_3
-秘密,ひみつ,"secret, secrecy",Genki_Ln.17 JLPT JLPT_3 JLPT_2 Genki
-微妙,びみょう,"delicate, subtle",JLPT JLPT_2 JLPT_3
-紐,ひも,"string, cord",JLPT JLPT_2 JLPT_3
-冷やす,ひやす,"to cool, to refrigerate",JLPT JLPT_2 JLPT_3
-費用,ひよう,"cost, expense",JLPT JLPT_2 JLPT_3
-表,ひょう,"table (e.g., Tab 1), chart, list",JLPT JLPT_2 JLPT_3
-秒,びょう,second (60th min),JLPT JLPT_2 JLPT_3
-評価,ひょうか,"assessment, evaluation",JLPT JLPT_2 JLPT_3
-表現,ひょうげん,"expression, presentation",JLPT JLPT_2 JLPT_3
-表情,ひょうじょう,facial expression,JLPT JLPT_2 JLPT_3
-平等,びょうどう,"equality, impartiality, evenness",JLPT JLPT_2 JLPT_3
-評判,ひょうばん,"fame, reputation",JLPT JLPT_2 JLPT_3
-表面,ひょうめん,"surface, outside, face",JLPT JLPT_2 JLPT_3
-広がる,ひろがる,"to spread (out), to extend, to stretch, to reach to, to get around",JLPT JLPT_2 JLPT_3
-広げる,ひろげる,"to spread, to extend, to expand, to enlarge",JLPT JLPT_2 JLPT_3
-広める,ひろめる,"to broaden, to propagate",JLPT JLPT_2 JLPT_3
-品,ひん,"goods; taste, elegance",JLPT JLPT_2 JLPT_3
-瓶,びん,bottle,JLPT JLPT_2 JLPT_3
-便,びん,"way, means; flight",JLPT Genki_Ln.10 JLPT_3 JLPT_2 Genki
-ピン,ピン,pin,JLPT JLPT_2 JLPT_3
-不,ふ,"un(~), non(~), negative prefix",JLPT JLPT_2 JLPT_3
-不,ぶ,"un(~), non(~), negative prefix",JLPT JLPT_2 JLPT_3
-無,ぶ,"nothing, naught, nil, zero",JLPT JLPT_2 JLPT_3
-分,ぶ,"dividing, part",JLPT JLPT_2 JLPT_3
-不安,ふあん,"anxiety, uneasiness",JLPT JLPT_2 JLPT_3
-風景,ふうけい,scenery,JLPT JLPT_2 JLPT_3
-夫婦,ふうふ,"married couple, husband and wife",JLPT Genki_Ln.14 Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14 Genki
-笛,ふえ,"flute, whistle",JLPT JLPT_2 JLPT_3
-不可,ふか,"wrong, bad, impossible",JLPT JLPT_2 JLPT_3
-深まる,ふかまる,to deepen,JLPT JLPT_2 JLPT_3
-武器,ぶき,"weapon, arms",JLPT JLPT_2 JLPT_3
-拭く,ふく,"to wipe, to dry",JLPT JLPT_2 JLPT_3
-服装,ふくそう,"clothes, attire",JLPT JLPT_2 JLPT_3
-含む,ふくむ,"to contain, to include",JLPT JLPT_2 JLPT_3
-含める,ふくめる,to include,JLPT JLPT_2 JLPT_3
-袋,ふくろ,"bag, sack",JLPT JLPT_2 JLPT_3
-不幸,ふこう,"unhappiness, sorrow, misfortune",JLPT JLPT_2 JLPT_3
-節,ふし,"tune, tone, knob",JLPT JLPT_2 JLPT_3
-無事,ぶじ,"safety, peace",JLPT JLPT_2 JLPT_3
-不思議,ふしぎ,"mystery, curiosity",JLPT JLPT_2 JLPT_3
-不自由,ふじゆう,"discomfort, disability, inconvenience",JLPT JLPT_2 JLPT_3
-夫人,ふじん,"wife, Mrs, madam",JLPT JLPT_2 JLPT_3
-婦人,ふじん,woman (same as 女性 (じょせい)、女の人 (おんなのひと)),JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.13
-不正,ふせい,"injustice, unfairness",JLPT JLPT_2 JLPT_3
-防ぐ,ふせぐ,"to defend (against), to protect, to prevent",JLPT JLPT_2 JLPT_3
-不足,ふそく,"insufficiency, shortage",JLPT JLPT_2 JLPT_3
-舞台,ぶたい,stage (theater),JLPT JLPT_2 JLPT_3
-双子,ふたご,"twins, a twin",JLPT JLPT_2 JLPT_3
-再び,ふたたび,"again, once more, a second time",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.13
-普段,ふだん,"in everyday situations, usually, ordinarily",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.15
-縁,ふち,"edge, rim",JLPT JLPT_2 JLPT_3
-打つ,ぶつ,"to hit, to strike",JLPT JLPT_2 JLPT_3
-不通,ふつう,"blockade, interruption, stoppage",JLPT JLPT_2 JLPT_3
-物価,ぶっか,(commodity/consumer) prices,JLPT Genki_Ln.13 Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.6 Genki
-ぶつかる,ぶつかる,"to strike, to collide with",JLPT JLPT_2 JLPT_3
-ぶつける,ぶつける,"to knock, to strike hard, to hit and attack",JLPT JLPT_2 JLPT_3
-物質,ぶっしつ,"material, substance",JLPT JLPT_2 JLPT_3
-物理,ぶつり,physics,JLPT JLPT_2 JLPT_3
-筆,ふで,writing brush,JLPT JLPT_2 JLPT_3
-ふと,ふと,"suddenly, accidentally, incidentally",JLPT JLPT_2 JLPT_3
-部分,ぶぶん,"portion, section, part",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.12
-不平,ふへい,"complaint, discontent, dissatisfaction",JLPT JLPT_2 JLPT_3
-不満,ふまん,"dissatisfaction, discontent, complaints",JLPT JLPT_2 JLPT_3
-増やす,ふやす,"to increase (v.t.), to add to",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14
-殖やす,ふやす,"to increase, to add to",JLPT JLPT_2 JLPT_3
-プラス,プラス,plus,JLPT JLPT_2 JLPT_3
-プラスチック,プラスチック,plastic,JLPT JLPT_2 JLPT_3
-プラン,プラン,plan,JLPT JLPT_2 JLPT_3
-不利,ふり,"disadvantage, drawback",JLPT JLPT_2 JLPT_3
-振る,ふる,"to wave, to shake; to sprinkle; to cast (actor)",JLPT JLPT_2 JLPT_3
-震える,ふるえる,"to shiver, to shake, to quake",JLPT JLPT_2 JLPT_3
-ブレーキ,ブレーキ,a brake,JLPT JLPT_2 JLPT_3
-触れる,ふれる,"to touch, to feel, to violate",JLPT JLPT_2 JLPT_3
-プロ,プロ,professional,JLPT JLPT_2 JLPT_3
-分,ぶん,"dividing, part, segment",JLPT JLPT_2 JLPT_3
-文,ぶん,sentence,JLPT JLPT_2 JLPT_3
-雰囲気,ふんいき,"atmosphere (e.g., musical), mood, ambiance",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.12
-分析,ぶんせき,analysis,JLPT JLPT_2 JLPT_3
-文明,ぶんめい,civilization,JLPT JLPT_2 JLPT_3
-分野,ぶんや,"field, sphere",JLPT JLPT_2 JLPT_3
-塀,へい,"wall, fence",JLPT JLPT_2 JLPT_3
-平均,へいきん,"equilibrium, balance, average",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.5
-平和,へいわ,peace,JLPT JLPT_2 JLPT_3
-別に,べつに,"(not) particularly, nothing",JLPT JLPT_2 JLPT_3
-減らす,へらす,"to decrease, to diminish",JLPT JLPT_2 JLPT_3
-減る,へる,"to decrease (in size or number), to diminish",JLPT JLPT_2 JLPT_3
-ベルト,ベルト,Belt for western clothes,JLPT JLPT_2 JLPT_3
-変化,へんか,"change, variation, shift",JLPT JLPT_2 JLPT_3
-ペンキ,ペンキ,paint,JLPT JLPT_2 JLPT_3
-変更,へんこう,"change, modification, alteration",JLPT JLPT_2 JLPT_3
-ベンチ,ベンチ,bench,JLPT JLPT_2 JLPT_3
-弁当,べんとう,box lunch,JLPT JLPT_2 JLPT_3
-方,ほう,side,JLPT JLPT_2 JLPT_3
-法,ほう,Act (law: the X Act),JLPT JLPT_2 JLPT_3
-棒,ぼう,"pole, rod, stick",JLPT JLPT_2 JLPT_3
-冒険,ぼうけん,"risk, venture, adventure",JLPT JLPT_2 JLPT_3
-方向,ほうこう,"direction, course, way",JLPT JLPT_2 JLPT_3
-報告,ほうこく,"report, information",JLPT JLPT_2 JLPT_3
-宝石,ほうせき,"gem, jewel",JLPT JLPT_2 JLPT_3
-包装,ほうそう,"packing, wrapping",JLPT JLPT_2 JLPT_3
-豊富,ほうふ,"abundance, plenty",JLPT JLPT_2 JLPT_3
-方法,ほうほう,"method, means, technique",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.8
-方々,ほうぼう,"here and there, everywhere",JLPT JLPT_2 JLPT_3
-訪問,ほうもん,"call, visit",JLPT JLPT_2 JLPT_3
-吠える,ほえる,"to bark, to howl",JLPT JLPT_2 JLPT_3
-ボーイ,ボーイ,porter; boy,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.6
-ボート,ボート,rowing boat,JLPT JLPT_2 JLPT_3
-ホーム,ホーム,platform; home,JLPT JLPT_2 JLPT_3
-ボール,ボール,ball; bowl,JLPT JLPT_3 JLPT_2 Genki_Ln.22 Genki
-他,ほか,other (esp. places and things),JLPT JLPT_2 JLPT_3
-誇り,ほこり,pride,JLPT JLPT_2 JLPT_3
-埃,ほこり,dust,JLPT JLPT_2 JLPT_3
-保証,ほしょう,"guarantee, assurance, warranty",JLPT JLPT_2 JLPT_3
-保存,ほぞん,"preservation, conservation",JLPT JLPT_2 JLPT_3
-歩道,ほどう,walkway,JLPT JLPT_2 JLPT_3
-仏,ほとけ,Buddha,JLPT JLPT_2 JLPT_3
-骨,ほね,bone,JLPT JLPT_2 JLPT_3
-炎,ほのお,flame,JLPT JLPT_2 JLPT_3
-頬,ほほ,cheek (of face),JLPT JLPT_2 JLPT_3
-頬,ほお,cheek (of face),JLPT JLPT_2 JLPT_3
-ほぼ,ほぼ,"almost, roughly",JLPT JLPT_2 JLPT_3
-微笑む,ほほえむ,to smile,JLPT JLPT_2 JLPT_3
-堀,ほり,"moat, canal",JLPT JLPT_2 JLPT_3
-濠,ほり,moat,JLPT JLPT_2 JLPT_3
-本当,ほんと,"truth, reality",JLPT JLPT_2 JLPT_3
-本人,ほんにん,the person himself,JLPT JLPT_2 JLPT_3
-本物,ほんもの,genuine article,JLPT JLPT_2 JLPT_3
-ぼんやり,ぼんやり,"dim, faint, vague",JLPT JLPT_2 JLPT_3
-間,ま,"space, room, pause",JLPT JLPT_2 JLPT_3
-まあ,まあ,well (used when making a modest or hesitant statement),JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.13
-マーケット,マーケット,market,JLPT JLPT_2 JLPT_3
-マイク,マイク,mic,JLPT JLPT_2 JLPT_3
-迷子,まいご,lost (stray) child,JLPT JLPT_2 JLPT_3
-マイナス,マイナス,minus,JLPT JLPT_2 JLPT_3
-任せる,まかせる,"to entrust to another, to leave to",JLPT JLPT_2 JLPT_3
-巻く,まく,"to wind, to coil, to roll",JLPT JLPT_2 JLPT_3
-蒔く,まく,to sow (seeds),JLPT JLPT_2 JLPT_3
-撒く,まく,"to scatter, to sprinkle, to sow",JLPT JLPT_2 JLPT_3
-幕,まく,"curtain, act (in play)",JLPT JLPT_2 JLPT_3
-負け,まけ,"defeat, loss",JLPT JLPT_2 JLPT_3
-孫,まご,grandchild,JLPT JLPT_2 JLPT_3
-まさか,まさか,by no means,JLPT JLPT_2 JLPT_3
-まさに,まさに,"correctly, surely",JLPT JLPT_2 JLPT_3
-混ざる,まざる,"to be mixed, to mingle with",JLPT JLPT_2 JLPT_3
-交ざる,まざる,"to be mixed, to mingle with",JLPT JLPT_2 JLPT_3
-混じる,まじる,"to be mixed, to mingle with",JLPT JLPT_2 JLPT_3
-交じる,まじる,"to be mixed, to mingle with",JLPT JLPT_2 JLPT_3
-増す,ます,"to increase, to gain",JLPT JLPT_2 JLPT_3
-貧しい,まずしい,"poor, needy",JLPT JLPT_2 JLPT_3
-マスター,マスター,"bar owner, master (e.g., arts, science)",JLPT JLPT_2 JLPT_3
-ますます,ますます,"increasingly (same as もっと), more and more",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.9
-混ぜる,まぜる,"to mix, to stir",JLPT JLPT_2 JLPT_3
-交ぜる,まぜる,"to be mixed, to be blended with",JLPT JLPT_2 JLPT_3
-街,まち,"town; street, road",JLPT JLPT_2 JLPT_3
-間違い,まちがい,mistake,JLPT Genki_Ln.19 JLPT_3 JLPT_2 Genki
-松,まつ,pine tree,JLPT JLPT_2 JLPT_3
-真っ赤,まっか,"deep red, flushed (of face)",JLPT JLPT_2 JLPT_3
-全く,まったく,"really, completely",JLPT JLPT_2 JLPT_3
-祭,まつり,"festival, feast",JLPT JLPT_2 JLPT_3
-まとまる,まとまる,"to be collected, to be settled, to be in order",JLPT JLPT_2 JLPT_3
-まとめる,まとめる,"to put in order, to collect, to bring to a conclusion",JLPT JLPT_2 JLPT_3
-学ぶ,まなぶ,to learn; to study,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.8
-真似,まね,"mimicry, imitation, behavior",JLPT JLPT_2 JLPT_3
-招く,まねく,to invite,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.13
-まぶしい,まぶしい,"dazzling, radiant",JLPT JLPT_2 JLPT_3
-柵,さく,"fence, paling",JLPT_1 JLPT JLPT_3
-裂ける,さける,"to split, to tear, to burst",JLPT_1 JLPT JLPT_3
-裁く,さばく,to judge,JLPT_1 JLPT JLPT_3
-酸化,さんか,oxidation,JLPT_1 JLPT JLPT_3
-死,し,"death, decease",JLPT_1 JLPT JLPT_3
-資格,しかく,"qualifications, requirements, capabilities",JLPT_1 JLPT JLPT_3
-視覚,しかく,"sense of sight, vision",JLPT_1 JLPT JLPT_3
-指揮,しき,"command, direction",JLPT_1 JLPT JLPT_3
-磁気,じき,magnetism,JLPT_1 JLPT JLPT_3
-磁器,じき,"porcelain, china",JLPT_1 JLPT JLPT_3
-自己,じこ,"self, oneself",JLPT_1 JLPT JLPT_3
-字体,じたい,"font, lettering",JLPT_1 JLPT JLPT_3
-辞退,じたい,refusal,JLPT_1 JLPT JLPT_3
-視点,してん,"opinion, point of view, visual point",JLPT_1 JLPT JLPT_3
-脂肪,しぼう,"fat, grease",JLPT_1 JLPT JLPT_3
-志望,しぼう,"wish, desire, ambition",JLPT_1 JLPT JLPT_3
-衆,しゅう,"masses, people",JLPT_1 JLPT JLPT_3
-住,じゅう,"dwelling, living",JLPT_1 JLPT JLPT_3
-修飾,しゅうしょく,ornamentation; modification (gram),JLPT_1 JLPT JLPT_3
-私用,しよう,"personal use, private business",JLPT_1 JLPT JLPT_3
-仕様,しよう,"way, method, specification",JLPT_1 JLPT JLPT_3
-情,じょう,"feelings, emotion, passion",JLPT_1 JLPT JLPT_3
-生涯,しょうがい,one's lifetime,JLPT_1 JLPT JLPT_3
-上司,じょうし,one's superior,JLPT Intermediate_Japanese JLPT_1 JLPT_3 Intermediate_Japanese_Ln.9
-正体,しょうたい,"natural shape, one's true colors, true character",JLPT_1 JLPT JLPT_3
-照明,しょうめい,illumination,JLPT_1 JLPT JLPT_3
-女史,じょし,Ms.,JLPT_1 JLPT JLPT_3
-助詞,じょし,"(gram) particle(s), postposition",JLPT Intermediate_Japanese JLPT_1 JLPT_3 Intermediate_Japanese_Ln.13
-ショック,ショック,shock,JLPT Intermediate_Japanese JLPT_1 JLPT_3 Intermediate_Japanese_Ln.4
-進行,しんこう,advance,JLPT_1 JLPT JLPT_3
-新興,しんこう,"rising, developing, emergent",JLPT_1 JLPT JLPT_3
-振興,しんこう,"promotion, encouragement",JLPT_1 JLPT JLPT_3
-申告,しんこく,"report, statement",JLPT_1 JLPT JLPT_3
-真理,しんり,truth,JLPT_1 JLPT JLPT_3
-水洗,すいせん,flushing,JLPT_1 JLPT JLPT_3
-ストレス,ストレス,stress,JLPT_1 JLPT JLPT_3
-擦る,する,"to rub, to chafe",JLPT_1 JLPT JLPT_3
-正規,せいき,"regular, legitimate",JLPT_1 JLPT JLPT_3
-精巧,せいこう,"elaborate, delicate, exquisite",JLPT_1 JLPT JLPT_3
-精算,せいさん,"exact calculation, adjustment",JLPT_1 JLPT JLPT_3
-成年,せいねん,"majority, adult age",JLPT_1 JLPT JLPT_3
-声明,せいめい,"declaration, statement, proclamation",JLPT_1 JLPT JLPT_3
-姓名,せいめい,full name,JLPT_1 JLPT JLPT_3
-生理,せいり,"physiology, menses",JLPT_1 JLPT JLPT_3
-節,せつ,"when, if; section; clause",JLPT_1 JLPT JLPT_3
-膳,ぜん,"(small) table, tray, meal",JLPT_1 JLPT JLPT_3
-禅,ぜん,Zen (Buddhism),JLPT_1 JLPT JLPT_3
-選挙,せんきょ,election,JLPT JLPT_1 JLPT_3 Genki_Ln.23 Genki
-先行,せんこう,"preceding, going first",JLPT_1 JLPT JLPT_3
-選考,せんこう,"selection, screening",JLPT_1 JLPT JLPT_3
-相,そう,"aspect, phase, countenance",JLPT_1 JLPT JLPT_3
-沿う,そう,"to run along, to follow",JLPT_1 JLPT JLPT_3
-添う,そう,"to accompany, to comply with",JLPT_1 JLPT JLPT_3
-僧,そう,"monk, priest",JLPT_1 JLPT JLPT_3
-像,ぞう,"statue, image",JLPT_1 JLPT JLPT_3
-捜査,そうさ,"search (esp. in criminal investigations, investigation)",JLPT_1 JLPT JLPT_3
-操縦,そうじゅう,"management, control, manipulation",JLPT_1 JLPT JLPT_3
-創造,そうぞう,creation,JLPT_1 JLPT JLPT_3
-隊,たい,"party, troops",JLPT_1 JLPT JLPT_3
-退学,たいがく,dropping out of school,JLPT_1 JLPT JLPT_3
-タイトル,タイトル,title,JLPT_1 JLPT JLPT_3
-ダウン,ダウン,down,JLPT_1 JLPT JLPT_3
-高まる,たかまる,to rise; to grow; to mount (v.i.),JLPT Intermediate_Japanese JLPT_1 JLPT_3 Intermediate_Japanese_Ln.14
-断つ,たつ,"to sever, to cut off",JLPT_1 JLPT JLPT_3
-盾,たて,shield,JLPT_1 JLPT JLPT_3
-例え,たとえ,example; even though,JLPT_1 JLPT JLPT_3
-チャイム,チャイム,chime,JLPT_1 JLPT JLPT_3
-挑戦,ちょうせん,"challenge, defiance",JLPT_1 JLPT JLPT_3
-治療,ちりょう,medical treatment,JLPT_1 JLPT JLPT_3
-対,つい,"pair, couple, set",JLPT_1 JLPT JLPT_3
-接ぐ,つぐ,to join; to piece together; to set (bones); to graft (trees),JLPT_1 JLPT JLPT_3
-継ぐ,つぐ,to succeed (someone in a business or inheritance,JLPT_1 JLPT JLPT_3
-摘む,つむ,"to pluck, to pick, to trim",JLPT_1 JLPT JLPT_3
-露,つゆ,dew,JLPT_1 JLPT JLPT_3
-強まる,つよまる,"to get strong, to gain strength",JLPT_1 JLPT JLPT_3
-強める,つよめる,"to strengthen, to emphasize",JLPT_1 JLPT JLPT_3
-データ,データ,data,JLPT_1 JLPT JLPT_3
-デザイン,デザイン,design,JLPT_1 JLPT JLPT_3
-デザート,デザート,dessert,JLPT_1 JLPT JLPT_3
-転校,てんこう,change schools,JLPT_1 JLPT JLPT_3
-伝言,でんごん,verbal message,JLPT_1 JLPT JLPT_3
-と,と,and,JLPT_1 JLPT JLPT_3
-問う,とう,"to ask, to question",JLPT_1 JLPT JLPT_3
-棟,とう,ridge (of roof,JLPT_1 JLPT JLPT_3
-倒産,とうさん,"(corporate) bankruptcy, insolvency",JLPT_1 JLPT JLPT_3
-同士,どうし,"one another, companion, comrade",JLPT Intermediate_Japanese JLPT_1 JLPT_3 Intermediate_Japanese_Ln.9
-同志,どうし,"same mind, comrade, kindred soul",JLPT_1 JLPT JLPT_3
-当然,とうぜん,obvious; natural,JLPT Intermediate_Japanese JLPT_1 JLPT_3 Intermediate_Japanese_Ln.15
-動揺,どうよう,"disturbance, flutter shock",JLPT_1 JLPT JLPT_3
-説く,とく,"to explain, to advocate",JLPT_1 JLPT JLPT_3
-綴じる,とじる,"to bind, to file",JLPT_1 JLPT JLPT_3
-供,とも,"accompanying, attendant, companion, retinue",JLPT_1 JLPT JLPT_3
-並,なみ,"medium (e.g., food serving size, quality, price, etc.), ordinary",JLPT Intermediate_Japanese JLPT_1 JLPT_3 Intermediate_Japanese_Ln.6
-慣らす,ならす,to accustom,JLPT_1 JLPT JLPT_3
-馴らす,ならす,"to domesticate, to tame",JLPT_1 JLPT JLPT_3
-難,なん,"difficulty, hardships, defect",JLPT_1 JLPT JLPT_3
-音,ね,"sound, note",JLPT_1 JLPT JLPT_3
-年鑑,ねんかん,yearbook,JLPT_1 JLPT JLPT_3
-脳,のう,"brain, memory",JLPT_1 JLPT JLPT_3
-臨む,のぞむ,"to look out on, to face, to attend (function)",JLPT_1 JLPT JLPT_3
-肺,はい,lung,JLPT_1 JLPT JLPT_3
-～敗,はい,"counter for loss, defeat",JLPT_1 JLPT JLPT_3
-映える,はえる,"to shine, to look attractive, to look pretty",JLPT_1 JLPT JLPT_3
-諮る,はかる,"to consult with, to confer",JLPT_1 JLPT JLPT_3
-図る,はかる,"to plot, to attempt, to devise, to design, to refer A to B",JLPT_1 JLPT JLPT_3
-生やす,はやす,"to grow, to cultivate, to wear beard",JLPT_1 JLPT JLPT_3
-班,はん,"group, party, section (mil)",JLPT_1 JLPT JLPT_3
-判,はん,size (of paper or books),JLPT_1 JLPT JLPT_3
-版,はん,edition,JLPT_1 JLPT JLPT_3
-碑,ひ,stone monument bearing an inscription,JLPT_1 JLPT JLPT_3
-非行,ひこう,"delinquency, misconduct",JLPT_1 JLPT JLPT_3
-票,ひょう,"label, ballot, sign",JLPT_1 JLPT JLPT_3
-広まる,ひろまる,"to spread, to be propagated",JLPT_1 JLPT JLPT_3
-深める,ふかめる,"to deepen, to heighten, to intensify",JLPT_1 JLPT JLPT_3
-福,ふく,good fortune,JLPT_1 JLPT JLPT_3
-振り,ふり,"style, manner",JLPT_1 JLPT JLPT_3
-経る,へる,"to pass, to elapse, to experience",JLPT_1 JLPT JLPT_3
-保護,ほご,"care, protection, shelter",JLPT_1 JLPT JLPT_3
-保障,ほしょう,"guarantee, security, warranty",JLPT_1 JLPT JLPT_3
-補償,ほしょう,"compensation, reparation",JLPT_1 JLPT JLPT_3
-ほっと,ほっと,feel relieved,JLPT_1 JLPT JLPT_3
-前もって,まえもって,"in advance, beforehand, previously",JLPT_1 JLPT JLPT_3
-膜,まく,"membrane, film",JLPT_1 JLPT JLPT_3
-マスコミ,マスコミ,mass communication,JLPT_1 JLPT JLPT_3
-股,また,"thigh, crotch",JLPT_1 JLPT JLPT_3
-末,まつ,the end of,JLPT_1 JLPT JLPT_3
-マッサージ,マッサージ,massage,JLPT_1 JLPT JLPT_3
-見掛ける,みかける,"to (happen to see), to notice, to catch sight of",JLPT_1 JLPT JLPT_3
-捲る,めくる,"to turn over, to turn pages of a book",JLPT_1 JLPT JLPT_3
-メッセージ,メッセージ,message,JLPT_1 JLPT JLPT_3
-野党,やとう,opposition party,JLPT_1 JLPT JLPT_3
-優,ゆう,"superiority, high grade",JLPT_1 JLPT JLPT_3
-有機,ゆうき,organic,JLPT_1 JLPT JLPT_3
-世,よ,"world, society, generation",JLPT_1 JLPT JLPT_3
-良い,よい,"good, nice",JLPT_1 JLPT JLPT_3
-予想,よそう,"expectation, anticipation, prediction",JLPT_1 JLPT JLPT_3
-弱まる,よわまる,"to weaken, to be emaciated, to be dejected",JLPT_1 JLPT JLPT_3
-弱める,よわめる,to weaken,JLPT_1 JLPT JLPT_3
-ラベル,ラベル,label,JLPT_1 JLPT JLPT_3
-ルール,ルール,rule,JLPT_1 JLPT JLPT_3
-枠,わく,"frame, slide",JLPT_1 JLPT JLPT_3
+expression,reading,meaning,tags,guid
+作法,さほう,"manners, etiquette, propriety",JLPT JLPT_2 JLPT_3,HYeQ[!t+v+
+様々,さまざま,"varied, various",JLPT JLPT_2 JLPT_3,l>?/o{CjV<
+冷ます,さます,"to cool, to let cool",JLPT JLPT_2 JLPT_3,m(o0n4^}Z$
+覚ます,さます,to awaken,JLPT JLPT_2 JLPT_3,t9@aJ[u<UZ
+冷める,さめる,"to become cool, to wear off",JLPT JLPT_2 JLPT_3,LR.A;82:W|
+覚める,さめる,"to wake, to wake up",JLPT JLPT_2 JLPT_3,Dob+O4(+<L
+左右,さゆう,left and right; influence,JLPT JLPT_2 JLPT_3,d8br}6f4&T
+皿,さら,"plate, dish",JLPT Genki_Ln.14 JLPT_3 JLPT_2 Genki,p*f@mDk_ih
+更に,さらに,"furthermore, moreover",JLPT JLPT_2 JLPT_3,n=YLy+|9V>
+去る,さる,"to leave, to go away",JLPT JLPT_2 JLPT_3,q:@^dVE|Ux
+猿,さる,monkey,JLPT JLPT_3 JLPT_2 Genki_Ln.22 Genki,I;FmV}C|Mm
+騒ぎ,さわぎ,"uproar, disturbance",JLPT JLPT_2 JLPT_3,"b-,^J/-<a("
+参加,さんか,participation,JLPT JLPT_2 JLPT_3,NJ??D?6U!^
+参考,さんこう,"reference, consultation",JLPT JLPT_2 JLPT_3,Han8<B?^r0
+賛成,さんせい,"approval, agreement",JLPT JLPT_2 JLPT_3,"emfZ/!E,?["
+酸性,さんせい,acidity,JLPT JLPT_2 JLPT_3,geVhjMXt@#
+酸素,さんそ,oxygen,JLPT JLPT_2 JLPT_3,DM##q[%RFu
+氏,し,"family name, lineage",JLPT JLPT_2 JLPT_3,LAOK_nHPS/
+詩,し,poem; poetry,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.13,PI;rr><.*1
+幸せ,しあわせ,"happiness, blessing",JLPT JLPT_2 JLPT_3,MYpn~@*11o
+ジーンズ,ジーンズ,jeans,JLPT JLPT_3 JLPT_2 Genki_Ln.2 Genki,o3hhzYEH)l
+ジェット機,ジェットき,jet plane,JLPT JLPT_2 JLPT_3,fS!]EX&j7m
+四角,しかく,square,JLPT JLPT_2 JLPT_3,J[L(f7xE~B
+直に,じかに,"immediately, readily, directly",JLPT JLPT_2 JLPT_3,"Gui,0]IdY5"
+しかも,しかも,"moreover, furthermore, besides, plus",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.9 Intermediate_Japanese_Ln.2,NW!O~u6B#]
+四季,しき,four seasons,JLPT JLPT_2 JLPT_3,j=w0weSQi)
+直,じき,"immediately, soon, shortly",JLPT JLPT_2 JLPT_3,wd?tx<3Bac
+時期,じき,"time, season, period",JLPT JLPT_2 JLPT_3,DJ<W>Fb$j>
+支給,しきゅう,"payment, allowance",JLPT JLPT_2 JLPT_3,MpCDrKuR@c
+至急,しきゅう,"urgent, pressing",JLPT JLPT_2 JLPT_3,"K+,ttKQ<dz"
+しきりに,しきりに,"frequently, repeatedly, eagerly",JLPT JLPT_2 JLPT_3,E|Rw@W(/Em
+刺激,しげき,"stimulus, impetus, incentive",JLPT JLPT_2 JLPT_3,PD*^rLK60i
+資源,しげん,resources,JLPT JLPT_2 JLPT_3,m(PG+T&|gr
+事件,じけん,"event, affair, incident",JLPT JLPT_2 JLPT_3,MbFCnlA+g8
+時刻,じこく,"time, hour",JLPT JLPT_2 JLPT_3,"oN.E,s)Z}n"
+自殺,じさつ,suicide,JLPT JLPT_2 JLPT_3,y#JDw}f8E1
+事実,じじつ,"fact, truth, reality",JLPT JLPT_2 JLPT_3,qUB-Jtt?i`
+支出,ししゅつ,"expenditure, expenses",JLPT JLPT_2 JLPT_3,PrmuroD(_w
+事情,じじょう,"circumstances, situation, reasons",JLPT JLPT_2 JLPT_3,B&D.VmCJRe
+詩人,しじん,poet,JLPT JLPT_2 JLPT_3,J|*bb(L^Qr
+自身,じしん,oneself,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14,Mms_kL$qBA
+沈む,しずむ,to sink; to feel depressed,JLPT JLPT_2 JLPT_3,v(wY-5e=dv
+自然,しぜん,"nature, spontaneous",JLPT JLPT_2 JLPT_3,K#D]Lme)]J
+思想,しそう,"thought, idea",JLPT JLPT_2 JLPT_3,"udM,dvR}EZ"
+舌,した,tongue,JLPT JLPT_2 JLPT_3,i22E-x*lSS
+次第,しだい,order; circumstances; immediate(ly),JLPT JLPT_2 JLPT_3,m7IQESq>:Z
+従う,したがう,"to abide (by the rules), to obey",JLPT JLPT_2 JLPT_3,jQOK[Z2G2a
+したがって,したがって,"therefore, consequently",JLPT JLPT_2 JLPT_3,zE+XZL-yO%
+親しい,したしい,"intimate, close (e.g., friend)",JLPT JLPT_2 JLPT_3,JLb1]#eUH.
+質,しつ,"quality, nature (of person)",JLPT JLPT_2 JLPT_3,i9bGgE8&)u
+失業,しつぎょう,unemployment,JLPT JLPT_2 JLPT_3,L*e(K1S8y>
+湿気,しっけ,"moisture, humidity, dampness",JLPT JLPT_2 JLPT_3,mI:_~nX$Y!
+実験,じっけん,lab work; experiment,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.5,hmPfhao45;
+実現,じつげん,"implementation, materialization, realization",JLPT JLPT_2 JLPT_3,fGH.>rJnym
+実行,じっこう,"practice, execution (e.g., program), realization",JLPT JLPT_2 JLPT_3,O_Qp[P4rQP
+実際,じっさい,in fact; in actuality,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.15,"B6Z:.Y11k,"
+実施,じっし,"enforcement, carry out, operation",JLPT JLPT_2 JLPT_3,dXLqmB^MiP
+湿度,しつど,humidity,JLPT JLPT_2 JLPT_3,lZGX2R~;Bn
+じっと,じっと,"patiently, quietly",JLPT JLPT_2 JLPT_3,Nkvz[eNt`n
+実に,じつに,"indeed, truly, surely",JLPT JLPT_2 JLPT_3,I|OQWMaQog
+実は,じつは,actually; in fact,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.1,s#X::H+4<F
+失望,しつぼう,"disappointment, despair",JLPT JLPT_2 JLPT_3,mi8g|r~Txf
+実力,じつりょく,ability; force,JLPT JLPT_2 JLPT_3,F5g81kES4+
+支店,してん,branch store (office),JLPT JLPT_3 JLPT_2 Genki_Ln.20 Genki,h*O$^StSa>
+指導,しどう,"leadership, guidance, coaching",JLPT JLPT_2 JLPT_3,AKsjeKTYcK
+自動,じどう,"automatic, self-motion",JLPT JLPT_2 JLPT_3,O4.zUw/o_S
+児童,じどう,"children, juvenile",JLPT JLPT_2 JLPT_3,"e,|tEbv]Zq"
+品,しな,"thing, article, goods",JLPT JLPT_2 JLPT_3,bDnAvhtlH7
+支配,しはい,"rule, control, direction",JLPT JLPT_2 JLPT_3,GJx2Cizi1x
+芝居,しばい,"play, drama",JLPT JLPT_2 JLPT_3,gtSlTkyCFW
+しばしば,しばしば,"often, again and again, frequently",JLPT JLPT_2 JLPT_3,oKzAa``eqH
+芝生,しばふ,lawn,JLPT JLPT_2 JLPT_3,"wbx:,PABM*"
+支払,しはらい,payment,JLPT JLPT_2 JLPT_3,Ev?:EQ7Ks`
+支払う,しはらう,to pay,JLPT JLPT_2 JLPT_3,"ND2,<K].}x"
+死亡,しぼう,death,JLPT JLPT_2 JLPT_3,zYjIN3r3C
+資本,しほん,"funds, capital",JLPT JLPT_2 JLPT_3,K]eJp4bmn-
+姉妹,しまい,sisters,JLPT JLPT_2 JLPT_3,D=K+>4{9gs
+しまった (かん),しまった (かん),Damn it!,JLPT JLPT_2 JLPT_3,lG^NNUo)xn
+自慢,じまん,"pride, boast",JLPT JLPT_2 JLPT_3,I/xy:2]J/|
+地味,じみ,"quiet, plain, conservative",JLPT JLPT_2 JLPT_3,o(yU(Vt?_.
+示す,しめす,"to show, to indicate",JLPT JLPT_2 JLPT_3,Jd8*LeirRj
+占める,しめる,to take up; to account for,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14,r`M6Y4!/$F
+湿る,しめる,"to be wet, to be damp",JLPT JLPT_2 JLPT_3,uFiSD0nBbH
+下,しも,"under, below, beneath",JLPT JLPT_2 JLPT_3,"NEdu]f-jA,"
+霜,しも,frost,JLPT JLPT_2 JLPT_3,r%B(k2*%-2
+借金,しゃっきん,"debt, loan, liabilities",JLPT JLPT_2 JLPT_3,HTrhI~ql4k
+しゃべる,しゃべる,"to talk, to chat, to chatter (same as 話す (はなす))",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.8,xm(;YK[sEF
+週,しゅう,week,JLPT JLPT_2 JLPT_3,"x+o,UuIX0t"
+州,しゅう,"state, province",JLPT JLPT_2 JLPT_3,"P_~2Qd-Z,0"
+銃,じゅう,gun,JLPT JLPT_2 JLPT_3,g}R=q_AV`]
+周囲,しゅうい,"surroundings, circumference, environs",JLPT JLPT_2 JLPT_3,k;vO#x`Yq;
+収穫,しゅうかく,"harvest, crop, ingathering",JLPT JLPT_2 JLPT_3,Q1;gC;3=ME
+宗教,しゅうきょう,religion,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.3,h2}ja7i^zZ
+重視,じゅうし,"importance, stress",JLPT JLPT_2 JLPT_3,p)R=DLs-/X
+就職,しゅうしょく,finding employment,JLPT JLPT_2 JLPT_3,G#y*V:{2Bq
+ジュース,ジュース,"juice, soft drink; deuce",JLPT Genki_Ln.12 JLPT_3 JLPT_2 Genki,w1Xid7|yfz
+修正,しゅうせい,"amendment, correction",JLPT JLPT_2 JLPT_3,gUKGu[G9oC
+重体,じゅうたい,"seriously ill, critical state",JLPT JLPT_2 JLPT_3,"F]Ml+g6],&"
+渋滞,じゅうたい,"congestion (e.g., traffic), delay",JLPT JLPT_2 JLPT_3,f6HLmc1`E?
+重大,じゅうだい,"serious, important",JLPT JLPT_2 JLPT_3,bRTiuj?[St
+住宅,じゅうたく,"resident, housing",JLPT JLPT_2 JLPT_3,"bO,.P:9Wr8"
+集団,しゅうだん,"group, mass",JLPT JLPT_2 JLPT_3,O[N$vC_)x(
+集中,しゅうちゅう,"concentration, focusing the mind",JLPT JLPT_2 JLPT_3,z{<Xu{#h*c
+収入,しゅうにゅう,"income, revenue",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14,Ow2ez*OE$v
+住民,じゅうみん,"inhabitants, residents",JLPT JLPT_2 JLPT_3,M3~&[?-]c=
+重要,じゅうよう,"important, essential",JLPT JLPT_2 JLPT_3,d;5d4|x2m2
+修理,しゅうり,"repairing, mending",JLPT JLPT_2 JLPT_3,i2Z^HI-&!g
+主義,しゅぎ,"doctrine, cause, principle",JLPT JLPT_2 JLPT_3,mm(7ICuhH@
+宿泊,しゅくはく,lodging,JLPT JLPT_2 JLPT_3,sJf/S8qo)G
+手術,しゅじゅつ,surgical operation,JLPT JLPT_2 JLPT_3,O=U-eHfq4I
+首相,しゅしょう,Prime Minister,JLPT JLPT_2 JLPT_3,"h%Bt%?=g9,"
+手段,しゅだん,"means, way, measure",JLPT JLPT_2 JLPT_3,cG]JN2+6BK
+主張,しゅちょう,"claim, insistence, assertion",JLPT JLPT_2 JLPT_3,PQKr-g-1[?
+出場,しゅつじょう,participation,JLPT JLPT_2 JLPT_3,u|Gl.@-_{b
+出身,しゅっしん,come from,JLPT JLPT_2 JLPT_3,E~$fFKz?VN
+出版,しゅっぱん,publication,JLPT JLPT_2 JLPT_3,pHGL?y?[mQ
+首都,しゅと,capital city,JLPT JLPT_2 JLPT_3,"pV,3~,Z87["
+主婦,しゅふ,housewife,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.8 Genki_Ln.1 Genki,cu7/mz5_+B
+主要,しゅよう,"chief, main",JLPT JLPT_2 JLPT_3,e/wz>k>*.!
+需要,じゅよう,demand,JLPT JLPT_2 JLPT_3,wIb;!:/d[S
+種類,しゅるい,"variety, kind",JLPT JLPT_2 JLPT_3,yLzP_}wHk~
+順,じゅん,"order, turn",JLPT JLPT_2 JLPT_3,j(7}!qj-R?
+瞬間,しゅんかん,"moment, second",JLPT JLPT_2 JLPT_3,w74BNqe`C[
+順調,じゅんちょう,doing well,JLPT JLPT_2 JLPT_3,QTXqs`sU2C
+順番,じゅんばん,"turn (in line), order of things",JLPT JLPT_2 JLPT_3,"B3?=*++0m,"
+使用,しよう,"use (same as 使うこと (つかうこと)), application, employment, utilization",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.11,"fv),c7#%~v"
+小,しょう,small,JLPT JLPT_2 JLPT_3,He3e1#-/kV
+章,しょう,"chapter, section; medal",JLPT JLPT_2 JLPT_3,Cp$qz7LRQ1
+賞,しょう,"prize, award",JLPT JLPT_2 JLPT_3,ixda5oQQ=r
+上,じょう,first volume; superior quality; governmental,JLPT JLPT_2 JLPT_3,bjtdx{-WQ5
+障害,しょうがい,"obstacle, impediment",JLPT JLPT_2 JLPT_3,lN`%jCJ3Cv
+奨学金,しょうがくきん,scholarship,Genki_Ln.16 JLPT JLPT_3 JLPT_2 Genki,Q-*B#$A6L:
+乗客,じょうきゃく,passenger,JLPT JLPT_2 JLPT_3,F?2lxj<[^L
+上京,じょうきょう,proceeding to the capital (Tokyo),JLPT JLPT_2 JLPT_3,EmcG8c7y3D
+状況,じょうきょう,"state of affairs, situation",JLPT JLPT_2 JLPT_3,eJ+`w-qU@C
+条件,じょうけん,"conditions, terms",JLPT JLPT_2 JLPT_3,PesF@2hHde
+正午,しょうご,"noon, mid-day",JLPT JLPT_2 JLPT_3,i0$lSUJ-1J
+正直,しょうじき,"honesty, integrity, frankness",JLPT JLPT_2 JLPT_3,l~d^29Cn=%
+常識,じょうしき,common sense,JLPT JLPT_2 JLPT_3,b?[*`UKS8R
+少女,しょうじょ,young girl,JLPT JLPT_2 JLPT_3,lN;?Tr6q{x
+少々,しょうしょう,a little; short (time) (formal for 少し (すこし)),JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.8 Genki_Ln.20 Genki,Ievwu]EUfz
+症状,しょうじょう,"symptoms, condition",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.12,v+Eb}=L(fE
+生じる,しょうじる,"to occur, to arise, to be generated",JLPT JLPT_2 JLPT_3,"F/qG4,c8v/"
+状態,じょうたい,"condition, situation",JLPT JLPT_2 JLPT_3,u!E?FPG-@p
+上達,じょうたつ,"improvement, advance",JLPT JLPT_2 JLPT_3,Cc{1AI[wlm
+冗談,じょうだん,a joke,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.10,CllWuV2>%{
+上等,じょうとう,"first class, very good",JLPT JLPT_2 JLPT_3,tjn_MUpJQp
+衝突,しょうとつ,"collision, conflict",JLPT JLPT_2 JLPT_3,D@=pGn%86P
+商人,しょうにん,"trader, shopkeeper, merchant",JLPT JLPT_2 JLPT_3,MlJB*>A^h!
+承認,しょうにん,"recognition, approval",JLPT JLPT_2 JLPT_3,"N==,~orf~["
+少年,しょうねん,"boys, juveniles",JLPT JLPT_2 JLPT_3,p6fQoD5WK;
+商売,しょうばい,"trade, business, commerce",JLPT JLPT_2 JLPT_3,"LoHl,.u1Y|"
+消費,しょうひ,"consumption, expenditure",JLPT JLPT_2 JLPT_3,r7nT91%)]@
+商品,しょうひん,"commodity, merchandise",JLPT JLPT_2 JLPT_3,w+UOx&@[sL
+賞品,しょうひん,"prize, trophy",JLPT JLPT_2 JLPT_3,M}I~*8Gv<&
+消防,しょうぼう,"fire fighting, fire department",JLPT JLPT_2 JLPT_3,u20O%VZ|ID
+情報,じょうほう,"information, (military) intelligence",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.3,cpG:I1X!x-
+証明,しょうめい,"proof, verification",JLPT JLPT_2 JLPT_3,l8;-B$4N!G
+省略,しょうりゃく,"omission, abbreviation, abridgment",JLPT JLPT_2 JLPT_3,jp1y&-#kyn
+女王,じょおう,queen,JLPT JLPT_2 JLPT_3,furG^[#|I<
+職,しょく,employment,JLPT JLPT_2 JLPT_3,"hJY}5,Qu8j"
+職業,しょくぎょう,"occupation, business",JLPT JLPT_2 JLPT_3,tU=ntM)WP{
+食卓,しょくたく,dining table,JLPT JLPT_2 JLPT_3,o})uu+vtqN
+食品,しょくひん,foodstuff,JLPT JLPT_2 JLPT_3,iU(>r<G;@0
+植物,しょくぶつ,"plant, vegetation",JLPT JLPT_2 JLPT_3,mpdopLG{vR
+食物,しょくもつ,"food, foodstuff",JLPT JLPT_2 JLPT_3,KrMVp?T5YJ
+食欲,しょくよく,appetite (for food),JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.12,qt1GC>c)@^
+食料,しょくりょう,food,JLPT JLPT_2 JLPT_3,"k76m(C.Z,~"
+食糧,しょくりょう,"provisions, rations",JLPT JLPT_2 JLPT_3,"e~`&J:],P}"
+書斎,しょさい,"study, den",JLPT JLPT_2 JLPT_3,z(Zi=4k7-t
+女子,じょし,"woman, girl",JLPT JLPT_2 JLPT_3,y}`qNApt9R
+助手,じょしゅ,"helper, assistant",JLPT JLPT_2 JLPT_3,F9rI>UKU}`
+徐々に,じょじょに,"slowly, little by little",JLPT JLPT_2 JLPT_3,Ik@-$!%)*d
+署名,しょめい,signature,JLPT JLPT_2 JLPT_3,"C)w4*u^eJ,"
+書物,しょもつ,books,JLPT JLPT_2 JLPT_3,dsq%HW0O`l
+女優,じょゆう,actress,JLPT JLPT_2 JLPT_3,g6/0nLbYEk
+処理,しょり,"processing, treatment, disposition",JLPT JLPT_2 JLPT_3,"n-}WPF,.CB"
+書類,しょるい,"documents, official papers",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14 Genki_Ln.22 Genki,Ehj{.OHy`#
+知らせ,しらせ,notice,JLPT JLPT_2 JLPT_3,tE;LJdiq{b
+尻,しり,"buttocks, bottom",JLPT JLPT_2 JLPT_3,Cp-T01W>>7
+知合い,しりあい,acquaintance,JLPT JLPT_2 JLPT_3,Jz(h+XVbH4
+印,しるし,mark; symbol; evidence,JLPT JLPT_2 JLPT_3,F?8:NFp=(i
+城,しろ,castle,JLPT JLPT_2 JLPT_3,GnhkX+7b^.
+進学,しんがく,going on to university,JLPT JLPT_2 JLPT_3,p#!GLXFzk~
+神経,しんけい,"nerve, sensitivity",JLPT JLPT_2 JLPT_3,"mz&,NqxuZ0"
+真剣,しんけん,"seriousness, earnestness",JLPT JLPT_2 JLPT_3,PuRLKa9@q(
+信仰,しんこう,"(religious) faith, belief",JLPT JLPT_2 JLPT_3,g~oH1SUq[>
+信号,しんごう,"traffic lights, signal, semaphore",JLPT JLPT_3 JLPT_2 Genki_Ln.20 Genki,z?zKX+/#?f
+人工,じんこう,"artificial, man made, human work,",JLPT JLPT_2 JLPT_3,zQ3t>E=&2U
+深刻,しんこく,serious,JLPT JLPT_2 JLPT_3,Kel_M-JGRX
+診察,しんさつ,medical examination (of a patient),JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.12,Mx*u-x#R2}
+人種,じんしゅ,race (of people),JLPT JLPT_2 JLPT_3,Mm&n`P$vPl
+信じる,しんじる,to believe,JLPT JLPT_2 JLPT_3,E~EJs-CkJ`
+人生,じんせい,"(human) life (e.g., conception to death)",JLPT JLPT_2 JLPT_3,G{?]K0G%It
+親戚,しんせき,relative(s),Genki_Ln.16 JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.9 Genki,f;-yjmPO85
+新鮮,しんせん,fresh,JLPT JLPT_2 JLPT_3,hgsIFo;k1C
+心臓,しんぞう,heart,JLPT JLPT_2 JLPT_3,FBeXkqV5hu
+身体,しんたい,the body,JLPT JLPT_2 JLPT_3,t3y~q`<OO!
+身長,しんちょう,"height (of body), stature",JLPT JLPT_2 JLPT_3,v2>$s!00R?
+慎重,しんちょう,"careful, prudent, cautious",JLPT JLPT_2 JLPT_3,H{qX;#1p@y
+審判,しんぱん,"umpire, referee, judgment",JLPT JLPT_2 JLPT_3,"i+^OoCXV,-"
+人物,じんぶつ,"character, personality, talented man",JLPT JLPT_2 JLPT_3,OXSwNDOM:u
+進歩,しんぽ,"improvement, progress, development",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.13,C*Oco$5$I7
+親友,しんゆう,"close friend, buddy",JLPT JLPT_2 JLPT_3,e!XKqiS_]u
+信用,しんよう,"confidence, dependence",JLPT JLPT_2 JLPT_3,D_Xu621X(*
+信頼,しんらい,"reliance, trust, confidence",JLPT JLPT_2 JLPT_3,Cc(neZE[/;
+心理,しんり,mentality,JLPT JLPT_2 JLPT_3,M4-pHm{8Hp
+人類,じんるい,"mankind, humanity",JLPT JLPT_2 JLPT_3,yGfC3NH0c~
+巣,す,"nest, breeding place",JLPT JLPT_2 JLPT_3,wae)m$%B2U
+酢,す,vinegar,JLPT JLPT_2 JLPT_3,S|>MWw8{x
+図,ず,"figure, drawing, illustration",JLPT JLPT_2 JLPT_3,o=i@Vi;`4G
+水準,すいじゅん,"level, standard",JLPT JLPT_2 JLPT_3,LrR5Wf1Z7N
+推薦,すいせん,recommendation,JLPT JLPT_2 JLPT_3,jvDU?eC@&E
+スイッチ,スイッチ,switch,JLPT Genki_Ln.18 JLPT_3 JLPT_2 Genki,D+{$1{/[wR
+睡眠,すいみん,sleep,JLPT JLPT_2 JLPT_3,wh0!*D%WvE
+数,すう,"number, figure",JLPT JLPT_2 JLPT_3,J]}my?o<Q!
+数字,すうじ,"numeral, figure",JLPT JLPT_2 JLPT_3,B[Gra1kO)v
+スープ,スープ,(Western) soup,JLPT JLPT_2 JLPT_3,"s,J:5SYdW2"
+末,すえ,"the end of, powder",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.4,EyKo./;AAl
+姿,すがた,"figure, shape, appearance",JLPT JLPT_2 JLPT_3,gTn!6ZHkYs
+スキー,スキー,ski,JLPT JLPT_3 JLPT_2 Genki_Ln.9 Genki,EDq$^7+uK~
+救う,すくう,"to rescue from, to help out of",JLPT JLPT_2 JLPT_3,Pzdj_}ruVB
+すくなくとも,すくなくとも,at least,JLPT JLPT_2 JLPT_3,s64aNUZ0&F
+優れる,すぐれる,"to surpass, to outstrip, to excel",JLPT JLPT_2 JLPT_3,"fFuIf,@I[N"
+スケート,スケート,"skate(s), skating",JLPT JLPT_2 JLPT_3,DQ0-nYW7>.
+スケジュール,スケジュール,schedule,JLPT JLPT_2 JLPT_3,m}P~NJ788C
+少しも,すこしも,"anything of, not one bit",JLPT JLPT_2 JLPT_3,pSmTW}7_?}
+過ごす,すごす,"to pass, to spend (time)",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.11,oE9$X-z%xN
+筋,すじ,"muscle, string, line",JLPT JLPT_2 JLPT_3,M#_TzTBk6]
+進める,すすめる,"to advance, to promote, to hasten",JLPT JLPT_2 JLPT_3,u2l`IqNk23
+勧める,すすめる,"to urge (someone) to do (something), to recommend",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.13,"IBeh,nV1Dt"
+スター,スター,star,JLPT JLPT_2 JLPT_3,hHJocr{1ix
+スタイル,スタイル,style,JLPT JLPT_2 JLPT_3,wQruLdJqJI
+スタンド,スタンド,stand,JLPT JLPT_2 JLPT_3,"Qz:R,pd5SR"
+頭痛,ずつう,headache,JLPT JLPT_2 JLPT_3,hcxF9uQ5ZX
+ずっと,ずっと,for a long time; all the time; consecutively,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.5 Genki_Ln.22 Genki,OCoZDHO:^u
+すっぱい,すっぱい,"sour, acid",JLPT JLPT_2 JLPT_3,d)l(J.2Nu=
+すてき,すてき,"lovely, great",JLPT JLPT_2 JLPT_3,B~-XSf&NNC
+既に,すでに,already (same as もう),JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.13,d=:dSSUK:`
+すなわち,すなわち,"that is, namely, e.g.",JLPT JLPT_2 JLPT_3,zS=.lQe1_+
+スピーチ,スピーチ,speech,JLPT JLPT_3 JLPT_2 Genki Genki_Ln.21,pvM3{8vA`1
+全て,すべて,"all, the whole, entirely",JLPT JLPT_2 JLPT_3,kq!H^iT|N4
+済ませる,すませる,to be finished,JLPT JLPT_2 JLPT_3,vQUpvSA005
+角,すみ,corner,JLPT JLPT_2 JLPT_3,b^^N<lR$T]
+墨,すみ,ink,JLPT JLPT_2 JLPT_3,Pt>IB]Y%[8
+すみません (かん),すみません (かん),"sorry, excuse me",JLPT JLPT_2 JLPT_3,Kr6X0TH7=(
+澄む,すむ,"to clear (e.g., weather), to become transparent",JLPT JLPT_2 JLPT_3,d^/yYeQD1M
+清む,すむ,"to clear (e.g., weather), to become transparent",JLPT JLPT_2 JLPT_3,wMyt{WAjxX
+刷る,する,to print,JLPT JLPT_2 JLPT_3,MuPBNA;83U
+為る,する,"to do, to attempt",JLPT JLPT_2 JLPT_3,z;FwzGK-v+
+鋭い,するどい,"pointed, sharp",JLPT JLPT_2 JLPT_3,s@c[Ya@R|h
+すれ違う,すれちがう,to pass by one another,JLPT JLPT_2 JLPT_3,fP+0(@n(JZ
+ずれる,ずれる,"move, off the point",JLPT JLPT_2 JLPT_3,F2j?XV=5UF
+正,せい,"(logical) true, regular",JLPT JLPT_2 JLPT_3,AC@`-8Z+qv
+生,せい,birth,JLPT JLPT_2 JLPT_3,"yDy>Z9R,FJ"
+性,せい,"sex, gender",JLPT JLPT_2 JLPT_3,Gy*nj#x|I/
+姓,せい,"surname, family name",JLPT JLPT_2 JLPT_3,"sO,Mg|Q.hG"
+所為,せい,"cause, reason, fault",JLPT JLPT_2 JLPT_3,yy|zc*n):n
+税,ぜい,tax,JLPT JLPT_2 JLPT_3,eEs:NyUxEV
+性格,せいかく,"character, personality",JLPT Intermediate_Japanese Genki_Ln.19 JLPT_3 JLPT_2 Genki Intermediate_Japanese_Ln.3,l3(d&u3o-<
+正確,せいかく,"accurate, punctuality, exact",JLPT JLPT_2 JLPT_3,rg^|Ktq*}h
+世紀,せいき,century,JLPT JLPT_2 JLPT_3,MQfIjnh7j}
+請求,せいきゅう,"claim, demand, request",JLPT JLPT_2 JLPT_3,KNbh$sySYl
+税金,ぜいきん,"tax, duty",Genki_Ln.15 JLPT JLPT_3 JLPT_2 Genki,Ah}s1$;.$[
+清潔,せいけつ,clean,JLPT JLPT_2 JLPT_3,vJiZ-)))FJ
+制限,せいげん,"restriction, restraint, limitation",JLPT JLPT_2 JLPT_3,P3D^cMd_|f
+成功,せいこう,"success, hit",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.12,bkv%QuVn22
+正式,せいしき,"official, formal",JLPT JLPT_2 JLPT_3,zSQ*)G#Yvj
+性質,せいしつ,"nature, property, disposition",JLPT JLPT_2 JLPT_3,E(70}4c-m*
+精神,せいしん,"mind, soul, spirit",JLPT JLPT_2 JLPT_3,tLy]a8CB9?
+成人,せいじん,adult,JLPT JLPT_2 JLPT_3,"g@,iQ!8;."
+精々,せいぜい,"at the most, at best",JLPT JLPT_2 JLPT_3,q[aqj]#7$-
+成績,せいせき,"grade (i.e., on a test), academic record",JLPT Genki_Ln.12 Intermediate_Japanese JLPT_3 JLPT_2 Genki Intermediate_Japanese_Ln.3,o4$BUl?TFA
+製造,せいぞう,"manufacture, production",JLPT JLPT_2 JLPT_3,OAvZo`.~[q
+贅沢,ぜいたく,"luxury, extravagance",JLPT JLPT_2 JLPT_3,"iRbk]j,(Bl"
+成長,せいちょう,growth,JLPT JLPT_2 JLPT_3,lSq)ru5`@&
+生長,せいちょう,growth,JLPT JLPT_2 JLPT_3,G5ys*Os]kn
+制度,せいど,"system, institution",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14,]d3#w;wAU
+青年,せいねん,"youth, young man",JLPT JLPT_2 JLPT_3,r|D|m%Ih@3
+生年月日,せいねんがっぴ,birth date,JLPT JLPT_2 JLPT_3,H8|M5HOte?
+製品,せいひん,"manufactured goods, finished goods",JLPT JLPT_2 JLPT_3,GY93^mZ;)a
+政府,せいふ,"government, administration",JLPT Intermediate_Japanese Genki JLPT_3 JLPT_2 Intermediate_Japanese_Ln.15 Genki_Ln.21,zDQAHO%nD/
+生物,せいぶつ,"living thing, organism",JLPT JLPT_2 JLPT_3,nx3;swk;nm
+生命,せいめい,life,JLPT JLPT_2 JLPT_3,HfE8+JV[><
+整理,せいり,"sorting, arrangement",JLPT JLPT_2 JLPT_3,zlHgN/N7&U
+咳,せき,cough,JLPT Genki_Ln.12 JLPT_3 JLPT_2 Genki,yQ$e7`wCNr
+石炭,せきたん,coal,JLPT JLPT_2 JLPT_3,t&C>c}0]R(
+責任,せきにん,"duty, responsibility",JLPT JLPT_2 JLPT_3,HKrlH:Fl)i
+石油,せきゆ,"oil, petroleum, kerosene",JLPT JLPT_2 JLPT_3,"gJm,E%Jb`a"
+世間,せけん,"world, society",JLPT JLPT_2 JLPT_3,pFmc#=7y9*
+説,せつ,theory,JLPT JLPT_2 JLPT_3,kNv(nqwBQ3
+積極的,せっきょくてき,"positive, active, proactive",JLPT JLPT_2 JLPT_3,zQ[EQ]wde[
+設計,せっけい,"plan, design",JLPT JLPT_2 JLPT_3,i>to8js@e$
+絶対,ぜったい,"definitely, without fail, absoluteness",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.7,"g,<A9qJmV)"
+セット,セット,set,JLPT JLPT_2 JLPT_3,qu4w*^0<Ni
+愛,あい,love,JLPT JLPT_2 JLPT_3,hFW1YrLt0]
+相変わらず,あいかわらず,"as ever, as usual",JLPT JLPT_2 JLPT_3,Ojow^*$or
+愛情,あいじょう,"love, affection",JLPT JLPT_2 JLPT_3,Qzcx!}<3R3
+合図,あいず,"sign, signal",JLPT JLPT_2 JLPT_3,fU+XD$S~|s
+アイスクリーム,アイスクリーム,ice cream,JLPT JLPT_2 JLPT_3,NP9A]*VE%:
+愛する,あいする,to love,JLPT JLPT_2 JLPT_3,DeM>~uF)IC
+相手,あいて,partner; addressee; the person you are talking to,Genki Genki_Ln.22 Intermediate_Japanese Intermediate_Japanese_Ln.2 JLPT JLPT_2 JLPT_3,y[.4]/S_M)
+あいにく,あいにく,unfortunately,JLPT JLPT_2 JLPT_3,hzWiJ*CbeE
+遭う,あう,"to meet, to encounter (undesirable nuance)",JLPT JLPT_2 JLPT_3,5(WM8:K%>
+アウト,アウト,out,JLPT JLPT_2 JLPT_3,l:i}>N{A|}
+明かり,あかり,"lamplight, light (in general)",JLPT JLPT_2 JLPT_3,evqBji16kk
+空き,あき,"vacancy, opening, space",JLPT JLPT_2 JLPT_3,o4~on{17B&
+明らか,あきらか,"obvious, clear",JLPT JLPT_2 JLPT_3,xr&[9MdyXM
+諦める,あきらめる,"to give up, to abandon",Genki Genki_Ln.14 Intermediate_Japanese Intermediate_Japanese_Ln.13 JLPT JLPT_2 JLPT_3,cVjy7W5yAS
+飽きる,あきる,"to get tired of, to lose interest in",JLPT JLPT_2 JLPT_3,MTVy#<!xxJ
+握手,あくしゅ,handshake,JLPT JLPT_2 JLPT_3,BX@vSTsJMQ
+悪魔,あくま,"devil, demon, evil spirit",JLPT JLPT_2 JLPT_3,gY|8LCMcvD
+明ける,あける,"to dawn, to become daylight",JLPT JLPT_2 JLPT_3,QYMAJT+i|R
+揚げる,あげる,"to lift, to fry",JLPT JLPT_2 JLPT_3,kDT9EKS)@x
+挙げる,あげる,"to raise; to list, to cite",JLPT JLPT_2 JLPT_3,"GPil,F&M@,"
+預かる,あずかる,to keep (something) for (someone),Intermediate_Japanese Intermediate_Japanese_Ln.10 JLPT JLPT_2 JLPT_3,n!!dea66oU
+預ける,あずける,"to give into custody, to deposit",JLPT JLPT_2 JLPT_3,ITjUmdJ?SA
+汗,あせ,"sweat, perspiration",JLPT JLPT_2 JLPT_3,L.:p?!w~-_
+与える,あたえる,to give,Intermediate_Japanese Intermediate_Japanese_Ln.5 JLPT JLPT_2 JLPT_3,GyK@0^nn9D
+温かい,あたたかい,warm,JLPT JLPT_2 JLPT_3,QwQJvr;Yu/
+暖まる,あたたまる,to warm up,JLPT JLPT_2 JLPT_3,cRMS.07iEY
+温まる,あたたまる,"to warm oneself, to get warm",JLPT JLPT_2 JLPT_3,Cc_8n~b{Xr
+暖める,あたためる,"to warm (up to someone/something), to heat (up to someone/something)",JLPT JLPT_2 JLPT_3,c^bO3wi-j`
+温める,あたためる,"to warm, to heat",JLPT JLPT_2 JLPT_3,nR%K+*);#2
+辺り,あたり,"vicinity, nearby",Intermediate_Japanese Intermediate_Japanese_Ln.6 JLPT JLPT_2 JLPT_3,Nhf6;`GIs6
+当たり前,あたりまえ,"usual, common, obvious",JLPT JLPT_2 JLPT_3,"F|qH}g,OWJ"
+当たる,あたる,"to be hit, to be successful",JLPT JLPT_2 JLPT_3,c~5${Vgwlg
+あちこち,あちこち,here and there,JLPT JLPT_2 JLPT_3,zllf&_UO$c
+扱う,あつかう,"to treat, to handle, to deal with",Intermediate_Japanese Intermediate_Japanese_Ln.14 JLPT JLPT_2 JLPT_3,"o08cD,?4sA"
+集まり,あつまり,"gathering, meeting, collection",JLPT JLPT_2 JLPT_3,jBK/@[g6Hm
+当てる,あてる,to hit; to apply to,JLPT JLPT_2 JLPT_3,z-r@1e!?]p
+跡,あと,trace; remains; scar,JLPT JLPT_2 JLPT_3,q{EbQ0$xa;
+穴,あな,hole,JLPT JLPT_2 JLPT_3,J_{zaxL58i
+油,あぶら,oil,JLPT JLPT_2 JLPT_3,h++g*X+)DT
+脂,あぶら,fat,JLPT JLPT_2 JLPT_3,yaI6J=&24M
+誤り,あやまり,error,JLPT JLPT_2 JLPT_3,Q&O=zHLH43
+粗,あら,"defect, flaw, fault",JLPT JLPT_2 JLPT_3,uo3L]S3}+n
+嵐,あらし,storm,JLPT JLPT_2 JLPT_3,"x>[,-C/.7:"
+争う,あらそう,"to dispute, to argue, to fight",JLPT JLPT_2 JLPT_3,gCt~zB/0M*
+新た,あらた,"new, fresh",JLPT JLPT_2 JLPT_3,vUk>5+m4>^
+あらゆる,あらゆる,"all, every",JLPT JLPT_2 JLPT_3,fRH=B?!]8k
+表す,あらわす,"to express, to show",JLPT JLPT_2 JLPT_3,J4D9:Mg)~^
+現す,あらわす,"to show, to appear, to reveal",JLPT JLPT_2 JLPT_3,"J};,Fjv6&g"
+著す,あらわす,"to write, to publish",JLPT JLPT_2 JLPT_3,A}kQPl<:b_
+現れ,あらわれ,"expression, indication, sign",JLPT JLPT_2 JLPT_3,wIR$)+P>p)
+現れる,あらわれる,"to appear (v.i.), to become visible; to express",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.8,uNu]Gn1cS@
+ありがとう,ありがとう,Thank you,JLPT JLPT_2 JLPT_3,"BCk,]QT,C;"
+在る; 有る,ある,"to live, to be, to exist",JLPT JLPT_2 JLPT_3,ugXsXN3GZ/
+或,ある,"a certain..., some...",JLPT JLPT_2 JLPT_3,fPA~S.(r2^
+あるいは,あるいは,"or, perhaps",JLPT JLPT_2 JLPT_3,GpvtMObv5I
+アルバム,アルバム,album,JLPT JLPT_2 JLPT_3,LY~;26p.Bn
+泡,あわ,"bubble, foam",JLPT JLPT_2 JLPT_3,xuN<Cc$=0q
+合わせる,あわせる,to combine,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14,I=R#`?=:d[
+慌てる,あわてる,to become confused、to panic,JLPT JLPT_2 JLPT_3,QKvMMW7GPN
+哀れ,あわれ,"helpless, pity, pathetic",JLPT JLPT_2 JLPT_3,Di(vg]NB]7
+案,あん,"plan, scheme, proposal",JLPT JLPT_2 JLPT_3,wa#Lw#FwSj
+案外,あんがい,unexpectedly,JLPT JLPT_2 JLPT_3,c{:][-]9cx
+暗記,あんき,"memorization, learning by heart",JLPT JLPT_2 JLPT_3,J|(sO>=G;)
+安定,あんてい,"stability, equilibrium",JLPT JLPT_2 JLPT_3,tq=A(a}mBR
+あんなに,あんなに,"to that extent, to that degree",JLPT JLPT_2 JLPT_3,qL7ozV1EL!
+あんまり,あんまり,"not very, not much",JLPT JLPT_2 JLPT_3,nQM2*X0Uly
+胃,い,stomach,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.12,J;|<l]nldO
+委員,いいん,committee member,JLPT JLPT_2 JLPT_3,"yw,e]%D0#"
+意外,いがい,"unexpected, surprising",JLPT JLPT_2 JLPT_3,w~HVZz5(Yv
+行き,いき,going,JLPT JLPT_2 JLPT_3,sv:5&WPn~-
+行き,ゆき,going,JLPT JLPT_2 JLPT_3,Qo3!wH.:.8
+息,いき,breath,JLPT JLPT_2 JLPT_3,Mg6)U{FFzO
+勢い,いきおい,"force, vigor, momentum",JLPT JLPT_2 JLPT_3,b/)jjg52IA
+生き物,いきもの,"living thing, creature",JLPT JLPT_2 JLPT_3,cJD+|G`QOg
+いけない,いけない,"must not do, bad, wrong",JLPT JLPT_2 JLPT_3,rH~_kL3NSH
+医師,いし,"doctor, physician",JLPT JLPT_2 JLPT_3,L]3urgx$u7
+意思,いし,"intention, purpose",JLPT JLPT_2 JLPT_3,GeK4#dpi2R
+意志,いし,"will, volition",JLPT JLPT_2 JLPT_3,F^=nB=4_Bt
+維持,いじ,"maintenance, preservation",JLPT JLPT_2 JLPT_3,NkxQSQGjpb
+意識,いしき,"consciousness, senses",JLPT JLPT_2 JLPT_3,B.j@@N??C@
+異常,いじょう,"strangeness, abnormality, disorder",JLPT JLPT_2 JLPT_3,O08lYk-IK<
+意地悪,いじわる,"malicious, mean, unkind",JLPT JLPT_2 JLPT_3,Q2_n%:>L!6
+泉,いずみ,"spring, fountain",JLPT JLPT_2 JLPT_3,l*ms=cUi*A
+いずれ,いずれ,"where, which, who",JLPT JLPT_2 JLPT_3,tyll~{/>;}
+以前,いぜん,in the past; before,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.15,vzioeTDgh&
+板,いた,"board, plank",JLPT JLPT_2 JLPT_3,rTsp9B=&#y
+偉大,いだい,greatness,JLPT JLPT_2 JLPT_3,Dj58mSmcXd
+抱く,いだく,"to hold (v.t.) (written expression), to embrace, to harbor",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.8,bnBW}<VC5Y
+いたずら,いたずら,"trick, practical joke",JLPT JLPT_2 JLPT_3,GffoWqmg)Q
+いただきます,いただきます,expression of gratitude before meals,JLPT JLPT_2 JLPT_3,jhTihku]b|
+痛み,いたみ,"pain, ache, sore",JLPT JLPT_2 JLPT_3,fCH])@V^N}
+至る,いたる,"to come, to arrive",JLPT JLPT_2 JLPT_3,go_hN=pqmn
+市,いち,"market, fair",JLPT_1 JLPT JLPT_2 JLPT_3,b}j[=OS2%d
+位置,いち,"place, position",JLPT JLPT_2 JLPT_3,rRL{bp[klU
+一時,いちじ,"for a time, temporarily",JLPT JLPT_2 JLPT_3,rZn?lv+;:4
+一度に,いちどに,all at once,JLPT JLPT_2 JLPT_3,AK)V=Yq3mS
+市場,いちば,"market, bazaar",JLPT JLPT_2 JLPT_3,DBqN2uJ#li
+いつか,いつか,"sometime, one day",JLPT JLPT_2 JLPT_3,FR_y9u}n#<
+一家,いっか,"family, clan",JLPT JLPT_2 JLPT_3,l/wm^:qD$x
+一種,いっしゅ,"a species, a kind, a variety",JLPT JLPT_2 JLPT_3,sn._eGR[}-
+一瞬,いっしゅん,"a moment, an instant",JLPT JLPT_2 JLPT_3,Qq!{_/r0wa
+一生,いっしょう,throughout (one's) life,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.8,AtHZ6K9AwM
+一層,いっそう,"much more, still more",JLPT JLPT_2 JLPT_3,CjCbT!QO~}
+一体,いったい,one object; body; what on earth?; generally,JLPT JLPT_2 JLPT_3,K?hP0<cU>&
+一致,いっち,agreement; conformity,JLPT JLPT_2 JLPT_3,ysxIQslQyD
+いつでも,いつでも,"(at) any time, always",JLPT JLPT_2 JLPT_3,N>sX%eJi!w
+いつのまにか,いつのまにか,before one knows,JLPT JLPT_2 JLPT_3,D<V5f@i{!T
+一般,いっぱん,"general, average",JLPT JLPT_2 JLPT_3,mhggl5@LT?
+一方,いっぽう,on the other hand; meanwhile,JLPT JLPT_2 JLPT_3,ta7h-#VP%b
+いつまでも,いつまでも,"forever, for good, eternally",JLPT JLPT_2 JLPT_3,r@zE/Lc+82
+移動,いどう,"migration, movement",JLPT JLPT_2 JLPT_3,yz:o#%V|;@
+従兄弟,いとこ,cousin (male),JLPT JLPT_2 JLPT_3,CcBJPKt<s5
+従姉妹,いとこ,cousin (female),JLPT JLPT_2 JLPT_3,s78r`;/ON~
+稲,いね,rice-plant,JLPT JLPT_2 JLPT_3,HQD[kKI--m
+居眠り,いねむり,"dozing, nodding off",JLPT JLPT_2 JLPT_3,p&}.agckN6
+命,いのち,life,JLPT JLPT_2 JLPT_3,"z7V@a,~`Re"
+違反,いはん,"violation (of law), infringement",JLPT JLPT_2 JLPT_3,jOqAs(GP-H
+衣服,いふく,clothes,JLPT JLPT_2 JLPT_3,pHoA66%Mk&
+居間,いま,living room,JLPT JLPT_2 JLPT_3,G/@=.gt:M?
+今に,いまに,"before long, soon",JLPT JLPT_2 JLPT_3,E1NlCS5^&;
+今にも,いまにも,"at any time, soon",JLPT JLPT_2 JLPT_3,Kiwg*7Fayc
+イメージ,イメージ,one's image,JLPT JLPT_2 JLPT_3,m5PWtQuC8
+否,いや,"no, the noes",JLPT JLPT_2 JLPT_3,t%b|d?y!x;
+以来,いらい,"since, henceforth",JLPT JLPT_2 JLPT_3,wKMM5>=Rhf
+依頼,いらい,request; dependence,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.15,"A,;GX*Z1pN"
+いらいら,いらいら,"getting nervous, irritation",JLPT JLPT_2 JLPT_3,cX)s!En;S_
+いらっしゃい,いらっしゃい,welcome,JLPT JLPT_2 JLPT_3,c2%8d/UU0k
+医療,いりょう,"medical care, medical treatment",JLPT JLPT_2 JLPT_3,kJzii8E*wG
+岩,いわ,rock,JLPT JLPT_2 JLPT_3,G|eL<b]=]q
+祝い,いわい,"celebration, festival",JLPT JLPT_2 JLPT_3,GZfmX5Jx8(
+祝う,いわう,"to congratulate, to celebrate",JLPT JLPT_2 JLPT_3,X@UPs?&].
+言わば,いわば,so to speak,JLPT JLPT_2 JLPT_3,ISB~|Yz?TD
+いわゆる,いわゆる,"the so-called, so-to-speak",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14,pIL=hHO-Je
+インク,インク,ink,JLPT JLPT_2 JLPT_3,q1l^_2FS@C
+印刷,いんさつ,printing,JLPT JLPT_2 JLPT_3,M!0uun/z}U
+印象,いんしょう,impression,JLPT JLPT_2 JLPT_3,Q*RbG8|1@p
+引退,いんたい,retirement,JLPT JLPT_2 JLPT_3,CiE>>/IlUa
+インタビュー,インタビュー,interview,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.15,Lr#jpXZo&{
+引用,いんよう,"quotation, citation",JLPT JLPT_2 JLPT_3,mgmTGyy@R!
+ウイスキー,ウイスキー,whiskey,JLPT JLPT_2 JLPT_3,pU);qhPs)v
+上,うわ,"upper, outer, surface",JLPT JLPT_2 JLPT_3,Alx@.Upj.V
+魚,うお,fish,JLPT JLPT_2 JLPT_3,"OhV1B,p7lY"
+うがい,うがい,gargling,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.12,k@]kPJW~yl
+受け取る,うけとる,"to receive, to get, to accept",JLPT JLPT_2 JLPT_3,"Jr/,h++/bg"
+動かす,うごかす,"to move, to shift",JLPT JLPT_2 JLPT_3,NB>1{PM|;}
+兎,うさぎ,"rabbit, hare",JLPT JLPT_2 JLPT_3,"fu:N<z:T,%"
+牛,うし,"cattle, cow",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.10,f~4k*~tyLI
+失う,うしなう,"to lose, to part with",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14,pYDJ7QMJY3
+疑う,うたがう,"to doubt, to distrust",JLPT JLPT_2 JLPT_3,rNjW1$Ny&Q
+宇宙,うちゅう,"universe, cosmos, space",JLPT JLPT_2 JLPT_3,z$:a2a^Sj:
+討つ,うつ,"to attack, to avenge",JLPT JLPT_2 JLPT_3,PyYz(3~uk@
+撃つ,うつ,"to attack, to shoot",JLPT JLPT_2 JLPT_3,E~&l5[EXS/
+うっかり,うっかり,carelessly; inadvertently,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.15,e}eZDDJ?#=
+映す,うつす,"to project, to reflect, to cast (shadow)",JLPT JLPT_2 JLPT_3,v%$=^xk|L|
+訴える,うったえる,"to complain, to appeal, to sue (a person)",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.12,q3vDC2@R>l
+写る,うつる,"to be photographed, to be projected",JLPT JLPT_2 JLPT_3,CI<Sr}lwt|
+映る,うつる,"to be reflected, to come out (photo)",JLPT JLPT_2 JLPT_3,b:A%=5OyPu
+うなる,うなる,"to groan, to moan",JLPT JLPT_2 JLPT_3,s+o0tk>SxK
+奪う,うばう,"to rob, to deprive",JLPT JLPT_2 JLPT_3,wyO.=2:4&2
+馬,うま,horse; promoted bishop (in Japanese chess known as shogi),JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.10,I-Qwz&8r5B
+生まれ,うまれ,"birth, birth-place",JLPT JLPT_2 JLPT_3,deVvQ9]dKk
+有無,うむ,"yes or no, presence or absence",JLPT JLPT_2 JLPT_3,q6A?^f?DMI
+梅,うめ,"plum, lowest (of a three-tier ranking system)",JLPT JLPT_2 JLPT_3,unQPf%DK.[
+埋める,うめる,"to bury, to fill up, to fill (a seat, a vacant position)",JLPT JLPT_2 JLPT_3,wtEE639hh4
+裏切る,うらぎる,"to betray, to turn traitor",JLPT JLPT_2 JLPT_3,hCN[eLWk|~
+羨ましい,うらやましい,"envious, enviable",JLPT JLPT_2 JLPT_3,P/?}=]sJqp
+売れる,うれる,to be sold,JLPT JLPT_2 JLPT_3,"wjQK4P,#&y"
+噂,うわさ,"rumor, gossip",JLPT JLPT_2 JLPT_3,iJw30XJ732
+運,うん,"fortune, luck",JLPT JLPT_2 JLPT_3,"niW>.BR,WX"
+運転,うんてん,"operation, driving",JLPT JLPT_2 JLPT_3,x@0Upz+IK7
+柄,え,"handle (of a sword, dagger, etc.), grip",JLPT_1 JLPT JLPT_2 JLPT_3,vAFwXg-!s2
+永遠,えいえん,"eternity, perpetuity, immortality",JLPT JLPT_2 JLPT_3,DxPif#CAiw
+永久,えいきゅう,"eternity, perpetuity, immortality",JLPT JLPT_2 JLPT_3,"H2N,Hwk+O>"
+影響,えいきょう,"influence, effect",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.9,xzq]$1i3z}
+営業,えいぎょう,"business, trade, management",JLPT JLPT_2 JLPT_3,xesLH`A]]j
+衛星,えいせい,satellite,JLPT_1 JLPT JLPT_2 JLPT_3,mODPl+GnJ<
+栄養,えいよう,"nutrition, nourishment",JLPT JLPT_2 JLPT_3,D*<eW1UGaQ
+笑顔,えがお,smile (on one's face),JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.11,"ck|m~NB,1+"
+描く,えがく,"to draw, to depict, to describe",JLPT JLPT_2 JLPT_3,A%|&4/hW0O
+餌,えさ,"feed, bait",JLPT JLPT_2 JLPT_3,kFT)$ftn@z
+エネルギー,エネルギー,energy (GER: energie),JLPT JLPT_2 JLPT_3,z36oBXl-RE
+得る,える,"to get, to gain, to win, to learn",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.11,v$jA3Lrsi]
+得る,うる,"to get, to gain, to win",JLPT JLPT_2 JLPT_3,sT#y1FGTc!
+円,えん,"circle, yen",JLPT JLPT_2 JLPT_3,lsb6<icN4?
+延期,えんき,"postponement, adjournment",JLPT JLPT_2 JLPT_3,DUXFS%Wd#v
+演技,えんぎ,"acting, performance",JLPT JLPT_2 JLPT_3,IH<gd>zmOh
+援助,えんじょ,"assistance, aid, support",JLPT JLPT_2 JLPT_3,h`{I^&2VL&
+エンジン,エンジン,engine,JLPT JLPT_2 JLPT_3,qw.wG*b!Qa
+演説,えんぜつ,"speech, address",JLPT JLPT_2 JLPT_3,ubLUzysT08
+演奏,えんそう,musical performance,JLPT JLPT_2 JLPT_3,G9]&KRGi[P
+老い,おい,"old age, the aged",JLPT JLPT_2 JLPT_3,"Hz1%S/^$?,"
+追い付く,おいつく,"to overtake, to catch up (with)",JLPT JLPT_2 JLPT_3,g{~7a$v2sm
+王,おう,king,JLPT JLPT_2 JLPT_3,k#_<4ay=~G
+追う,おう,"to chase, to run after",JLPT JLPT_2 JLPT_3,x%>16|CvCA
+応援,おうえん,"aid, assistance, help",JLPT JLPT_2 JLPT_3,NDS^Ak)|LB
+王様,おうさま,king,JLPT JLPT_2 JLPT_3,nKPemrJ_V5
+王子,おうじ,prince,JLPT JLPT_2 JLPT_3,"L`,J_WL+]h"
+応じる,おうじる,"to adapt, to respond, to comply with",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14,"xK:s,vBFc7"
+横断,おうだん,crossing,JLPT JLPT_2 JLPT_3,z/T^y6%uiO
+終える,おえる,to finish,JLPT JLPT_2 JLPT_3,"hO,Zn$Rx<F"
+大いに,おおいに,"much, considerably (same as 大変 (たいへん)), greatly",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.13,fVz%iJ3-E?
+覆う,おおう,"to cover, to hide, to conceal",JLPT JLPT_2 JLPT_3,Lm%oB!j+E)
+大家,おおや,landlord,JLPT JLPT_2 JLPT_3,gc9}{t}#g|
+丘,おか,"hill, height",JLPT JLPT_2 JLPT_3,j@=CkW8>0!
+沖,おき,open sea,JLPT JLPT_2 JLPT_3,d?Pt2wu__v
+奥,おく,"interior, inner part",JLPT JLPT_2 JLPT_3,V}(}>#0tD
+贈る,おくる,"to present, to give to, to award to",JLPT JLPT_2 JLPT_3,rV3X4}6{nQ
+起こる,おこる,"to occur, to happen",JLPT JLPT_2 JLPT_3,jY1}sGq4X}
+押える,おさえる,"to stop, to restrain, to press down",JLPT JLPT_2 JLPT_3,Om1hU>MYS0
+幼い,おさない,"very young, childish",JLPT JLPT_2 JLPT_3,uA[`]K&k.D
+収める,おさめる,"to store to pay, to supply",JLPT JLPT_2 JLPT_3,jL2$>p8($[
+納める,おさめる,"to store to pay, to supply",JLPT JLPT_2 JLPT_3,I#wxPQAM&H
+治める,おさめる,"to govern, to manage; to subdue",JLPT JLPT_2 JLPT_3,Groy5Mh=b[
+お辞儀,おじぎ,bow,JLPT JLPT_2 JLPT_3,N&e8jCT!9`
+お洒落,おしゃれ,"smartly dressed, fashion-conscious",JLPT JLPT_2 JLPT_3,q1.@7#(;?<
+お喋り,おしゃべり,"chattering, talk",JLPT JLPT_2 JLPT_3,J0fhZBKfSu
+汚染,おせん,"pollution, contamination",JLPT JLPT_2 JLPT_3,I?+Cu[l]f]
+恐らく,おそらく,perhaps,JLPT JLPT_2 JLPT_3,kL/tl<Mv0J
+恐れる,おそれる,"to fear, to be afraid of",JLPT JLPT_2 JLPT_3,x;Xt$GbU:n
+恐ろしい,おそろしい,"terrible, dreadful",JLPT JLPT_2 JLPT_3,JGyLnws+gz
+教わる,おそわる,to be taught,JLPT JLPT_2 JLPT_3,"j.|V-R,hM8"
+お互い,おたがい,"mutual, reciprocal, each other",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.1,"I%(y!,oeu|"
+穏やか,おだやか,"calm, gentle, quiet",JLPT JLPT_2 JLPT_3,iQhH7HaHk_
+男の人,おとこのひと,man,JLPT JLPT_3 JLPT_2 Genki_Ln.7 Genki,Bqnqcw;5C8
+大人しい,おとなしい,"obedient, docile, quiet",JLPT JLPT_2 JLPT_3,NiKO$K>WA9
+劣る,おとる,"to fall behind, to be inferior to",JLPT JLPT_2 JLPT_3,Kb0v_SukC>
+鬼,おに,"ogre, demon, 'it' (e.g.,in a game of tag)",JLPT JLPT_2 JLPT_3,Ewa5_MZt)z
+帯,おび,"band, sash",JLPT JLPT_2 JLPT_3,x^<)4<JIn8
+お昼,おひる,"lunch, noon",JLPT JLPT_2 JLPT_3,"QU,c7/WKET"
+オフィス,オフィス,office,JLPT JLPT_2 JLPT_3,t+v1qGjm`2
+溺れる,おぼれる,"to be drowned, to indulge in",JLPT JLPT_2 JLPT_3,L6mI#frmDD
+お前,おまえ,"you (sing), presence (of a high personage)",JLPT JLPT_2 JLPT_3,kiGe-uw>iW
+おめでとう,おめでとう,"Congratulations!, an auspicious occasion!",JLPT JLPT_2 JLPT_3,IjwH:94kN^
+お目に掛かる,おめにかかる,"meet ~, see ~",JLPT JLPT_2 JLPT_3,O[qSUns&-f
+思い付く,おもいつく,"to think of, to hit upon",JLPT JLPT_2 JLPT_3,phC=E!Uzsp
+思い出,おもいで,"memories, recollections, reminiscence",JLPT JLPT_3 JLPT_2 Genki_Ln.23 Genki,C>r<Y|QfhA
+主に,おもに,"mainly, primarily",JLPT JLPT_2 JLPT_3,KJv^Ck6t)-
+思わず,おもわず,"unintentional, spontaneous",JLPT JLPT_2 JLPT_3,mqEM$vUJ]Z
+泳ぎ,およぎ,swimming,JLPT JLPT_2 JLPT_3,p%YEcD<#qK
+およそ,およそ,"about, roughly, approximately",JLPT JLPT_2 JLPT_3,cmb!OC{1dV
+及ぼす,およぼす,"to exert, to cause, to exercise",JLPT JLPT_2 JLPT_3,lC%7ty:^eB
+下す,おろす,"to lower, to let go down",JLPT JLPT_2 JLPT_3,JRZI*AHd)D
+降ろす,おろす,"to take down, to launch, to drop",JLPT JLPT_2 JLPT_3,PQD_mXy>W.
+卸す,おろす,"to sell wholesale, grated (vegetables)",JLPT JLPT_2 JLPT_3,GT*kAh$cd0
+音,おん,"sound, note",JLPT JLPT_2 JLPT_3,gkN]*wY]?s
+恩,おん,"favor, obligation, debt of gratitude",JLPT JLPT_2 JLPT_3,"A4Iq0-B@,;"
+温暖,おんだん,warmth,JLPT JLPT_2 JLPT_3,N&n<_QP1.Q
+温度,おんど,temperature,JLPT JLPT_2 JLPT_3,NA1Ge#l-~k
+可,か,passable,JLPT JLPT_2 JLPT_3,l:l&EInHym
+蚊,か,mosquito,JLPT JLPT_3 JLPT_2 Genki Genki_Ln.21,j=4=()Uwi2
+課,か,"department, division",JLPT JLPT_2 JLPT_3,QQ1!.:!+a[
+カー,カー,car,JLPT JLPT_2 JLPT_3,o!p+_Rb<h*
+カード,カード,"card, curd",JLPT JLPT_2 JLPT_3,"F,Np^@m5hi"
+貝,かい,"shell, shellfish",JLPT JLPT_2 JLPT_3,HNd6/BU{>X
+害,がい,"harm, damage",JLPT JLPT_2 JLPT_3,g|Fzqe^$7$
+会員,かいいん,"member, the membership",JLPT JLPT_2 JLPT_3,li]JQ4<Kd[
+絵画,かいが,"picture, painting",JLPT JLPT_2 JLPT_3,emKUHOyrV`
+海外,かいがい,"foreign, abroad, overseas",JLPT JLPT_2 JLPT_3,qq4=IgxkU<
+会計,かいけい,"account, finance",JLPT JLPT_2 JLPT_3,bX?OL%f/L+
+解決,かいけつ,"settlement, solution, resolution",JLPT JLPT_2 JLPT_3,rmn(v?B?3g
+会合,かいごう,"meeting, assembly",JLPT JLPT_2 JLPT_3,f9BQ|i/j|}
+外交,がいこう,diplomacy,JLPT JLPT_2 JLPT_3,A]90<@ohwE
+開始,かいし,"start, commencement, beginning",JLPT JLPT_2 JLPT_3,qgkolirBJK
+解釈,かいしゃく,"explanation, interpretation",JLPT JLPT_2 JLPT_3,Ih/AkEg/|E
+外出,がいしゅつ,"outing, going out",JLPT JLPT_2 JLPT_3,Ol@%UFQ/rD
+改善,かいぜん,"betterment, improvement",JLPT JLPT_2 JLPT_3,fv+>GYURp:
+快適,かいてき,"pleasant, agreeable",JLPT JLPT_2 JLPT_3,Bh^`k;OTy|
+回復,かいふく,"recovery (from illness), rehabilitation, restoration",JLPT JLPT_2 JLPT_3,wc6OB#:n9.
+飼う,かう,to keep; to own (a pet); to raise; to feed,JLPT Genki_Ln.11 JLPT_3 JLPT_2 Genki,wfURRt4tC[
+帰す,かえす,to send back,JLPT JLPT_2 JLPT_3,LZ<.!]FC|8
+代える,かえる,"to exchange, to interchange, to substitute",JLPT JLPT_2 JLPT_3,Ccj6!`~jPu
+替える,かえる,"to exchange, to interchange, to substitute",JLPT JLPT_2 JLPT_3,"Fv2F,v+u]8"
+換える,かえる,"to exchange, to interchange, to substitute",JLPT JLPT_3 JLPT_2 Genki_Ln.23 Genki,mmtj;wD(Zd
+反る,かえる,"to warp, to be warped, to curve",JLPT JLPT_2 JLPT_3,"vDLMxa,sN/"
+香り,かおり,"aroma, fragrance",JLPT JLPT_2 JLPT_3,me}_g<26n*
+画家,がか,painter,JLPT JLPT_2 JLPT_3,Pl:-st.KZ+
+抱える,かかえる,to hold or carry under or in the arms,JLPT JLPT_2 JLPT_3,"PQR[r=WB$,"
+価格,かかく,"price, value",JLPT JLPT_2 JLPT_3,xFP@p4LxH5
+化学,かがく,chemistry,JLPT JLPT_2 JLPT_3,Sh/.K7MGJ
+輝く,かがやく,"to shine, to glitter, to sparkle",JLPT JLPT_2 JLPT_3,Dzyp)tD%e
+係,かかり,person in charge,JLPT JLPT_2 JLPT_3,Q&QZSK._J<
+罹る,かかる,to suffer from,JLPT JLPT_2 JLPT_3,h_Phc0xEm%
+限る,かぎる,"to restrict, to limit, to confine",JLPT JLPT_2 JLPT_3,Ku)jdi.uTn
+掻く,かく,to scratch,JLPT JLPT_2 JLPT_3,K):N$B19m+
+描く,かく,"to draw, to depict, to describe",JLPT JLPT_2 JLPT_3,grO;5{y}I|
+嗅ぐ,かぐ,"to sniff, to smell",JLPT JLPT_2 JLPT_3,vaKqc&PyP9
+家具,かぐ,furniture,Genki_Ln.15 JLPT JLPT_3 JLPT_2 Genki,gqN}MYosw6
+学,がく,"learning, knowledge",JLPT JLPT_2 JLPT_3,w:XhV>-rir
+額,がく,amount; frame,JLPT JLPT_2 JLPT_3,iG]&$wbDKv
+覚悟,かくご,"resolution, resignation, readiness",JLPT JLPT_2 JLPT_3,j/*:m6x0J)
+確実,かくじつ,"certainty, reliability, soundness",JLPT JLPT_2 JLPT_3,Nzie2SM<&O
+学者,がくしゃ,scholar,JLPT JLPT_2 JLPT_3,RamhNRc=y:
+学習,がくしゅう,"study, learning",JLPT JLPT_2 JLPT_3,PHg7|5Zlfd
+隠す,かくす,"to hide, to conceal",JLPT JLPT_2 JLPT_3,vMufH!:aAV
+拡大,かくだい,"magnification, enlargement",JLPT JLPT_2 JLPT_3,f7kQq91Ua<
+確認,かくにん,"affirmation, confirmation",JLPT JLPT_2 JLPT_3,kk{ITQ}D*5
+学問,がくもん,"scholarship, study, learning",JLPT JLPT_2 JLPT_3,Jk{+Uk9@=d
+隠れる,かくれる,"to hide, to be hidden",JLPT JLPT_2 JLPT_3,Iv9k~&!9Sa
+影,かげ,"shade, shadow, other side",JLPT JLPT_2 JLPT_3,e~q8TnSV#A
+陰,かげ,"shade, shadow, other side",JLPT JLPT_2 JLPT_3,JZ1GmL8t.y
+欠ける,かける,to be lacking,JLPT JLPT_2 JLPT_3,c*r`UH]nG8
+加減,かげん,adjustment; addition and subtraction,JLPT JLPT_2 JLPT_3,h.?lP}8!)~
+過去,かこ,past,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.13,"dbDE7?,;2l"
+籠,かご,"basket, cage",JLPT JLPT_2 JLPT_3,nt-Kbv73>]
+囲む,かこむ,"to surround, to encircle",JLPT JLPT_2 JLPT_3,"AC8Gt39]%,"
+火災,かさい,"conflagration, fire",JLPT JLPT_2 JLPT_3,C?jW[uV]~u
+重なる,かさなる,"to be piled up, lie on top of one another",JLPT JLPT_2 JLPT_3,qEGvs]3ApH
+重ねる,かさねる,"to pile up, to put something on another, to heap up",JLPT JLPT_2 JLPT_3,i%7_$Pa~m]
+飾り,かざり,decoration,JLPT JLPT_2 JLPT_3,b$htguAWNP
+貸し,かし,"loan, lending",JLPT JLPT_2 JLPT_3,hK1t$y~&<
+菓子,かし,"confectionery, sweet",JLPT JLPT_2 JLPT_3,uK+`Lg$t0E
+家事,かじ,household matters; housework (same as 家の仕事 (いえのしごと)),JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14 Genki_Ln.22 Genki,oS4iCB;y-f
+賢い,かしこい,"wise, clever, smart",JLPT JLPT_2 JLPT_3,rE7F6b61Rm
+歌手,かしゅ,singer,JLPT Genki_Ln.11 JLPT_3 JLPT_2 Genki,NmC8EM=]mA
+数,かず,"number, figure, amount",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.3,DD:chgc^KO
+稼ぐ,かせぐ,"to earn income, to labor",JLPT JLPT_2 JLPT_3,rzTOas5wcB
+数える,かぞえる,to count,JLPT JLPT_2 JLPT_3,J-q>{61#D9
+型,かた,"mold, model, style",JLPT JLPT_2 JLPT_3,p8F!A2no<N
+肩,かた,shoulder,JLPT JLPT_2 JLPT_3,dyYF&B&tH[
+堅い,かたい,"hard, firm, solid",JLPT JLPT_2 JLPT_3,Pf^;5Zn/;l
+硬い,かたい,"hard, firm, solid",JLPT JLPT_2 JLPT_3,"A5A<hg!,v}"
+方々,かたがた,persons,JLPT JLPT_2 JLPT_3,hkfynYZJHd
+片付く,かたづく,"to put in order, to solve",JLPT JLPT_2 JLPT_3,ijUQHB/ROv
+刀,かたな,"sword, saber",JLPT JLPT_2 JLPT_3,E>:sV*K^8H
+語る,かたる,"to talk, to tell, to recite",JLPT JLPT_2 JLPT_3,K~y=o(hWS(
+勝ち,かち,"win, victory",JLPT JLPT_2 JLPT_3,f)TI}tuNi!
+価値,かち,"value, worth, merit",JLPT JLPT_2 JLPT_3,B$%nCt/^FZ
+がっかり,がっかり,"feel disappointed, be dejected, lose heart",JLPT JLPT_2 JLPT_3,r9|(w>UYj4
+活気,かっき,vigor; liveliness; vitality; energy,JLPT Intermediate_Japanese JLPT_1 JLPT_3 JLPT_2 Intermediate_Japanese_Ln.10,HUA^lTjb!P
+楽器,がっき,musical instrument,JLPT Genki_Ln.13 JLPT_3 JLPT_2 Genki,zj[&tINbu_
+学期,がっき,term (school),JLPT JLPT_2 JLPT_3,rPinGb_30Q
+活動,かつどう,"action, activity",JLPT JLPT_2 JLPT_3,wt]>L`Ku^c
+活躍,かつやく,activity,JLPT JLPT_2 JLPT_3,eCZu2QGL8i
+活用,かつよう,conjugation; practical use,JLPT JLPT_2 JLPT_3,fVw4kRg|j)
+仮定,かてい,"assumption, supposition, hypothesis",JLPT JLPT_2 JLPT_3,O=OdQ3=*sS
+過程,かてい,process,JLPT JLPT_2 JLPT_3,x/zB4*S269
+課程,かてい,"course, curriculum",JLPT JLPT_2 JLPT_3,"g,{yU7}}eo"
+悲しむ,かなしむ,"to be sad, to mourn for, to regret",JLPT JLPT_2 JLPT_3,z^+]Gk=mf_
+必ずしも,かならずしも,"(not) always, (not) necessarily",JLPT JLPT_2 JLPT_3,vW8w*Wj8S6
+かなり,かなり,"considerably, fairly, quite",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.7,zc@WXAK&cO
+金,かね,"gold, metal; money",JLPT JLPT_2 JLPT_3,sL^]E[vBWQ
+鐘,かね,"bell, chime",JLPT JLPT_2 JLPT_3,uWo]p3>gV)
+可能,かのう,"possible, practicable, feasible",JLPT JLPT_2 JLPT_3,s89#AFndfj
+株,かぶ,stock; stump (of tree),JLPT JLPT_2 JLPT_3,i!::Yg?ZPB
+被る,かぶる,to wear; to be covered with,JLPT JLPT_2 JLPT_3,KZvZ3xJvf=
+我慢,がまん,"patience, endurance, perseverance",JLPT JLPT_2 JLPT_3,b.uAP*cO(_
+上,かみ,first volume; superior quality; governmental,JLPT JLPT_2 JLPT_3,B2f-z2M%?X
+神,かみ,god,JLPT JLPT_2 JLPT_3,bOG}3!+.y2
+雷,かみなり,thunder,JLPT JLPT_2 JLPT_3,A`y:r{2n8V
+髪の毛,かみのけ,hair (head),JLPT JLPT_2 JLPT_3,k>oV)Rt7]w
+科目,かもく,"(school) subject, curriculum, course",JLPT JLPT_2 JLPT_3,mt1}<&PDy^
+かもしれない,かもしれない,"maybe, perhaps",JLPT JLPT_2 JLPT_3,"fXI7dlE,H5"
+かゆい,かゆい,"itchy, itching",JLPT JLPT_2 JLPT_3,i@bIkK/P`w
+歌謡,かよう,"song, ballad",JLPT JLPT_2 JLPT_3,B8j5MHOl3a
+空,から,empty,JLPT JLPT_2 JLPT_3,"LiJsM!pT#,"
+殻,から,"shell, husk, hull",JLPT JLPT_2 JLPT_3,"F87p.DC4,p"
+柄,がら,pattern; build; character,JLPT JLPT_2 JLPT_3,uk^tW>*afz
+刈る,かる,"to cut (hair), to mow (grass), to harvest",JLPT JLPT_2 JLPT_3,ON/-tkLwG!
+河,かわ,"river, stream",JLPT JLPT_2 JLPT_3,mIM2jXP:@M
+皮,かわ,"skin, hide, leather",JLPT JLPT_2 JLPT_3,C<.^aCL_QG
+革,かわ,leather,JLPT JLPT_2 JLPT_3,z`KQfm{h;f
+可愛そう,かわいそう,"poor, pitiable, pathetic",JLPT JLPT_2 JLPT_3,jCbD|/Ou5e
+可愛らしい,かわいらしい,"lovely, sweet",JLPT JLPT_2 JLPT_3,KYl^v5PK_;
+乾かす,かわかす,to dry,JLPT JLPT_2 JLPT_3,JoU47]zU{d
+渇く,かわく,to be thirsty,JLPT JLPT_2 JLPT_3,g:zQk;6g:U
+代る,かわる,"to take the place of, to relieve, to be substituted for",JLPT JLPT_2 JLPT_3,f9j%&rI)[J
+缶,かん,"can, tin",JLPT_1 JLPT JLPT_2 JLPT_3,fnx%_qW>Wk
+勘,かん,"perception, intuition, the sixth sense",JLPT JLPT_2 JLPT_3,lle<t+CbfW
+考え,かんがえ,"thinking, thought, ideas",JLPT JLPT_2 JLPT_3,ry3gkU$VWf
+感覚,かんかく,"sense, sensation",JLPT JLPT_2 JLPT_3,"p)VaZN,wP="
+間隔,かんかく,"space, interval, SPC",JLPT JLPT_2 JLPT_3,qbs8.xdCB<
+観客,かんきゃく,"audience, spectator(s)",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.7,j%h6<&[KnW
+環境,かんきょう,"environment, circumstance",JLPT JLPT_3 JLPT_2 Genki Genki_Ln.21,v:iQ;XlPLV
+歓迎,かんげい,"welcome, reception",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.5,e6r/_jeu;I
+観光,かんこう,sightseeing,Genki_Ln.15 JLPT JLPT_3 JLPT_2 Genki,n*g6UOKH98
+観察,かんさつ,"observation, survey",JLPT JLPT_2 JLPT_3,q)XNacsL_{
+感じ,かんじ,"feeling, sense, impression",JLPT JLPT_2 JLPT_3,w_sfjfQ#7V
+感謝,かんしゃ,"thanks, gratitude",JLPT JLPT_2 JLPT_3,H)_*dziOH#
+患者,かんじゃ,patient,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.12,ow]ljz^dy0
+勘定,かんじょう,"calculation, counting, consideration",JLPT JLPT_2 JLPT_3,lT@?`jcn/-
+感情,かんじょう,"emotion(s), feeling(s), sentiment",JLPT JLPT_2 JLPT_3,KwSZ]};@<N
+感じる,かんじる,"to feel, to sense",JLPT JLPT_2 JLPT_3,"tat.#S,YWC"
+感心,かんしん,admiration,JLPT JLPT_2 JLPT_3,Ll7N}.KB!4
+関心,かんしん,"concern, interest",JLPT JLPT_2 JLPT_3,ugNZxV5.;6
+関する,かんする,"to concern, to be related",JLPT JLPT_2 JLPT_3,j?=:~N:vEw
+完成,かんせい,"complete, completion; perfection",JLPT JLPT_2 JLPT_3,Gz+d-Na>Wq
+完全,かんぜん,"perfection, completeness",JLPT JLPT_2 JLPT_3,"mx8.$z,opn"
+乾燥,かんそう,"dry, arid, dehydrated",JLPT JLPT_2 JLPT_3,o&PKDt@8.N
+感想,かんそう,"(one's) impressions, (one's) thoughts",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.11,LSEXg:S7:(
+感動,かんどう,"being deeply moved, excitement",JLPT JLPT_2 JLPT_3,mO)}<zEdx8
+監督,かんとく,"supervision, control, (movie) director",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.7,J6H&uZ7Px>
+管理,かんり,"control, management (e.g., of a business)",JLPT JLPT_2 JLPT_3,GKHgUyo>J7
+完了,かんりょう,"completion, conclusion",JLPT JLPT_2 JLPT_3,nU7gs|>hqI
+関連,かんれん,"relation, connection, relevance",JLPT JLPT_2 JLPT_3,qM07gcK[)f
+議員,ぎいん,"member of the Diet, congress, or parliament",JLPT JLPT_2 JLPT_3,HgQ-~|%58x
+記憶,きおく,"memory, recollection, remembrance",JLPT JLPT_2 JLPT_3,"E,/>3<s?|+"
+気温,きおん,temperature (weather - not used for things),JLPT Genki_Ln.12 JLPT_3 JLPT_2 Genki,BBA~snq[*i
+機械,きかい,"machine, machinery",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14,"gbY2LYN_B,"
+器械,きかい,instrument,JLPT JLPT_2 JLPT_3,l7Ho]DDWuu
+議会,ぎかい,"Diet, congress, parliament",JLPT JLPT_2 JLPT_3,lGMTgzdnaN
+期間,きかん,"period, term",JLPT JLPT_2 JLPT_3,iw;V~SjnTE
+機関,きかん,"engine; institution, organization",JLPT JLPT_2 JLPT_3,OOR48r}N5c
+企業,きぎょう,"industry, business, undertaking",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14,"m,c9$UCg]/"
+効く,きく,to be effective,JLPT JLPT_2 JLPT_3,LC`=c%l]6(
+期限,きげん,"deadline, term",JLPT JLPT_2 JLPT_3,DXtaD5za4M
+機嫌,きげん,"humor, temper, mood",JLPT JLPT_2 JLPT_3,g?wFVr$Cb>
+気候,きこう,climate,JLPT JLPT_2 JLPT_3,zi^=GdE6J`
+岸,きし,"bank, coast, shore",JLPT JLPT_2 JLPT_3,hm_._Qp@I~
+生地,きじ,fabric; dough,JLPT JLPT_2 JLPT_3,0J|w~z~jj
+記事,きじ,"article, news story",JLPT JLPT_2 JLPT_3,D?VHH^x3x^
+技師,ぎし,"engineer, technician",JLPT JLPT_2 JLPT_3,u=&Ix|N:mj
+記者,きしゃ,reporter,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.15,L%Xdco]ND%
+傷,きず,"wound, injury, hurt",JLPT JLPT_2 JLPT_3,Q?7OEINT{!
+期待,きたい,"expectation, anticipation, hope",JLPT JLPT_2 JLPT_3,q|E5|~(~TI
+気体,きたい,"vapor, gas",JLPT JLPT_2 JLPT_3,BVN])vG*1F
+帰宅,きたく,returning home,JLPT JLPT_2 JLPT_3,z!%Pu#*l7[
+貴重,きちょう,"precious, valuable",JLPT JLPT_2 JLPT_3,i#)MEqHOiw
+議長,ぎちょう,chairman,JLPT JLPT_2 JLPT_3,ivgef2]KwO
+きちんと,きちんと,"precisely, accurately",JLPT JLPT_2 JLPT_3,"r#L,S)sfK&"
+きつい,きつい,"tight, close, intense",JLPT JLPT_2 JLPT_3,j)>u~$9^*r
+気付く,きづく,"to notice, to recognize, to become aware of",JLPT JLPT_2 JLPT_3,xDh?wq7iT8
+気に入る,きにいる,"to like, to be please",JLPT JLPT_2 JLPT_3,"uegN*W,m$w"
+記入,きにゅう,"entry, filling in of forms",JLPT JLPT_2 JLPT_3,vlEX%x--1.
+記念,きねん,"commemoration, memory",JLPT JLPT_2 JLPT_3,H8>Vf=G.}w
+機能,きのう,"function, faculty",JLPT JLPT_2 JLPT_3,QB(9=:5m2@
+気の毒,きのどく,"pitiful, a pity",JLPT JLPT_2 JLPT_3,qiFq+*QK@q
+寄付,きふ,"contribution, donation",JLPT JLPT_2 JLPT_3,P<<3-~akkr
+希望,きぼう,"hope, wish, aspiration",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.3,"rKl|qTb,g-"
+基本,きほん,"basic, basis",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.15,r&MTg)%4_-
+決まり,きまり,"settlement, conclusion, rule",JLPT JLPT_2 JLPT_3,DmsWlm^9ML
+気味,きみ,"-like, -looking, -looked",JLPT JLPT_2 JLPT_3,iNru&P?85/
+奇妙,きみょう,"strange, queer, curious",JLPT JLPT_2 JLPT_3,LWN?@8(b&a
+義務,ぎむ,"duty, obligation, responsibility",JLPT JLPT_2 JLPT_3,Da7kYMio|S
+疑問,ぎもん,"question, problem, doubt",JLPT JLPT_2 JLPT_3,zRRFu?JoKE
+逆,ぎゃく,"reverse, opposite",JLPT JLPT_2 JLPT_3,EiDH#>VXk9
+キャプテン,キャプテン,captain,JLPT JLPT_2 JLPT_3,pQT]>v52;$
+キャンプ,キャンプ,camp,JLPT Genki_Ln.11 JLPT_3 JLPT_2 Genki,F4[L_8oSn
+旧,きゅう,ex-,JLPT JLPT_2 JLPT_3,wKI{_3LgUf
+級,きゅう,"class, grade, rank",JLPT JLPT_2 JLPT_3,ywhuZF1TJ0
+球,きゅう,"globe, sphere, ball",JLPT JLPT_2 JLPT_3,P<LmV^}EUI
+休暇,きゅうか,"vacation, holiday, day off",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.1,HtR8NVhhfe
+休憩,きゅうけい,"rest, break, intermission",JLPT JLPT_2 JLPT_3,M?^9bN:14o
+急激,きゅうげき,"sudden, precipitous, radical",JLPT JLPT_2 JLPT_3,bR.b24bzOE
+吸収,きゅうしゅう,"absorption, suction",JLPT JLPT_2 JLPT_3,uP}=0<A&zm
+救助,きゅうじょ,"relief, aid, rescue",JLPT JLPT_2 JLPT_3,x{|!Zu?h8!
+急速,きゅうそく,"rapid (e.g., progress)",JLPT JLPT_2 JLPT_3,H*fw]->cqe
+休息,きゅうそく,"rest, relief, relaxation",JLPT JLPT_2 JLPT_3,mFQb-ci%=n
+急に,きゅうに,suddenly,JLPT JLPT_2 JLPT_3,nbPHpp}wLe
+給料,きゅうりょう,"salary, wages",Genki_Ln.17 JLPT JLPT_3 JLPT_2 Genki,bFBKO):>Pu
+器用,きよう,"skillful, handy",JLPT JLPT_2 JLPT_3,j>:wz+YD-O
+教科書,きょうかしょ,textbook,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Genki_Ln.6 Intermediate_Japanese_Ln.13 Genki,kkoTF|;.kp
+競技,きょうぎ,"game, match, contest",JLPT JLPT_2 JLPT_3,c3-]g>CAR$
+行儀,ぎょうぎ,manners,JLPT JLPT_2 JLPT_3,yCsCHa$b|3
+供給,きょうきゅう,"supply, provision",JLPT JLPT_2 JLPT_3,H.&4r-|xC*
+教授,きょうじゅ,"teaching, instruction; professor",JLPT JLPT_2 JLPT_3,j9WXPp%y<F
+強調,きょうちょう,"emphasis, stress, stressed point",JLPT JLPT_2 JLPT_3,ekVG@ic`Qc
+共通,きょうつう,"commonness, mutual",JLPT JLPT_2 JLPT_3,iNbpa<XIBY
+共同,きょうどう,"cooperation, association, collaboration",JLPT JLPT_2 JLPT_3,M&4X!=%k6!
+恐怖,きょうふ,"fear, terror",JLPT JLPT_2 JLPT_3,E^f~?uHKoJ
+協力,きょうりょく,"cooperation, collaboration",JLPT JLPT_2 JLPT_3,C?Z%aW?GmJ
+強力,きょうりょく,"powerful, strong",JLPT JLPT_2 JLPT_3,"o`2(1ZfJ,z"
+許可,きょか,"permission, approval",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.4,xgOJVyt)!-
+局,きょく,"office, bureau, station(TV, radio)",JLPT JLPT_2 JLPT_3,tQ0a`!@5U(
+巨大,きょだい,"huge, gigantic, enormous",JLPT JLPT_2 JLPT_3,"xA&bS[Q4,y"
+嫌う,きらう,"to hate, to dislike, to loathe",JLPT JLPT_2 JLPT_3,br%KM$_?V3
+霧,きり,"fog, mist",JLPT JLPT_2 JLPT_3,xhY3{w-]xD
+切れ,きれ,"cloth, piece, cut",JLPT JLPT_2 JLPT_3,no-N<tQ].O
+切れる,きれる,"to cut well, to be sharp; to break (off)",JLPT JLPT_2 JLPT_3,vq3fa)$([j
+記録,きろく,"record, minutes, document",JLPT JLPT_2 JLPT_3,E9&**2T5hb
+議論,ぎろん,"argument, discussion, dispute",JLPT JLPT_2 JLPT_3,tHrivglW.I
+金,きん,"gold, metal; money",JLPT JLPT_2 JLPT_3,}{gI`5unu
+銀,ぎん,silver,JLPT JLPT_2 JLPT_3,r=)`V@J5eU
+禁煙,きんえん,No Smoking,JLPT JLPT_2 JLPT_3,O$<^K)0$)}
+金額,きんがく,amount of money,JLPT JLPT_2 JLPT_3,"MF#,QebEjl"
+金庫,きんこ,"safe, vault",JLPT JLPT_2 JLPT_3,fW#b}db?aR
+禁止,きんし,"prohibition, ban",JLPT JLPT_2 JLPT_3,Gdm1sTV(+-
+金銭,きんせん,"money, cash",JLPT JLPT_2 JLPT_3,gfWr=5X>7*
+金属,きんぞく,metal,JLPT JLPT_2 JLPT_3,y9?7a-hRGY
+近代,きんだい,modern times,JLPT JLPT_2 JLPT_3,":<%,Q>)l%"
+緊張,きんちょう,"tension, mental strain, nervousness",JLPT JLPT_2 JLPT_3,G?ovKqSJ{(
+筋肉,きんにく,"muscle, sinews",JLPT JLPT_2 JLPT_3,rIZ[8xFGmr
+金融,きんゆう,"finance, money and banking",JLPT JLPT_2 JLPT_3,ft);I1go9:
+句,く,phrase,JLPT JLPT_2 JLPT_3,s#j6K^u/Ut
+食う,くう,(male) (vulg.) to eat,JLPT JLPT_2 JLPT_3,m^2{l`XD/G
+偶然,ぐうぜん,"(by) chance, unexpectedly",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.4,Bjglx^BH1F
+臭い,くさい,"stinky, smelly, bad-smelling",JLPT JLPT_2 JLPT_3,wHN8;QJo.]
+鎖,くさり,chain,JLPT JLPT_2 JLPT_3,cOg]TL4|L&
+腐る,くさる,"to rot, to go bad",JLPT JLPT_2 JLPT_3,u_}*Hl&WiO
+癖,くせ,"a habit (often a bad habit), peculiarity",JLPT JLPT_2 JLPT_3,Ae-]tyqPg+
+管,くだ,"pipe, tube",JLPT JLPT_2 JLPT_3,pL(+IcFnzy
+具体,ぐたい,"concrete, tangible, material",JLPT JLPT_2 JLPT_3,j&j}xVZwy2
+下り,くだり,down-train (going away from Tokyo),JLPT JLPT_2 JLPT_3,ll}#-y;}nb
+下る,くだる,"to get down, to descend",JLPT JLPT_2 JLPT_3,J8{HBuKP{o
+苦痛,くつう,"pain, agony",JLPT JLPT_2 JLPT_3,"gHRe}_+,oB"
+ぐっすり,ぐっすり,"sound asleep, fast asleep",JLPT JLPT_2 JLPT_3,p-l^nopeNF
+区別,くべつ,"distinction, differentiation, classification",JLPT JLPT_2 JLPT_3,BvvL(+LdQJ
+組,くみ,"class, team, set",JLPT JLPT_2 JLPT_3,Eo]xBl)F72
+組合,くみあい,"association, union",JLPT JLPT_2 JLPT_3,yqy^)Y;[n3
+組む,くむ,to put together,JLPT JLPT_2 JLPT_3,drFT5_xS_C
+汲む,くむ,"to draw, to scoop, to pump",JLPT JLPT_2 JLPT_3,Q)1C!FL!I~
+酌む,くむ,to serve sake,JLPT JLPT_2 JLPT_3,46h2Xe@mx
+悔しい,くやしい,"regrettable, mortifying, vexing",JLPT JLPT_2 JLPT_3,rlXMK!]p!4
+位,くらい,"grade, rank, about",JLPT JLPT_2 JLPT_3,n?/Ib+~G&7
+暮らし,くらし,living; life style,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.13,ur3R:N98HP
+クラシック,クラシック,classic(s),JLPT JLPT_2 JLPT_3,gWD`rMx`.V
+暮らす,くらす,"to live, to get along",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.11,uz%a*.FY`[
+グラス,グラス,glass; grass,JLPT JLPT_2 JLPT_3,"o%;,f2E00;"
+グランド,グランド,"gland, grand, (electrical) ground",JLPT JLPT_2 JLPT_3,y<]BSgg>1B
+クリーム,クリーム,cream,JLPT JLPT_2 JLPT_3,x%D6yIVKeG
+繰り返す,くりかえす,"to repeat, to do something over again",JLPT JLPT_2 JLPT_3,x/V;r?ugpG
+クリスマス,クリスマス,Christmas,JLPT Genki_Ln.14 JLPT_3 JLPT_2 Genki,qJB4cU<;.M
+狂う,くるう,"to go mad, to get out of order",JLPT JLPT_2 JLPT_3,LFsc7Cxxu?
+グループ,グループ,group,JLPT JLPT_2 JLPT_3,ml-qdb`4u(
+苦しい,くるしい,tough; physically strenuous,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.15,o9TWr2(ugU
+苦しむ,くるしむ,"to suffer, to groan, to be worried",JLPT JLPT_2 JLPT_3,JPH_;zI]Eb
+暮れ,くれ,"year end,",JLPT JLPT_2 JLPT_3,J-H`.dV)Ya
+苦労,くろう,hardship; suffering,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14,Qg]J+:tq@n
+加える,くわえる,"to append, to sum up, to add (up)",JLPT JLPT_2 JLPT_3,uHR{k-Ggpv
+咥える,くわえる,to hold something in the mouth,JLPT JLPT_2 JLPT_3,MP^AZ7xeUw
+詳しい,くわしい,detailed; full; accurate,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.8,OydH!z!UV$
+加わる,くわわる,"to join in, to accede to",JLPT JLPT_2 JLPT_3,C1e@=>t]o?
+訓,くん,native Japanese reading of a Chinese character,JLPT JLPT_2 JLPT_3,bzc~15=D>r
+軍,ぐん,"army, force, troops",JLPT JLPT_2 JLPT_3,snlGor1;5B
+郡,ぐん,"country, district",JLPT JLPT_2 JLPT_3,bXy5Bz>=dm
+軍隊,ぐんたい,"army, troops",JLPT JLPT_2 JLPT_3,ztU9>^6)?#
+訓練,くんれん,"practice, training",JLPT JLPT_2 JLPT_3,FBWzrhuPIY
+下,げ,"under, below, beneath",JLPT JLPT_2 JLPT_3,JgwryRe;fM
+計,けい,"plan; sum, total",JLPT JLPT_2 JLPT_3,oeGx?<asd*
+敬意,けいい,"respect, honor",JLPT JLPT_2 JLPT_3,PG>aot:bo~
+経営,けいえい,"management, administration",JLPT JLPT_2 JLPT_3,b~su7M=0~@
+景気,けいき,"condition, state, business (condition)",JLPT JLPT_2 JLPT_3,Ju%`{&u<L~
+傾向,けいこう,"tendency, trend, inclination",JLPT JLPT_2 JLPT_3,j=d#Ly-}f$
+警告,けいこく,warning,JLPT JLPT_2 JLPT_3,6frcgbqoo
+計算,けいさん,"calculation, reckoning",JLPT JLPT_2 JLPT_3,uhjx!mhsp>
+掲示,けいじ,"notice, bulletin",JLPT JLPT_2 JLPT_3,k:vtm*1T8E
+刑事,けいじ,"criminal case, (police) detective",JLPT JLPT_2 JLPT_3,e8dFatK7SV
+芸術,げいじゅつ,"(fine) art, the arts",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.10,pxydrozlB3
+契約,けいやく,"contract, compact, agreement",JLPT JLPT_2 JLPT_3,rb+qu;iaOF
+経由,けいゆ,"go by the way, via",JLPT JLPT_2 JLPT_3,iaYgH/NFbB
+ケース,ケース,case,JLPT_1 JLPT JLPT_2 JLPT_3,tQq4Ps7@D>
+ゲーム,ゲーム,game,JLPT JLPT_2 JLPT_3,"f6tl8,95d0"
+劇,げき,"drama, play",JLPT JLPT_2 JLPT_3,Fj4m~K@AaE
+劇場,げきじょう,"theater, playhouse",JLPT JLPT_2 JLPT_3,]#<%*v<%(
+化粧,けしょう,make-up (cosmetic),JLPT JLPT_2 JLPT_3,kU@d`$tb#v
+けち,けち,"stinginess, miser",JLPT JLPT_2 JLPT_3,s#8[d||F]p
+血液,けつえき,blood,JLPT JLPT_2 JLPT_3,hvJ?D%;5l%
+結果,けっか,"result, consequence",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.5,uus~EAck7g
+欠陥,けっかん,"defect, fault, deficiency",JLPT JLPT_2 JLPT_3,"JPtOP,>ga["
+結局,けっきょく,"after all, eventually",JLPT JLPT_2 JLPT_3,jyia6$GYCZ
+決心,けっしん,"determination, resolution",JLPT JLPT_2 JLPT_3,c0O1]G99<]
+欠席,けっせき,"absence, non-attendance",JLPT JLPT_2 JLPT_3,C}LnP5iu4O
+決定,けってい,"decision, determination",JLPT JLPT_2 JLPT_3,"Jp:0Ai2,VX"
+欠点,けってん,"faults, defect, weakness",JLPT JLPT_2 JLPT_3,M9`w:3e`~]
+結論,けつろん,conclusion,JLPT JLPT_2 JLPT_3,iMXuHup!!R
+煙,けむり,"smoke, fumes",JLPT JLPT_2 JLPT_3,lSxqx7`C*~
+蹴る,ける,to kick,JLPT JLPT_3 JLPT_2 Genki Genki_Ln.21,MV$~w0X!y2
+券,けん,"ticket, certificate",JLPT JLPT_2 JLPT_3,hb?hf::?yp
+県,けん,prefecture,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.7,MN<nt8!(02
+見解,けんかい,"opinion, point of view",JLPT JLPT_2 JLPT_3,G#%jy:[3F!
+限界,げんかい,"limit, bound",JLPT JLPT_2 JLPT_3,JaoBjFZQ]<
+現金,げんきん,cash,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.9,v>1Aj:QNui
+言語,げんご,language,JLPT JLPT_2 JLPT_3,ejQbjwn<j/
+健康,けんこう,health(y),JLPT JLPT_2 JLPT_3,n11FRELGTJ
+検査,けんさ,"inspection, examination",JLPT JLPT_2 JLPT_3,JUjY[Ey:u:
+現在,げんざい,"now (same as 今 (いま)), present, current",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.12,w(.$MQ!&Z<
+現実,げんじつ,reality,JLPT JLPT_2 JLPT_3,F232?ww;iJ
+現象,げんしょう,phenomenon,JLPT JLPT_2 JLPT_3,FyKmxf<-vO
+現状,げんじょう,"present condition, status quo",JLPT JLPT_2 JLPT_3,N|BEb?m$K?
+建設,けんせつ,"construction, foundation",JLPT JLPT_2 JLPT_3,znx=MK$=96
+現代,げんだい,"today, present-day",JLPT JLPT_2 JLPT_3,fu)f(:6JAs
+建築,けんちく,"construction, architecture",JLPT JLPT_2 JLPT_3,"NM6eAgwD,T"
+見当,けんとう,"estimate, guess",JLPT JLPT_2 JLPT_3,t]}1Fz~P+l
+検討,けんとう,"consideration, examination, investigation",JLPT JLPT_2 JLPT_3,Qr-3$@5oy:
+現場,げんば,"actual spot, scene, field",JLPT JLPT_2 JLPT_3,pPYxD+.Tt<
+憲法,けんぽう,constitution,JLPT JLPT_2 JLPT_3,Pt+Ua9}uUU
+権利,けんり,"right, privilege",JLPT JLPT_2 JLPT_3,BlH<4P^#PV
+後,ご,"afterwards, since then",JLPT JLPT_2 JLPT_3,NFyG.<z1HC
+碁,ご,Go (board game of capturing territory),JLPT JLPT_2 JLPT_3,e~/B8i!5F)
+恋,こい,"love, tender passion",JLPT JLPT_2 JLPT_3,I%Sh/ap#4{
+濃い,こい,"thick (as of color, liquid), dense, strong",JLPT JLPT_2 JLPT_3,cR>i$T~1vO
+恋人,こいびと,lover; sweetheart; girlfriend,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.9,"lgn5l,{H`B"
+幸運,こううん,"good luck, fortune",JLPT JLPT_2 JLPT_3,u*FUt2q$fc
+講演,こうえん,"lecture, talk",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.15,"vP=[7BPl,E"
+効果,こうか,"effect, result",JLPT JLPT_2 JLPT_3,vT0BrdLKhF
+硬貨,こうか,coin,JLPT JLPT_2 JLPT_3,"qBE<@>&,:4"
+高価,こうか,high price,JLPT JLPT_2 JLPT_3,J01j$uto]T
+豪華,ごうか,"luxurious, gorgeous, extravagance",JLPT JLPT_2 JLPT_3,VKR/XQP(/
+合格,ごうかく,"success, passing (e.g., exam)",JLPT JLPT_2 JLPT_3,wSq<0USuY5
+交換,こうかん,"exchange, swap",JLPT JLPT_2 JLPT_3,FoW0]ZL+c.
+航空,こうくう,"aviation, flying",JLPT JLPT_2 JLPT_3,gKh#|Nhux
+光景,こうけい,"scene, spectacle",JLPT JLPT_2 JLPT_3,uTN)wO>N*m
+合計,ごうけい,"sum total, total amount",JLPT JLPT_2 JLPT_3,z@(R~.`dKi
+攻撃,こうげき,"attack, strike, offensive",JLPT JLPT_2 JLPT_3,fbxr=B^K{z
+貢献,こうけん,"contribution, services",JLPT JLPT_2 JLPT_3,im57ib}9qS
+広告,こうこく,advertisement,JLPT Genki_Ln.13 Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.15 Genki,qa5XPpB~K$
+交際,こうさい,"friendship, association, acquaintance",JLPT JLPT_2 JLPT_3,nH$6L6<H;R
+校舎,こうしゃ,school building,JLPT JLPT_2 JLPT_3,x5W<B+BK>R
+後者,こうしゃ,the latter,JLPT JLPT_2 JLPT_3,kUquk|vi;&
+工場,こうば,"factory, plant",JLPT JLPT_2 JLPT_3,"kU8AM-,iY!"
+公正,こうせい,"justice, fairness, impartiality",JLPT JLPT_2 JLPT_3,N@!)sH2_75
+構成,こうせい,"organization, composition",JLPT JLPT_2 JLPT_3,Fd-KLO&b~!
+高速,こうそく,"high speed, high gear",JLPT JLPT_2 JLPT_3,"B,HIrwQ4QK"
+行動,こうどう,"action, conduct, behavior",JLPT JLPT_2 JLPT_3,Q_m+2cq0*[
+強盗,ごうとう,"robbery, burglary",JLPT JLPT_2 JLPT_3,lC8A_#]SF+
+後輩,こうはい,junior members of a group,JLPT JLPT_3 JLPT_2 Genki_Ln.22 Genki,exC.)`@)h[
+幸福,こうふく,"happiness, blessedness",JLPT JLPT_2 JLPT_3,KnC^{e}c.-
+公平,こうへい,"fairness, impartial, justice",JLPT JLPT_2 JLPT_3,"HfCG]C,9b3"
+候補,こうほ,candidacy,JLPT JLPT_2 JLPT_3,jI7M_ck/=4
+考慮,こうりょ,"consideration, taking into account",JLPT JLPT_2 JLPT_3,ORy-9jIY.M
+越える,こえる,"to exceed, to cross over, to cross",JLPT JLPT_2 JLPT_3,Ps<w%<}`Nz
+超える,こえる,"to exceed, to cross over, to cross",JLPT JLPT_2 JLPT_3,rn/xivT%1v
+コーチ,コーチ,coach,JLPT JLPT_2 JLPT_3,E.482d:D0W
+コード,コード,code; cord; chord,JLPT JLPT_2 JLPT_3,QKH0$=zpP3
+氷,こおり,"ice, hail",JLPT JLPT_2 JLPT_3,jVp@v3rS)h
+凍る,こおる,"to freeze, to be frozen over, to congeal",JLPT JLPT_2 JLPT_3,A<P8Ao~%+S
+ゴール,ゴール,goal,JLPT JLPT_2 JLPT_3,PTY>]PCTXK
+誤解,ごかい,misunderstanding,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.15,FY37~etpV/
+語学,ごがく,language study,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.8,lSZ`^u4$^l
+呼吸,こきゅう,"breath, respiration",JLPT JLPT_2 JLPT_3,HYaR{=4wss
+故郷,こきょう,hometown,JLPT JLPT_2 JLPT_3,x[p9$Yy?#r
+極,ごく,"quite, very",JLPT JLPT_2 JLPT_3,x-os]7T;c
+国語,こくご,national language,JLPT JLPT_2 JLPT_3,P(9q-`0&O-
+国籍,こくせき,nationality,JLPT JLPT_2 JLPT_3,r.}Cb086.1
+黒板,こくばん,blackboard,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.13,gM[VFRJO/m
+克服,こくふく,"conquest, overcome",JLPT JLPT_2 JLPT_3,cg-)t|ngzK
+国民,こくみん,"national, people, citizen",JLPT JLPT_2 JLPT_3,K+q@X-WIB[
+穀物,こくもつ,"grain, cereal, corn",JLPT JLPT_2 JLPT_3,EVuq#tu]8|
+腰,こし,"hip, waist",JLPT JLPT_2 JLPT_3,m<9C4|i/Uj
+胡椒,こしょう,pepper,JLPT JLPT_2 JLPT_3,b)_&^<=JnX
+個人,こじん,"individual, private person",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14,xJ9*Qc)q|;
+越す,こす,"to go over (e.g., with audience)",JLPT JLPT_2 JLPT_3,N~a2o@b;S|
+超す,こす,"to cross, to pass, to tide over",JLPT JLPT_2 JLPT_3,E.}3vgSSP~
+国家,こっか,"state, country, nation",JLPT JLPT_2 JLPT_3,g^&ilH.z=f
+国会,こっかい,"National Diet, parliament, congress",JLPT JLPT_2 JLPT_3,xLo2`0x`}C
+国境,こっきょう,national or state border,JLPT JLPT_2 JLPT_3,"ni,}~dk?wC"
+骨折,こっせつ,bone fracture,JLPT JLPT_2 JLPT_3,KXTKU$f!R4
+小包,こづつみ,"parcel, package",JLPT JLPT_2 JLPT_3,EPSe<f!:WV
+琴,こと,Japanese harp,JLPT JLPT_2 JLPT_3,lswbJ>f(+[
+異なる,ことなる,"to differ, to vary",JLPT JLPT_2 JLPT_3,GI=<w6vpiE
+諺,ことわざ,"proverb, saying",JLPT JLPT_2 JLPT_3,NY!nEVJ<.6
+断る,ことわる,"to refuse, to decline, to dismiss",JLPT JLPT_2 JLPT_3,g8Tps~wm2h
+粉,こな,"flour, powder",JLPT JLPT_2 JLPT_3,"w.,c]65Xdw"
+好み,このみ,"liking, taste, choice",JLPT JLPT_2 JLPT_3,gist9XPg!/
+好む,このむ,"to like, to prefer",JLPT JLPT_2 JLPT_3,O)%aoWh139
+こぼす,こぼす,to spill,JLPT JLPT_2 JLPT_3,eD]eIT[NNo
+こぼれる,こぼれる,"to overflow, to spill",JLPT JLPT_2 JLPT_3,D8@l08%7LL
+塵,ごみ,"garbage, litter",JLPT JLPT_2 JLPT_3,A^PPEPy8?0
+小麦,こむぎ,wheat,JLPT JLPT_2 JLPT_3,QFa;ZcAclR
+ごめんなさい,ごめんなさい,"I beg your pardon, excuse me, I'm sorry",JLPT JLPT_3 JLPT_2 Genki_Ln.4 Genki,fxa7^/$d15
+小屋,こや,"hut, cabin, shed",JLPT JLPT_2 JLPT_3,L1:(fi`+1`
+これら,これら,these,JLPT JLPT_2 JLPT_3,bJ5Dn}}2bE
+殺す,ころす,to kill,JLPT JLPT_2 JLPT_3,FEbGULqZc5
+転ぶ,ころぶ,"to fall down, to fall over",JLPT Genki_Ln.18 JLPT_3 JLPT_2 Genki,fb9L+KGLPL
+今回,こんかい,"now, this time, lately",JLPT JLPT_2 JLPT_3,v>V@:|&Nyu
+今後,こんご,"from now on, hereafter",JLPT JLPT_2 JLPT_3,"i[%,=_sR{<"
+混雑,こんざつ,"confusion, congestion",JLPT JLPT_2 JLPT_3,nJ8&5%w5iO
+こんなに,こんなに,"so, like this, in this way",JLPT JLPT_2 JLPT_3,yp0~/ynI.y
+困難,こんなん,"difficulty, distress",JLPT JLPT_2 JLPT_3,d&:m/eYAE}
+今日,こんにち,"today, this day",JLPT JLPT_2 JLPT_3,v>M{d#cP&m
+こんにちは,こんにちは,"hello, good day (daytime greeting)",JLPT JLPT_2 JLPT_3,v[Wf5IN)l&
+婚約,こんやく,"engagement, betrothal",JLPT JLPT_2 JLPT_3,"K{EyJ!,l%Q"
+混乱,こんらん,"chaos, confusion, mayhem",JLPT JLPT_2 JLPT_3,"FayR37Z,t-"
+差,さ,"difference, variation",JLPT JLPT_2 JLPT_3,FOmfV#Q?35
+サービス,サービス,"service, support system; goods or services without charge",JLPT JLPT_2 JLPT_3,bg5_R(4_L^
+際,さい,"on the occasion of, circumstances",JLPT JLPT_2 JLPT_3,Nv+d+Us](G
+最高,さいこう,"highest, supreme, the most",JLPT JLPT_2 JLPT_3,"Onra,t[Ph&"
+財産,ざいさん,"property, fortune, assets",JLPT JLPT_2 JLPT_3,s;c/9B[#a4
+最終,さいしゅう,"last, closing",JLPT JLPT_2 JLPT_3,flW!HkNC&a
+最中,さいちゅう,in the middle of,JLPT JLPT_2 JLPT_3,Ek!(iCG2TX
+最低,さいてい,"least, lowest, worst",Genki_Ln.17 JLPT JLPT_3 JLPT_2 Genki,N/OsVi[gL-
+才能,さいのう,"talent, ability",JLPT JLPT_2 JLPT_3,DHNwuYd#?N
+裁判,さいばん,"trial, judgment",JLPT JLPT_2 JLPT_3,Cj0VNC)aXI
+材料,ざいりょう,"ingredients, material",JLPT JLPT_2 JLPT_3,k38qoD9zt6
+幸い,さいわい,fortunately; luckily,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.8,d2lSIg);.
+サイン,サイン,autograph; sign; sine,JLPT JLPT_2 JLPT_3,x?{c^]RVe$
+境,さかい,"border, boundary, mental state",JLPT JLPT_2 JLPT_3,QShv^7rF%|
+逆らう,さからう,"to go against, to oppose, to disobey",JLPT JLPT_2 JLPT_3,o`A^ehWi@^
+盛り,さかり,"helping, serving",JLPT JLPT_2 JLPT_3,v$YrLV9qnx
+作業,さぎょう,"work, operation, manufacturing",JLPT JLPT_2 JLPT_3,b=vHpFfwSZ
+裂く,さく,"to tear, to split",JLPT JLPT_2 JLPT_3,LDUwnq~#Q?
+昨,さく,"last (year), yesterday",JLPT JLPT_2 JLPT_3,GL+Y)4yXcS
+作品,さくひん,"work, opus, production",JLPT JLPT_2 JLPT_3,MGr8G06#z_
+作物,さくもつ,"produce (e.g., agricultural), crops",JLPT JLPT_2 JLPT_3,p(LSOs6uw7
+桜,さくら,"cherry blossom, cherry tree",JLPT JLPT_2 JLPT_3,Jm^a%*`E!g
+酒,さけ,"alcohol, sake",JLPT JLPT_2 JLPT_3,t}%j30SHEF
+叫ぶ,さけぶ,"to shout, to cry",JLPT JLPT_2 JLPT_3,E5;W<1MI2|
+避ける,さける,"to avoid (physical contact); to ward off, to avert",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.15,QIaY:U+_Wa
+支える,ささえる,"support, hold, sustain",JLPT JLPT_2 JLPT_3,e#(-!es11Q
+刺さる,ささる,"to stick, to be stuck",JLPT JLPT_2 JLPT_3,di2BW%43-n
+刺す,さす,"to sting, to bite (e.g., bug), to prick, to stab",JLPT JLPT_3 JLPT_2 Genki Genki_Ln.21,e48t5Q~CL_
+指す,さす,"to point,",JLPT JLPT_2 JLPT_3,k`e;TAGgko
+挿す,さす,"to insert, to put in, to graft",JLPT JLPT_2 JLPT_3,"MY60EU`x,H"
+注す,さす,"to pour (drink), to serve (drinks)",JLPT JLPT_2 JLPT_3,qH4&#`}]gG
+射す,さす,"to shine, to strike",JLPT JLPT_2 JLPT_3,u.)8@5Yw87
+座席,ざせき,seat,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.10,"tDVi}8QLX,"
+誘う,さそう,"to invite (someone to do something with you); to tempt, to lure",Genki_Ln.15 Intermediate_Japanese JLPT JLPT_3 JLPT_2 Intermediate_Japanese_Ln.7 Genki,t@[{w{yfI4
+札,さつ,"bill, note",JLPT JLPT_2 JLPT_3,wTy^V@~}^O
+作家,さっか,"author, writer, novelist",JLPT JLPT_2 JLPT_3,BKI1ycChW6
+作曲,さっきょく,composition (of music),JLPT JLPT_2 JLPT_3,Io0i{.3D4v
+ざっと,ざっと,"roughly, in round numbers",JLPT JLPT_2 JLPT_3,"l]%gAJA,OM"
+さっぱり,さっぱり,"feeling refreshed, neat",JLPT JLPT_2 JLPT_3,"f,Wl.Ci0`l"
+さて,さて,"well; now (typically used when switching to a new, usually more important topic)",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.12,LIh4>dp+/=
+砂漠,さばく,desert,JLPT JLPT_2 JLPT_3,kKUmiT9F9W
+差別,さべつ,"discrimination, differentiation",JLPT JLPT_2 JLPT_3,dyD!/ON4A8
+ママ,ママ,Mama,JLPT JLPT_2 JLPT_3,zyZFReMUU6
+豆,まめ,"beans, peas",JLPT JLPT_2 JLPT_3,GoM5kwLZ`E
+守る,まもる,to protect; to abide (by the rules),JLPT JLPT_2 JLPT_3,KIn|zt16*V
+迷う,まよう,"to be puzzled, to be perplexed, to lose one's way",JLPT JLPT_2 JLPT_3,L;:4YYq`)5
+丸,まる,"circle, full (month)",JLPT JLPT_2 JLPT_3,Q)LW*l-M`[
+円,まる,circle,JLPT JLPT_2 JLPT_3,c11Q@w}#J~
+まるで,まるで,just like,JLPT JLPT_2 JLPT_3,nQ6e%/X<.r
+万一,まんいち,"by some chance, if by any chance",JLPT JLPT_2 JLPT_3,H0H9j9*ddg
+満足,まんぞく,satisfaction,JLPT JLPT_2 JLPT_3,Qfyuj9^wer
+身,み,"body, main part",JLPT JLPT_2 JLPT_3,FD}%mUxg1n
+実,み,"fruit, seed, good result",JLPT JLPT_2 JLPT_3,j`zE[mIWkt
+見送り,みおくり,seeing one off,JLPT JLPT_2 JLPT_3,"zL,W$(?WXy"
+味方,みかた,"ally, supporter",JLPT JLPT_2 JLPT_3,EF85/VL>m_
+見事,みごと,"splendid, magnificent",JLPT JLPT_2 JLPT_3,FG5RYvwId;
+ミス,ミス,"miss (mistake, error, failure), Miss",JLPT_1 JLPT JLPT_2 JLPT_3,h#^4pNfLXB
+満ちる,みちる,"to be full, to mature",JLPT JLPT_2 JLPT_3,u[~LhQX)13
+密,みつ,"thick, close",JLPT JLPT_2 JLPT_3,Q7s<b_//qW
+認める,みとめる,"to recognize, to notice; to approve",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.13 Intermediate_Japanese_Ln.3,"JetA%b8l~,"
+見舞い,みまい,"expression of sympathy, expression of concern",JLPT JLPT_2 JLPT_3,nw{(:&zpou
+土産,みやげ,souvenir,JLPT JLPT_2 JLPT_3,z~]qvc)tb[
+都,みやこ,city; capital,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.10,B3uIy2Ddpn
+妙,みょう,"strange, unusual",JLPT JLPT_2 JLPT_3,LNAQ6Xt7x$
+明後日,みょうごにち,day after tomorrow,JLPT JLPT_2 JLPT_3,vq>.q}^O]P
+未来,みらい,future (life tense),JLPT JLPT_2 JLPT_3,Ghk@nVs)kS
+魅力,みりょく,"charm, fascination, appeal",JLPT JLPT_2 JLPT_3,w{[H?`kNh]
+診る,みる,to examine (a patient),JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.12,Ap.|xWc<xg
+ミルク,ミルク,milk,JLPT JLPT_2 JLPT_3,rW2yU+[.3;
+無,む,"nothing, naught, zero",JLPT JLPT_2 JLPT_3,M/]]Gfu|C<
+向かい,むかい,"facing, opposite, across",JLPT JLPT_2 JLPT_3,v-M][z30<G
+迎え,むかえ,"meeting, person sent to pick up an arrival",JLPT JLPT_2 JLPT_3,M.JFq}D{XW
+向く,むく,to face,JLPT JLPT_2 JLPT_3,"B?VOe(a,ck"
+剥く,むく,"to peel, to skin",JLPT JLPT_2 JLPT_3,O9G!=VsU$R
+向ける,むける,"to turn towards, to point",JLPT JLPT_2 JLPT_3,O0#L}~28:p
+無視,むし,"disregard, ignore",JLPT JLPT_2 JLPT_3,"H?.,UKB|]n"
+蒸し暑い,むしあつい,"humid, sultry",JLPT JLPT_2 JLPT_3,b:SYmm(y*W
+虫歯,むしば,"cavity, tooth decay",JLPT JLPT_2 JLPT_3,p^*~90tI~;
+寧ろ,むしろ,"rather, better, instead",JLPT JLPT_2 JLPT_3,iKd&nF*kp>
+蒸す,むす,"to steam, to poultice, to be sultry",JLPT JLPT_2 JLPT_3,A8e|Klqr_`
+結ぶ,むすぶ,"to tie, to bind, to link",JLPT JLPT_2 JLPT_3,ymg7!.{d0`
+無駄,むだ,"futility, uselessness",JLPT JLPT_2 JLPT_3,f?04M}_6S/
+夢中,むちゅう,"crush, crazy, be hooked on",JLPT JLPT_2 JLPT_3,c*kD_bu37.
+胸,むね,"breast, chest",JLPT JLPT_2 JLPT_3,yLcSyJ#.nc
+無料,むりょう,"free, no charge",JLPT JLPT_2 JLPT_3,JN6`<L^h|2
+芽,め,sprout,JLPT JLPT_2 JLPT_3,"j,J}0*}#hN"
+明確,めいかく,"clear, definite",JLPT JLPT_2 JLPT_3,DCM(3>-lRK
+名刺,めいし,(name) card; business card,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.1,K3cZp`gUUo
+名詞,めいし,noun,JLPT JLPT_2 JLPT_3,iPorDGRE(|
+命じる,めいじる,"to order, to command, to appoint",JLPT JLPT_2 JLPT_3,qg|.+Szu_I
+名人,めいじん,"master, expert",JLPT JLPT_2 JLPT_3,Fni-n$8WrW
+命令,めいれい,"order, command, decree",JLPT JLPT_2 JLPT_3,KKSB-pS%yq
+迷惑,めいわく,"trouble, bother, annoyance",JLPT JLPT_2 JLPT_3,"i.t)w,3ng-"
+目上,めうえ,person of higher status; one's senior,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.2,oNjcNV)ff[
+飯,めし,"meals, food",JLPT JLPT_2 JLPT_3,IWA[~#BL^U
+滅多に,めったに,"rarely (with neg. verb), seldom",JLPT JLPT_2 JLPT_3,j)#=ex#L)O
+メモ,メモ,"memorandum, note",JLPT JLPT_2 JLPT_3,"skJ)D[(,@."
+面,めん,"face, mug, surface, side or facet, corner, page",JLPT JLPT_2 JLPT_3,"w,_Ik;ZYes"
+綿,めん,cotton,JLPT JLPT_2 JLPT_3,zi)_)]=$49
+免許,めんきょ,"license, permit, certificate",JLPT JLPT_3 JLPT_2 Genki_Ln.22 Genki,giqsadF8[_
+面接,めんせつ,interview,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Genki Genki_Ln.23 Intermediate_Japanese_Ln.3,"G{,..f)t;T"
+面倒,めんどう,"trouble, attention",JLPT JLPT_2 JLPT_3,jarwg?`xYM
+メンバー,メンバー,member,JLPT JLPT_2 JLPT_3,ioP<e}C#*T
+申し込む,もうしこむ,"to apply for, to make an application",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.3,p-@iqxnx(*
+申し訳,もうしわけ,"apology, excuse",JLPT JLPT_2 JLPT_3,"w0A,13h@XG"
+毛布,もうふ,blanket,JLPT JLPT_2 JLPT_3,G|6QSL6HzW
+燃える,もえる,to burn,JLPT JLPT_2 JLPT_3,C2}(_d=*8]
+目的,もくてき,"purpose, goal, aim",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.3,"FrxXy0,/EI"
+目標,もくひょう,"mark, objective, target",JLPT JLPT_2 JLPT_3,eD#(2kEfi#
+文字,もじ,"letter (of alphabet), character",JLPT JLPT_2 JLPT_3,v{bw_z2KT.
+文字,もんじ,"letter (of alphabet), character",JLPT JLPT_2 JLPT_3,i}R1C0Kg[i
+もしかすると,もしかすると,"perhaps, maybe, by some chance",JLPT JLPT_2 JLPT_3,E_gTNRA!W1
+もしも,もしも,if,JLPT JLPT_2 JLPT_3,Q41Ox`49(P
+持ち上げる,もちあげる,"to raise, to lift up, to flatter",JLPT JLPT_2 JLPT_3,Ck3.ZXZ[6p
+用いる,もちいる,"to use, to make use of",JLPT JLPT_2 JLPT_3,so5H6d<zN+
+もったいない,もったいない,"wasteful; more than one deserves, unworthy of",JLPT JLPT_2 JLPT_3,yewBxbz7]I
+尤も,もっとも,"quite right, plausible, natural",JLPT JLPT_2 JLPT_3,A>F:Ft1w22
+元,もと,"origin, original; former",JLPT JLPT_2 JLPT_3,"O)La7,`]AY"
+基,もと,basis,JLPT JLPT_2 JLPT_3,Icp_M75Xpg
+素,もと,prime,JLPT JLPT_2 JLPT_3,yGr3{oX4%H
+戻す,もどす,"to restore, to put back, to return",JLPT JLPT_2 JLPT_3,PmY(.gc-w+
+基づく,もとづく,"to be grounded on, to be based on",JLPT JLPT_2 JLPT_3,I&bTc?WHhL
+求める,もとめる,"to request, to ask for; to seek, to search for",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.4,lJ&@p010:m
+者,もの,person (same as 人 (ひと)),JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.3,vAI([v0H/E
+物音,ものおと,sounds,JLPT JLPT_2 JLPT_3,hL<`ZEm#E^
+物語,ものがたり,"tale, story, legend",JLPT JLPT_2 JLPT_3,b2F39/cX@{
+物事,ものごと,"things, everything",JLPT JLPT_2 JLPT_3,JYu;9)KWYP
+燃やす,もやす,to burn,JLPT JLPT_2 JLPT_3,h5FjFnJT{r
+模様,もよう,"pattern, figure, design",JLPT JLPT_2 JLPT_3,DCW6|C<9T)
+文句,もんく,a complaint,JLPT Intermediate_Japanese Genki JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14 Genki_Ln.21 Intermediate_Japanese_Ln.11,"q,87=b37fY"
+やがて,やがて,"before long, soon, at length",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.8,nlnms.mL_|
+役,やく,"role, position",JLPT JLPT_2 JLPT_3,sc=i9?h^tQ
+約,やく,"approximately, about, some",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.11,L31l;C5Xp=
+訳,やく,translation,JLPT JLPT_2 JLPT_3,CmgPQjblgT
+訳す,やくす,to translate,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.2,Cj2Ni~H!BW
+役割,やくわり,"assigning (allotment of) parts, role, duties",JLPT JLPT_2 JLPT_3,"jj*z,nk6$Z"
+家賃,やちん,rent,JLPT Genki_Ln.18 JLPT_3 JLPT_2 Genki,Og7<v^:R8@
+厄介,やっかい,"trouble, burden, care",JLPT JLPT_2 JLPT_3,O_#+8qFx*C
+宿,やど,"inn, lodging",JLPT JLPT_2 JLPT_3,F8A%9EzpfO
+雇う,やとう,"to employ, to hire",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.8,fsV)jU5lVf
+屋根,やね,roof,JLPT JLPT_2 JLPT_3,K@]5qy=.%v
+破る,やぶる,to tear; to violate; to defeat,JLPT JLPT_2 JLPT_3,Hc|1rO==::
+破れる,やぶれる,"to get torn, to wear out",JLPT JLPT_2 JLPT_3,Q>N&s5^Kb%
+辞める,やめる,to retire,JLPT JLPT_2 JLPT_3,J|2c^zFs0y
+やや,やや,"a little, partially, somewhat",JLPT JLPT_2 JLPT_3,OikgR+nKY0
+唯一,ゆいいつ,"only, sole, unique",JLPT JLPT_2 JLPT_3,mNuH=kxM-E
+勇気,ゆうき,"courage, bravery, boldness",JLPT JLPT_2 JLPT_3,z0tdm#]12w
+友好,ゆうこう,friendship,JLPT JLPT_2 JLPT_3,qSk@+t:._p
+有効,ゆうこう,"valid, effectual",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.10,iL.?i)%fKm
+優秀,ゆうしゅう,"superiority, excellence",JLPT JLPT_2 JLPT_3,O^v!ja{$6}
+優勝,ゆうしょう,"overall victory, championship",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.7,Gxir)F$3h;
+友情,ゆうじょう,"friendship, fellowship",JLPT JLPT_2 JLPT_3,hpnSza2$^g
+友人,ゆうじん,friend (formal),JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.15 Intermediate_Japanese_Ln.2,iE%IT=Qp]>
+有能,ゆうのう,"able, capable, efficient",JLPT JLPT_2 JLPT_3,P0&QeU;_J8
+郵便,ゆうびん,"mail, postal service",JLPT JLPT_2 JLPT_3,y1Pm-8jy]k
+ユーモア,ユーモア,humor,JLPT JLPT_2 JLPT_3,df%[k|%u*+
+有利,ゆうり,"advantageous, better",JLPT JLPT_2 JLPT_3,H]2^aHqq32
+床,ゆか,floor,JLPT JLPT_2 JLPT_3,lG~]%rmVy|
+愉快,ゆかい,"pleasant, happy",JLPT JLPT_2 JLPT_3,"o,+Kowdko`"
+譲る,ゆずる,"to turn over, to assign, to hand over",JLPT JLPT_2 JLPT_3,Hvg@/iJB}O
+豊か,ゆたか,"abundant, wealthy, plentiful, rich",JLPT JLPT_2 JLPT_3,"d9lbZ0yM,{"
+茹でる,ゆでる,to boil,JLPT JLPT_2 JLPT_3,vocx6RiGG7
+許す,ゆるす,"to permit, to allow, to approve",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.8,jUZ.+k2dQs
+夜,よ,"evening, night",JLPT JLPT_2 JLPT_3,O|UO#;VR|i
+夜明け,よあけ,"dawn, daybreak",JLPT JLPT_2 JLPT_3,P]gvvnr3UX
+酔う,よう,to get drunk,JLPT JLPT_2 JLPT_3,Nw#Iv9NMME
+容易,ようい,"easy, simple, plain",JLPT JLPT_2 JLPT_3,P+bB1Di`Ky
+容器,ようき,"container, vessel",JLPT JLPT_2 JLPT_3,iaea{|Cg@:
+陽気,ようき,"season, weather, cheerfulness",JLPT JLPT_2 JLPT_3,u51di;kV4W
+要求,ようきゅう,"request, demand",JLPT JLPT_2 JLPT_3,nvC?4QsNf}
+用心,ようじん,"care, precaution, caution",JLPT JLPT_2 JLPT_3,Flc5De-&7.
+様子,ようす,"aspect, state, appearance",JLPT JLPT_2 JLPT_3,A7/`ZQ{`>8
+要するに,ようするに,"in a word, after all, in short …",JLPT JLPT_2 JLPT_3,FOjPBhXtfP
+要素,ようそ,element,JLPT JLPT_2 JLPT_3,GZk%&=rm6%
+要点,ようてん,"gist, main point",JLPT JLPT_2 JLPT_3,Qs5wBsMZ.}
+曜日,ようび,day of the week,JLPT JLPT_2 JLPT_3,H-|U<zuUTq
+ヨーロッパ,ヨーロッパ,Europe,JLPT JLPT_2 JLPT_3,cEJaT(aXg
+予期,よき,"expectation, forecast",JLPT JLPT_2 JLPT_3,k(Z/4d8ciX
+横切る,よこぎる,"to cross (e.g., arms), to traverse",JLPT JLPT_2 JLPT_3,ba+_Ekz}4>
+汚す,よごす,"to pollute, to make dirty",JLPT JLPT_2 JLPT_3,gASRu}ar&]
+予算,よさん,"estimate, budget",JLPT JLPT_2 JLPT_3,k15uOKT$nk
+止す,よす,"to cease, to give up",JLPT JLPT_2 JLPT_3,g87)Rqp|@G
+寄せる,よせる,"to collect, to gather, to put aside",JLPT JLPT_2 JLPT_3,M9{&7Gc5&~
+予測,よそく,"prediction, estimation",JLPT JLPT_2 JLPT_3,E(^1aDIi!6
+ヨット,ヨット,yacht,JLPT JLPT_2 JLPT_3,G/C^ah63g_
+夜中,よなか,"midnight, dead of night",JLPT JLPT_2 JLPT_3,QTA:28I)zV
+世の中,よのなか,"society, the world",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14,zQaur22G#@
+余分,よぶん,"extra, excess, surplus",JLPT JLPT_2 JLPT_3,uLcn4c5r}h
+予報,よほう,"forecast, prediction",JLPT JLPT_2 JLPT_3,CpZ2Kf3K1p
+予防,よぼう,"prevention, protection against",JLPT JLPT_2 JLPT_3,rDZhF+<_&}
+読み,よみ,reading,JLPT JLPT_2 JLPT_3,K?H`Don1~V
+嫁,よめ,"bride, daughter-in-law",JLPT JLPT_2 JLPT_3,oRq&EQjfdU
+余裕,よゆう,excess; surplus,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.15,E;;B#u-gwT
+より,より,"twist, ply",JLPT JLPT_2 JLPT_3,"P,gDgn3/%z"
+因る,よる,to come from,JLPT JLPT_2 JLPT_3,bk:?0yP.}A
+喜び,よろこび,"joy, pleasure, rejoicing",JLPT JLPT_2 JLPT_3,K+wNM)/!OH
+よろしく (かん),よろしく (かん),"best regards, please remember me",JLPT JLPT_2 JLPT_3,uLM;15kvNe
+四,よん,four,JLPT JLPT_2 JLPT_3,FT^HSOQQHt
+来,らい～,next ~,JLPT JLPT_2 JLPT_3,A=wX.vJ`;k
+ライター,ライター,lighter; writer,JLPT JLPT_2 JLPT_3,NgUl4>*Khu
+楽,らく,"comfort, ease",JLPT JLPT_2 JLPT_3,DiE;3Dx>c<
+ラケット,ラケット,racket,JLPT JLPT_2 JLPT_3,rc5WF%qwi^
+利益,りえき,"profits, gains",JLPT JLPT_2 JLPT_3,j{(4)&Jk(I
+理解,りかい,"understanding, comprehension",JLPT JLPT_2 JLPT_3,kKF%t{|4d1
+陸,りく,"land, shore",JLPT JLPT_2 JLPT_3,f7mi}zh7:U
+利口,りこう,"clever, shrewd, bright",JLPT JLPT_2 JLPT_3,fywFMWmChi
+離婚,りこん,divorce,JLPT JLPT_2 JLPT_3,PI9p-(a/mR
+理想,りそう,ideal,JLPT JLPT_3 JLPT_2 Genki_Ln.23 Genki,Ev]+?).P_6
+率,りつ,"rate, ratio, percentage",JLPT JLPT_2 JLPT_3,s+WV`q_zTd
+留学,りゅうがく,studying abroad,JLPT JLPT_2 JLPT_3,jA_j8gA?Xq
+流行,りゅうこう,"fashionable, fad, prevailing",JLPT JLPT_2 JLPT_3,oDwVFzWRDw
+量,りょう,"quantity, amount",JLPT JLPT_2 JLPT_3,EL&y=qJ[p]
+寮,りょう,"hostel, dormitory",Genki_Ln.17 JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.2 Genki,v~j5~V9)9G
+両替,りょうがえ,"change, money exchange",JLPT JLPT_2 JLPT_3,d:;<z]06Bi
+料金,りょうきん,"fee, charge, fare",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.10,zVvm;g>0?l
+例,れい,"instance, example, case",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.2,kB-8@n:7>K
+礼,れい,expression of gratitude; bow,JLPT JLPT_2 JLPT_3,EZ&Acuix#;
+例外,れいがい,exception,JLPT JLPT_2 JLPT_3,tw6[F{cyVX
+礼儀,れいぎ,"manners, courtesy, etiquette",JLPT JLPT_2 JLPT_3,Gd12dxU_~f
+冷静,れいせい,"calm, coolness",JLPT JLPT_2 JLPT_3,B49T]&wBB/
+列,れつ,"queue, line, row",JLPT JLPT_2 JLPT_3,xG=0sSj|M]
+列車,れっしゃ,train (ordinary),JLPT JLPT_2 JLPT_3,QT2^`L&p0(
+レベル,レベル,level,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.5,zpbh!KoN[L
+連想,れんそう,"association (of ideas), suggestion",JLPT JLPT_2 JLPT_3,"NQ21Zh,%s4"
+連続,れんぞく,"consecutive, continuity, continuing",JLPT JLPT_2 JLPT_3,ODN;p&H}o6
+老人,ろうじん,"the aged, old person",JLPT JLPT_2 JLPT_3,Fz<ozu`hKp
+労働,ろうどう,"labor, work",JLPT JLPT_2 JLPT_3,svW#2;;Cv:
+ロケット,ロケット,"locket, rocket",JLPT JLPT_2 JLPT_3,s>l2C%ZS6!
+論じる,ろんじる,"to argue, to discuss",JLPT JLPT_2 JLPT_3,PV@[>Orc)!
+論争,ろんそう,"controversy, dispute",JLPT JLPT_2 JLPT_3,OnROo#.Af[
+論文,ろんぶん,"thesis, paper",JLPT JLPT_2 JLPT_3,x9Y&i=]xwo
+輪,わ,"ring, hoop, circle",JLPT JLPT_2 JLPT_3,FnX+2P-4%V
+ワイン,ワイン,wine,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.9,k_34Ad?RbL
+わがまま,わがまま,"selfishness, egoism, willfulness",JLPT JLPT_2 JLPT_3,EZq`y]jF5A
+別れ,わかれ,"parting, separation, farewell",JLPT JLPT_2 JLPT_3,OMtj+e3iBn
+分かれる,わかれる,"to branch off, to diverge from",JLPT JLPT_2 JLPT_3,"h3]%FQ}r,e"
+脇,わき,side,JLPT JLPT_2 JLPT_3,jKWknj-GZC
+湧く,わく,"to boil, to grow hot",JLPT JLPT_2 JLPT_3,eVR+00~Wm
+分ける,わける,"to divide, to separate",JLPT JLPT_2 JLPT_3,o0j(Vbh=Dm
+わざと,わざと,on purpose,JLPT JLPT_2 JLPT_3,viYnUwNT3<
+僅か,わずか,"only, merely, a little",JLPT JLPT_2 JLPT_3,q2B/3.([A6
+綿,わた,cotton,JLPT JLPT_2 JLPT_3,v86=9+m*Zo
+話題,わだい,"topic, subject",JLPT JLPT_2 JLPT_3,z8.CmK<Fdr
+笑い,わらい,"laugh, laughter, smile",JLPT JLPT_2 JLPT_3,DQ4$VTV1]U
+割る,わる,"to divide, to break",JLPT JLPT_2 JLPT_3,oEUIbaXq]C
+悪口,わるくち,"abuse, insult",JLPT JLPT_2 JLPT_3,"d]Rs;YIR,B"
+我々,われわれ,we,JLPT JLPT_2 JLPT_3,E2(6GHR8(/
+湾,わん,"bay, gulf, inlet",JLPT JLPT_2 JLPT_3,P6{jsCe:#w
+椀,わん,bowl,JLPT JLPT_2 JLPT_3,l4kkf<]hlo
+碗,わん,bowl,JLPT JLPT_2 JLPT_3,jaH28ERkuW
+悪,あく,"evil, vice",JLPT_1 JLPT JLPT_3,Q1DWi+VRb<
+当り,あたり,"hit, success, reaching the mark",JLPT_1 JLPT JLPT_3,pvdd^T@ma/
+アップ,アップ,up,JLPT_1 JLPT JLPT_3,A[u&?[.Bro
+宛てる,あてる,"to address, to put",JLPT_1 JLPT JLPT_3,l&CGpg$n)R
+アンケート,アンケート,"questionnaire (FRE: enquete), survey",JLPT_1 JLPT JLPT_3,"jvw,M=`Mc4"
+異,い,difference (of opinion),JLPT_1 JLPT JLPT_3,KWy%Q&s$/y
+意,い,will,JLPT_1 JLPT JLPT_3,ue.p8Uogo]
+医院,いいん,"doctor's office (surgery), clinic",JLPT_1 JLPT JLPT_3,cxetSKwBbl
+怒り,いかり,anger,JLPT_1 JLPT JLPT_3,eag:XoP`Iu
+粋,いき,"chic, style, purity",JLPT_1 JLPT JLPT_3,ugWhTIM%@o
+意地,いじ,"disposition, spirit, obstinacy, appetite",JLPT_1 JLPT JLPT_3,Bt*R$hF@~7
+依然,いぜん,"still, as yet",JLPT_1 JLPT JLPT_3,gx*_AN|$_R
+傷める,いためる,"to damage, to impair, to spoil",JLPT_1 JLPT JLPT_3,uF3-=@-Bpo
+炒める,いためる,to stir-fry,JLPT_1 JLPT JLPT_3,"G^,`T^H<Y$"
+一帯,いったい,"a region, the whole place",JLPT_1 JLPT JLPT_3,DAOK/%LCS(
+異動,いどう,"a change, transfer",JLPT_1 JLPT JLPT_3,ew^/izF?S5
+衣料,いりょう,clothing,JLPT_1 JLPT JLPT_3,gj0|x/@YEn
+渦,うず,swirl,JLPT_1 JLPT JLPT_3,sfWs{S%^qV
+埋まる,うまる,"to be buried, to be filled",JLPT_1 JLPT JLPT_3,7lK)HuokX
+産む,うむ,"to give birth (v.t.), to deliver, to produce",JLPT Intermediate_Japanese JLPT_1 JLPT_3 Intermediate_Japanese_Ln.14,r|}xM1gEOl
+縁,えん,"chance, tie, relationship",JLPT_1 JLPT JLPT_3,oaiH%ZtU~K
+尾,お,"tail, ridge",JLPT_1 JLPT JLPT_3,wE6#3`(P-s
+負う,おう,"to bear, to owe",JLPT_1 JLPT JLPT_3,u~;tItu4oL
+遅れ,おくれ,"delay, lag",JLPT Intermediate_Japanese JLPT_1 JLPT_3 Intermediate_Japanese_Ln.14,l%9;2PC4x+
+教え,おしえ,"teachings, doctrine",JLPT_1 JLPT JLPT_3,xPgyX4=PH+
+驚き,おどろき,"surprise, astonishment, wonder",JLPT_1 JLPT JLPT_3,uYPDwf:Xey
+織る,おる,to weave,JLPT_1 JLPT JLPT_3,H-^?L/FUtJ
+欠く,かく,"to lack, to crack",JLPT_1 JLPT JLPT_3,"y:z4,KW,Y-"
+角,かく,angle,JLPT_1 JLPT JLPT_3,Q3RPtFjJo6
+核,かく,"nucleus, kernel",JLPT_1 JLPT JLPT_3,e?}Lbq98=N
+格,かく,"status, character, case",JLPT_1 JLPT JLPT_3,Bd<&>IEN#(
+学歴,がくれき,academic background,JLPT_1 JLPT JLPT_3,"oJD!i#Ghj,"
+駆ける,かける,to run,JLPT_1 JLPT JLPT_3,AlwjF+uaKO
+賭ける,かける,"to bet, to risk, to gamble",JLPT_1 JLPT JLPT_3,dX$E2ISF?E
+課題,かだい,"subject, theme, task",JLPT_1 JLPT JLPT_3,JNxi3:**/$
+片付け,かたづけ,"tidying up, finishing",JLPT_1 JLPT JLPT_3,b8#*+`Yer.
+加味,かみ,"seasoning, flavoring",JLPT_1 JLPT JLPT_3,IDJ]6]i7Jx
+借り,かり,"borrowing, debt, loan",JLPT_1 JLPT JLPT_3,eJ@~/@E_cp
+狩り,かり,hunting,JLPT_1 JLPT JLPT_3,F*!5GCg4U&
+管,かん,"pipe, tube",JLPT_1 JLPT JLPT_3,fcs)GZ>f[[
+～観,かん,"feeling, view",JLPT_1 JLPT JLPT_3,L#gN7p7zR4
+癌,がん,cancer,JLPT_1 JLPT JLPT_3,"p~,cAC,D+|"
+刊行,かんこう,"publication, issue",JLPT_1 JLPT JLPT_3,M#=U8)QH)D
+慣行,かんこう,"customary practice, habit, traditional event",JLPT_1 JLPT JLPT_3,xk+2IzF[p%
+歓声,かんせい,"cheer, shout of joy",JLPT_1 JLPT JLPT_3,"w6B,F.u4!."
+官僚,かんりょう,"bureaucrat, bureaucracy",JLPT_1 JLPT JLPT_3,vh@[V;%&ao
+器官,きかん,"organ (of body, instrument)",JLPT_1 JLPT JLPT_3,N2?AghIU$R
+季刊,きかん,"quarterly (e.g., magazine)",JLPT_1 JLPT JLPT_3,I;$Bk_n?X#
+起源,きげん,"origin, beginning, rise",JLPT_1 JLPT JLPT_3,tlShs$oI^}
+機構,きこう,"mechanism, organization",JLPT_1 JLPT JLPT_3,i}B:Es]N)f
+築く,きずく,"to build, to establish",JLPT_1 JLPT JLPT_3,i^HMG^80!G
+規制,きせい,regulation,JLPT_1 JLPT JLPT_3,CN`|`I@cQ2
+丘陵,きゅうりょう,hill,JLPT_1 JLPT JLPT_3,"E9ld1,7]!f"
+協議,きょうぎ,"conference, discussion, negotiation",JLPT_1 JLPT JLPT_3,Q?<#X?Sj/E
+享受,きょうじゅ,"enjoyment, being given",JLPT_1 JLPT JLPT_3,QIS<k>N.yl
+協調,きょうちょう,"co-operation, conciliation, harmony",JLPT_1 JLPT JLPT_3,q1MP[9CeAj
+切り,きり,"limits, place to leave off",JLPT_1 JLPT JLPT_3,B0AWr56JJ:
+菌,きん,"germ, bacterium",JLPT_1 JLPT JLPT_3,tmpS/:#W86
+近視,きんし,nearsightedness,JLPT_1 JLPT JLPT_3,"NkNB,nl-$5"
+苦,く,"trouble, worry, difficulty",JLPT_1 JLPT JLPT_3,rAG1%p4z{~
+群,ぐん,group,JLPT_1 JLPT JLPT_3,"LN,Tx3PlR-"
+刑,けい,"penalty, sentence, punishment",JLPT_1 JLPT JLPT_3,"lZo,b@3#8r"
+経緯,けいい,"sequence of events, course",JLPT_1 JLPT JLPT_3,vg;b<1L}X}
+計器,けいき,"meter, gauge",JLPT_1 JLPT JLPT_3,D|{=p=rf^U
+契機,けいき,"opportunity, chance",JLPT_1 JLPT JLPT_3,K8C9CieJaA
+携帯,けいたい,carrying something; mobile telephone,JLPT_1 JLPT JLPT_3,IrGZ6yI4>+
+形態,けいたい,"form, shape, figure",JLPT_1 JLPT JLPT_3,e/5N$:Z!T-
+血管,けっかん,blood vessel,JLPT_1 JLPT JLPT_3,QbJ9AEIh9>
+決行,けっこう,"doing (with resolve), carrying out (e.g., a plan)",JLPT_1 JLPT JLPT_3,F-+3sLP~)5
+件,けん,"matter, case, item",JLPT_1 JLPT JLPT_3,kQ?0ViPK+4
+減少,げんしょう,"decrease, reduction, decline",JLPT_1 JLPT JLPT_3,k4_<}lhTb#
+公演,こうえん,public performance,JLPT_1 JLPT JLPT_3,H?FP7|9MSw
+後悔,こうかい,"regret, repentance",JLPT_1 JLPT JLPT_3,Q1e2dQ@sG$
+航海,こうかい,"sail, voyage",JLPT_1 JLPT JLPT_3,dFa`<B!Rly
+拘束,こうそく,"restriction, restraint",JLPT_1 JLPT JLPT_3,wAH|5]9<;T
+荒廃,こうはい,ruin,JLPT_1 JLPT JLPT_3,Pi<&-yXN08
+降伏,こうふく,"capitulation, surrender, submission",JLPT_1 JLPT JLPT_3,nz>D*v/PPD
+興奮,こうふん,"excitement, stimulation",JLPT_1 JLPT JLPT_3,uG+;eVvuCD
+語句,ごく,"words, phrases",JLPT_1 JLPT JLPT_3,IeE<Oj.e6u
+個々,ここ,"individual, one by one",JLPT_1 JLPT JLPT_3,p2d:ics3}r
+故人,こじん,the deceased,JLPT_1 JLPT JLPT_3,i${0Y&niQE
+小銭,こぜに,"coins, small change",JLPT_1 JLPT JLPT_3,"e/(},oiNGD"
+ことによると,ことによると,(depending on the circumstances),JLPT_1 JLPT JLPT_3,B{&~P5e&VY
+コンテスト,コンテスト,contest,JLPT_1 JLPT JLPT_3,sp5g%^>}gq
+採集,さいしゅう,"collecting, gathering",JLPT_1 JLPT JLPT_3,Np[aMg9Zl4
+作,さく,"a work, a harvest",JLPT_1 JLPT JLPT_3,e0vQj1EM3V
+策,さく,"plan, policy",JLPT_1 JLPT JLPT_3,m7/9u%VJ!K
+設備,せつび,"equipment, device, facilities",JLPT JLPT_2 JLPT_3,LIo%jKRqQs
+絶滅,ぜつめつ,"destruction, extinction",JLPT JLPT_2 JLPT_3,io[YAo{Uu@
+節約,せつやく,"economizing, saving",JLPT JLPT_2 JLPT_3,"HN*O,b6I.s"
+攻める,せめる,"to attack, to assault",JLPT JLPT_2 JLPT_3,tc4C[W7HwN
+責める,せめる,"to condemn, to blame, to criticize",JLPT JLPT_2 JLPT_3,h&^&{;rWzw
+善,ぜん,"good, virtue",JLPT JLPT_2 JLPT_3,I+Wsd9&>8`
+全,ぜん,"all, whole, entire",JLPT JLPT_2 JLPT_3,"AlSQZeMOe,"
+全員,ぜんいん,all members,JLPT JLPT_2 JLPT_3,sZoXHnMU/8
+専攻,せんこう,"major subject, special study",JLPT JLPT_2 JLPT_3,ya8a{Dc>vj
+全国,ぜんこく,"the entire nation, country-wide, nation-wide",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.7,^t`okG[_.
+洗剤,せんざい,detergent,JLPT JLPT_2 JLPT_3,L<+Y;nNWE2
+先日,せんじつ,"the other day, a few days ago",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.2,u}70pX97Ud
+前者,ぜんしゃ,the former,JLPT JLPT_2 JLPT_3,PvTkSo0mR<
+選手,せんしゅ,player selected for a team (usually athletic),JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.7,v.;e@CEJx|
+全身,ぜんしん,"the whole body, full-length (portrait)",JLPT JLPT_2 JLPT_3,pwxE{6M)x(
+前進,ぜんしん,"advance, drive, progress",JLPT JLPT_2 JLPT_3,Bf[eOsL^b6
+センター,センター,center,JLPT JLPT_2 JLPT_3,CxiSJ@d^~:
+全体,ぜんたい,"whole, entirety, whatever (is the matter)",JLPT JLPT_2 JLPT_3,"P>z,++>r(]"
+選択,せんたく,"selection, choice",JLPT JLPT_2 JLPT_3,k:.P/+fPZu
+宣伝,せんでん,"advertisement, publicity",JLPT JLPT_2 JLPT_3,JC$lTUtjG[
+象,ぞう,elephant,JLPT Genki_Ln.13 JLPT_3 JLPT_2 Genki,q&<afrju^O
+騒音,そうおん,noise,JLPT JLPT_2 JLPT_3,Nq>ZUuvl@9
+増加,ぞうか,"increase, addition",JLPT JLPT_2 JLPT_3,LCq]gC<#T)
+操作,そうさ,"operation, management, processing",JLPT JLPT_2 JLPT_3,"mJ]7X>,V`y"
+想像,そうぞう,"imagination, guess",JLPT JLPT_2 JLPT_3,k^1Z0>wFtS
+相続,そうぞく,"succession, inheritance",JLPT JLPT_2 JLPT_3,gLl5L9nWQL
+装置,そうち,"equipment, installation, apparatus",JLPT JLPT_2 JLPT_3,QP$y~p+;R`
+相当,そうとう,"considerably, fairly; worth ~",JLPT JLPT_2 JLPT_3,X|0~/xXGn
+速度,そくど,"speed, velocity, rate",JLPT JLPT_2 JLPT_3,H;GE;N$A%]
+底,そこ,"bottom, sole",JLPT JLPT_2 JLPT_3,E!a4:Hc]KR
+そこで,そこで,"so (conj.), accordingly",JLPT JLPT_2 JLPT_3,Q`8<U+}b2H
+組織,そしき,organization; structure; tissue,JLPT JLPT_2 JLPT_3,zpGgl@h_Va
+そして,そして,and then,JLPT Genki_Ln.11 JLPT_3 JLPT_2 Genki,HVz1zz!rU*
+注ぐ,そそぐ,to pour (into),JLPT JLPT_2 JLPT_3,O|qtLZv)ag
+育つ,そだつ,"to be brought up, to grow (up)",JLPT JLPT_2 JLPT_3,DVd%wrkTnE
+そっくり,そっくり,the splitting image of; entirely,JLPT JLPT_2 JLPT_3,"il,5{T<Ci/"
+そっと,そっと,"softly, gently",JLPT JLPT_2 JLPT_3,dNlkAuY%B;
+袖,そで,sleeve,JLPT JLPT_2 JLPT_3,qAnG-iHgN/
+備える,そなえる,"to prepare, to furnish, to store",JLPT JLPT_2 JLPT_3,nSf<nF|Wp=
+具える,そなえる,to be furnished with,JLPT JLPT_2 JLPT_3,HK##7~;{8M
+そのうえ,そのうえ,"in addition, furthermore",JLPT JLPT_2 JLPT_3,g4O`W+&@o;
+そのうち,そのうち,"before long, eventually, sooner or later",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.1,PuLL>@8)rT
+そのまま,そのまま,"without change, as it is (e.g., now)",JLPT JLPT_2 JLPT_3,Ct<iM4(-qV
+蕎麦,そば,soba (buckwheat noodles),JLPT JLPT_2 JLPT_3,Bbh7N0fI`c
+ソファー,ソファー,"sofa, couch",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.12,z;bE4U6LP3
+粗末,そまつ,"humble, miserable, crude",JLPT JLPT_2 JLPT_3,j6Do>kVF89
+それぞれ,それぞれ,"each, every, respectively",JLPT JLPT_2 JLPT_3,IU/9u{#l]`
+それでも,それでも,"but (still), and yet, nevertheless",JLPT JLPT_2 JLPT_3,A4Ma6XxBkC
+それと,それと,and,JLPT JLPT_2 JLPT_3,qT%b.lO-Up
+それとも,それとも,"or, or else",JLPT JLPT_2 JLPT_3,FIBH9OiuNP
+揃う,そろう,"to become complete, to be equal",JLPT JLPT_2 JLPT_3,eH+q6_0;;H
+揃える,そろえる,"to put things in order, to arrange",JLPT JLPT_2 JLPT_3,"Hx^8k,vcgU"
+損,そん,"loss, disadvantage",JLPT JLPT_2 JLPT_3,r5pYyEz*uG
+損害,そんがい,"damage, loss",JLPT JLPT_2 JLPT_3,KNy-!0Msk~
+尊敬,そんけい,"respect, reverence, honor",JLPT JLPT_2 JLPT_3,nh_pmhy#.q
+存在,そんざい,"existence, being",JLPT JLPT_2 JLPT_3,Ah?vt+0Deq
+尊重,そんちょう,"respect, esteem, regard",JLPT JLPT_2 JLPT_3,h?{mP2f_-B
+田,た,rice field,JLPT JLPT_2 JLPT_3,"w7MwtWnKt,"
+他,た,other (esp. places and things),JLPT JLPT_2 JLPT_3,P;is[6zAC!
+対,たい,"pair, couple, set",JLPT JLPT_2 JLPT_3,"Moj,JFB9!<"
+大,だい,"big, great",JLPT JLPT_2 JLPT_3,LwTE(&7K+A
+題,だい,"title, subject, theme",JLPT JLPT_2 JLPT_3,F^XD~^:A@0
+体育,たいいく,"physical education, gymnastics, athletics",JLPT JLPT_2 JLPT_3,CYaFjR7lk/
+体温,たいおん,temperature (body),JLPT JLPT_2 JLPT_3,JV$<Rwhu{y
+大会,たいかい,"convention, (big) tournament, mass meeting",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.7,qPbid=y~O&
+大気,たいき,atmosphere,JLPT JLPT_2 JLPT_3,"Hhm(,tKo;q"
+代金,だいきん,"price, cost",JLPT JLPT_2 JLPT_3,d6Cwm*}ZjB
+退屈,たいくつ,"tedium, boring",JLPT JLPT_2 JLPT_3,F(8G#=fSzj
+滞在,たいざい,"stay, sojourn",JLPT JLPT_2 JLPT_3,bk>r|^ok!J
+大使,たいし,ambassador,JLPT JLPT_2 JLPT_3,zN!*9mGhu4
+大した,たいした,"significant, great, considerable",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.13,oM^M6iE>L5
+体重,たいじゅう,(body) weight,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.4,t`1!Oqj**T
+対象,たいしょう,"target; object (of worship, study, etc.); subject (i.e., of taxation)",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.8,"p^#)B+1eX,"
+対照,たいしょう,"contrast, antithesis, comparison",JLPT JLPT_2 JLPT_3,n>fKKV=_7/
+大臣,だいじん,cabinet minister,JLPT JLPT_2 JLPT_3,Ob3O=(AH>h
+対する,たいする,"to face, to confront, to oppose",JLPT JLPT_2 JLPT_3,ybI4-s}gla
+大戦,たいせん,"great war, great battle",JLPT JLPT_2 JLPT_3,f`t4(w295-
+態度,たいど,"attitude, manner",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.3,CRe5#!Zg2
+大統領,だいとうりょう,president,JLPT JLPT_2 JLPT_3,mQ?{N?L_2<
+大半,たいはん,"most of, majority, mostly",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.13,L@eG[f#yFA
+代表,だいひょう,"representative, delegation",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.7,[cqqR!>%Z
+大部分,だいぶぶん,"most part, majority",JLPT JLPT_2 JLPT_3,xCOUr6=j:7
+タイプライター,タイプライター,typewriter,JLPT JLPT_2 JLPT_3,wfroZ+;inq
+逮捕,たいほ,"arrest, apprehension, capture",JLPT JLPT_2 JLPT_3,"mP*P.Zr^,5"
+題名,だいめい,title,JLPT JLPT_2 JLPT_3,x5M%%Ua514
+ダイヤ,ダイヤ,(railway) schedule; diamond,JLPT JLPT_2 JLPT_3,u65Ybwgo>d
+太陽,たいよう,sun,JLPT JLPT_2 JLPT_3,Ods5M>&o#p
+平ら,たいら,"flatness, level, smooth",JLPT JLPT_2 JLPT_3,CCHa|.m;y*
+代理,だいり,"representation, proxy, deputy",JLPT JLPT_2 JLPT_3,`LJ^*Zc6.
+大陸,たいりく,continent,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.8,"j9v8D@q,-`"
+倒す,たおす,"to throw down, to beat",JLPT JLPT_2 JLPT_3,O)2K@u<S75
+タオル,タオル,(hand) towel,JLPT Genki_Ln.18 JLPT_3 JLPT_2 Genki,wEC@Qp%tX#
+だが,だが,"but, however",JLPT JLPT_2 JLPT_3,yVQqFsidK:
+互い,たがい,"mutual, each other",JLPT JLPT_2 JLPT_3,"A/w*RxK,aS"
+高める,たかめる,"to raise, to lift, to boost",JLPT JLPT_2 JLPT_3,k95gRhn5$b
+宝,たから,treasure,JLPT JLPT_2 JLPT_3,"Ms,V*:XqhK"
+宅,たく,"house, home",JLPT JLPT_2 JLPT_3,NDCW+QVEo*
+炊く,たく,"to boil, to cook",JLPT JLPT_2 JLPT_3,nMc=w-?iw5
+焚く,たく,"to burn, to kindle, to build a fire",JLPT JLPT_2 JLPT_3,Dg<UbH>Qcm
+抱く,だく,"to embrace, to hug",JLPT JLPT_2 JLPT_3,KKtZ{u;?<t
+だけど,だけど,however,JLPT JLPT_2 JLPT_3,B]!P5f2EJ8
+たしか,たしか,"certain, sure, if I remember correctly",JLPT JLPT_2 JLPT_3,Ai@Savd_m@
+確かめる,たしかめる,"to ascertain, to make sure",JLPT JLPT_2 JLPT_3,zRU$$MH{a;
+多少,たしょう,a little (same as 少し (すこし)),JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.13,Lr;d$E?/U|
+助かる,たすかる,to be saved; (something) helps (v.i.),JLPT Intermediate_Japanese Genki_Ln.18 JLPT_3 JLPT_2 Intermediate_Japanese_Ln.4 Genki,xVSsgH{D[a
+助ける,たすける,"to help (v.t.), to save, to rescue",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Genki Genki_Ln.22 Intermediate_Japanese_Ln.3,l/GW}?_@LC
+ただ,ただ,free of charge; just (~); only (~),JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.9 Genki_Ln.23 Genki,FnqECB)M9z
+只,ただ,"free of charge, mere, only",JLPT JLPT_2 JLPT_3,t3-MU5x.ml
+唯,ただ,"mere, sole, plain",JLPT JLPT_2 JLPT_3,F%qA~M)1]b
+戦い,たたかい,"battle, fight",JLPT JLPT_2 JLPT_3,q9<05fFYz
+戦う,たたかう,"to fight, to compete, to battle",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.7,Bby>Z<O$Cf
+叩く,たたく,"to strike, to beat",JLPT JLPT_2 JLPT_3,qn)FIw6-x/
+直ちに,ただちに,"at once, immediately",JLPT JLPT_2 JLPT_3,K6vcg?:lAW
+畳む,たたむ,to fold (clothes),JLPT JLPT_2 JLPT_3,rkct5mr//(
+立ち上がる,たちあがる,to stand up,JLPT JLPT_2 JLPT_3,HlZc:`g<19
+立場,たちば,"standpoint, position, situation",JLPT JLPT_2 JLPT_3,m+%3thjJjg
+建つ,たつ,"to stand; to be built (v.i.), to erect, to be erected",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.10,n<i_4fThiw
+経つ,たつ,(time) passes,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.4,"r,N`cWnW^X"
+達する,たっする,"to reach, to get to",JLPT JLPT_2 JLPT_3,wK1Ias[)#c
+唯,たった,"only, just",JLPT JLPT_2 JLPT_3,uOH:v;n@##
+だって,だって,"but, because, even",JLPT JLPT_2 JLPT_3,EX/P_yzE.A
+たっぷり,たっぷり,"full, in plenty, ample",JLPT JLPT_2 JLPT_3,m+yv?z5be0
+たとえ,たとえ,"even if, no matter, though",JLPT JLPT_2 JLPT_3,hFX[Llvj7<
+谷,たに,valley,JLPT JLPT_2 JLPT_3,hcMe_RS(U*
+他人,たにん,"unrelated person, stranger",JLPT JLPT_2 JLPT_3,hCa*aP>NLK
+種,たね,seed; material; cause,JLPT JLPT_2 JLPT_3,q$QKyzwhUV
+束,たば,"bunch, bundle",JLPT JLPT_2 JLPT_3,HpG5d&jd4^
+足袋,たび,Japanese socks (with split toe),JLPT JLPT_2 JLPT_3,bhqtwW<taj
+度,たび,counter for occurrences,JLPT JLPT_2 JLPT_3,c~q$.~Py-+
+旅,たび,"travel, trip, journey",JLPT JLPT_2 JLPT_3,AP3&ju<[do
+たびたび,たびたび,"often, repeatedly, frequently",JLPT JLPT_2 JLPT_3,N_zxk]NfeP
+玉,たま,"ball, sphere, coin",JLPT JLPT_2 JLPT_3,kel|c(YKw~
+球,たま,"globe, sphere, ball",JLPT JLPT_2 JLPT_3,"IL5}@,L(HU"
+弾,たま,"bullet, shot",JLPT JLPT_2 JLPT_3,t`CC/|.iog
+偶,たま,"even number, couple, friend",JLPT JLPT_2 JLPT_3,H%.6|y[Mxx
+騙す,だます,"to trick, to cheat, to deceive",JLPT JLPT_2 JLPT_3,Lk)a>8:jDg
+偶々,たまたま,"unexpectedly, accidentally, by chance",JLPT JLPT_2 JLPT_3,JUx|gK)1.9
+たまらない,たまらない,"intolerable, unbearable, unendurable",JLPT JLPT_2 JLPT_3,l`8q_oGHnv
+溜まる,たまる,"to collect, to gather, to accumulate",JLPT JLPT_2 JLPT_3,vB$#wF*|#8
+黙る,だまる,to be silent,JLPT JLPT_2 JLPT_3,s)emL*qV&)
+試し,ためし,"trial, test",JLPT JLPT_2 JLPT_3,qBNYe=mSa8
+試す,ためす,"to attempt, to test",JLPT JLPT_2 JLPT_3,OHz{.@pYIY
+溜める,ためる,"to accumulate, to collect",JLPT JLPT_2 JLPT_3,I-!#mDL3^x
+便り,たより,"news, correspondence, letter",JLPT JLPT_2 JLPT_3,gbz0bmQQdz
+頼る,たよる,"to rely on, to have recourse to, to depend on",JLPT JLPT_2 JLPT_3,Cpd=G;du6L
+段,だん,"step, stair, grade",JLPT JLPT_2 JLPT_3,CK0>fzUr{x
+単位,たんい,"credit (for a course in school); unit, denomination",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.3,ddo&;VY0jx
+単語,たんご,word; vocabulary,JLPT JLPT_3 JLPT_2 Genki_Ln.9 Genki,v$Mi}v}l@p
+男子,だんし,young man,JLPT JLPT_2 JLPT_3,o|;<c@[|f3
+単純,たんじゅん,simplicity,JLPT JLPT_2 JLPT_3,c0+aDZX4Q5
+誕生,たんじょう,birth,JLPT JLPT_2 JLPT_3,dP`<<G(e41
+ダンス,ダンス,dance,JLPT JLPT_2 JLPT_3,euR|T?GwM~
+団体,だんたい,"organization, association",JLPT JLPT_2 JLPT_3,N[4TY72XQk
+担当,たんとう,(in) charge,JLPT JLPT_2 JLPT_3,eVQE*ebssb
+単なる,たんなる,"mere, simple, sheer",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.15,bCE(TsI6rY
+単に,たんに,"simply, merely",JLPT JLPT_2 JLPT_3,ndj9zxLbCH
+地,ち,earth,JLPT JLPT_2 JLPT_3,o?b;2k}iDx
+地位,ちい,"(social) position, status",JLPT JLPT_2 JLPT_3,PA:U(:c/cc
+地域,ちいき,"area, region",JLPT JLPT_2 JLPT_3,kp_^FvzmU=
+チーズ,チーズ,cheese,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.9,v`l$a/$V*R
+チーム,チーム,team,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.7,zOpx4Q5dSu
+知恵,ちえ,"wisdom, wit, intelligence",JLPT JLPT_2 JLPT_3,jp9hTe)yc?
+地下,ちか,"basement, underground",JLPT JLPT_2 JLPT_3,I;*P_Q7^ak
+違い,ちがい,"difference, discrepancy",Genki_Ln.17 JLPT JLPT_3 JLPT_2 Genki,E&4b+:J$~A
+違いない,ちがいない,"(phrase) sure, no mistaking it, for certain",JLPT JLPT_2 JLPT_3,hLl(I;+k]7
+近頃,ちかごろ,"lately, recently, nowadays",JLPT JLPT_2 JLPT_3,f(L:7>]T]*
+地球,ちきゅう,the earth,JLPT JLPT_2 JLPT_3,qL[iG:?A.4
+地区,ちく,"district, section",JLPT JLPT_2 JLPT_3,f^*Mzp$yP!
+遅刻,ちこく,"lateness, late coming",JLPT JLPT_2 JLPT_3,BI&hsIsXx!
+知事,ちじ,prefectural governor,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.4,ISq?4C~q1c
+知識,ちしき,"knowledge, information",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.1,JB`8NU-%cx
+父親,ちちおや,father,JLPT JLPT_2 JLPT_3,x^b@}}_x/I
+知能,ちのう,"intelligence, brains",JLPT JLPT_2 JLPT_3,s0*$SOLx]G
+地平線,ちへいせん,horizon,JLPT JLPT_2 JLPT_3,K*ilXC|Xu$
+地方,ちほう,"area, locality, region",JLPT JLPT_2 JLPT_3,"z)]^*l}=r,"
+茶,ちゃ,tea,JLPT JLPT_2 JLPT_3,"fMCQ,=~B@s"
+チャンス,チャンス,"chance, opportunity",JLPT JLPT_2 JLPT_3,m8a~R)2L&s
+ちゃんと,ちゃんと,"perfectly, properly, exactly",JLPT JLPT_2 JLPT_3,fb]dH3uhx1
+中,ちゅう,"inside, middle, among",JLPT JLPT_2 JLPT_3,giNr]3xbMq
+注,ちゅう,"annotation, explanatory note",JLPT JLPT_2 JLPT_3,ewit4l?.v2
+中央,ちゅうおう,"central, center, middle",JLPT JLPT_2 JLPT_3,hbJS=^3J3d
+中学,ちゅうがく,"middle school, junior high school",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.1,BDc+1/~Gst
+中古,ちゅうこ,"used, second-hand",JLPT JLPT_2 JLPT_3,oGNXy5VYfH
+中止,ちゅうし,"suspension, stoppage, discontinuance",JLPT JLPT_2 JLPT_3,blGv@A}r>*
+駐車,ちゅうしゃ,"parking (e.g., car)",JLPT JLPT_2 JLPT_3,r:>>eJ5z0v
+昼食,ちゅうしょく,lunch (same as 昼ご飯 (ひるごはん)),JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.6,Ce&bm$.+x}
+中心,ちゅうしん,"center, core",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.10,qN$B1x]6v4
+注目,ちゅうもく,"notice, attention, observation",JLPT JLPT_2 JLPT_3,D//womH([Q
+注文,ちゅうもん,"order, request",JLPT JLPT_2 JLPT_3,"s6G1Y@{fM,"
+長期,ちょうき,long time period,JLPT JLPT_2 JLPT_3,c8O%1yU]YR
+調査,ちょうさ,survey; investigation,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.5,d$M#lyGTF?
+調子,ちょうし,"condition, state, tune, tone",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.5,"d]P8,Fg)ha"
+頂上,ちょうじょう,"top, summit, peak",JLPT JLPT_2 JLPT_3,dQdf#E1ni7
+ちょうだい,ちょうだい,-- colloquial form of ください; typically used by children or women --,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.11,o/CK30c)[2
+貯金,ちょきん,(bank) savings,JLPT JLPT_2 JLPT_3,Qk=_]>V~E6
+直接,ちょくせつ,"direct, immediate, firsthand",JLPT JLPT_2 JLPT_3,s&G:wJLBgj
+著者,ちょしゃ,"author, writer",JLPT JLPT_2 JLPT_3,f3<v-734W$
+散らす,ちらす,"to scatter, to disperse, to distribute",JLPT JLPT_2 JLPT_3,vw$z+tJyr%
+散る,ちる,"to fall, to scatter (e.g., blossoms)",JLPT JLPT_2 JLPT_3,J2:m]+werC
+遂に,ついに,"finally, at last",JLPT JLPT_2 JLPT_3,nxB*ZCg|Xk
+通過,つうか,"passage through, passing",JLPT JLPT_2 JLPT_3,ph$_=yR?BI
+通貨,つうか,currency,JLPT JLPT_2 JLPT_3,/j4TmH~2}
+通学,つうがく,commuting to school,JLPT JLPT_2 JLPT_3,J:l]_|3w@r
+通勤,つうきん,commuting to work,JLPT JLPT_2 JLPT_3,e/9Ql]v_wl
+通行,つうこう,"passage, passing",JLPT JLPT_2 JLPT_3,c^6[uEL+8F
+通じる,つうじる,"to run to, to lead to, to communicate",JLPT JLPT_2 JLPT_3,t0;rVhq2PA
+通信,つうしん,"correspondence, communications",JLPT JLPT_2 JLPT_3,jbQzL}efHR
+通訳,つうやく,interpretation; interpreter,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.8,A:!.K&=/gb
+捕まる,つかまる,to be arrested; to be caught,JLPT JLPT_3 JLPT_2 Genki Genki_Ln.21,zje2ssH%h&
+掴む,つかむ,"to seize, to catch, to grasp",JLPT JLPT_2 JLPT_3,AX[XflD{[A
+疲れ,つかれ,"tiredness, fatigue",JLPT JLPT_2 JLPT_3,il1GiN=]{4
+付き合い,つきあい,socialization; friendship; association,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.5,y]4O/.LN};
+付合う,つきあう,"to associate with, to keep company with, to get on with",JLPT JLPT_2 JLPT_3,comK`lsMXR
+次々,つぎつぎ,"in succession, one by one",JLPT JLPT_2 JLPT_3,tMy_Cz-rgH
+付く,つく,"to adjoin, to be attached, to adhere",JLPT JLPT_2 JLPT_3,CCTf>ERIuq
+就く,つく,"to settle in (place), to take (seat position), to study (under teacher)",JLPT JLPT_2 JLPT_3,f$o&/[vj_J
+突く,つく,"to thrust, to strike; to poke",JLPT JLPT_2 JLPT_3,deUV5De}4o
+次ぐ,つぐ,"to rank next to, to come after",JLPT JLPT_2 JLPT_3,lPJSJa%iEy
+注ぐ,つぐ,to pour (into),JLPT JLPT_2 JLPT_3,H]>=HALt|h
+付ける,つける,"to attach, to join, to add",JLPT JLPT_2 JLPT_3,COK~n$@s;+
+着ける,つける,"to put on, to wear; to draw up",JLPT JLPT_2 JLPT_3,xK/@QFUs`+
+伝わる,つたわる,"to be handed down, to be transmitted",JLPT JLPT_2 JLPT_3,I(SdOHy)n4
+土,つち,"earth, soil",JLPT JLPT_2 JLPT_3,b0C;E+y*OO
+続き,つづき,"sequel, continuation",JLPT JLPT_2 JLPT_3,DOx[F]Tq]~
+包み,つつみ,"bundle, package",JLPT JLPT_2 JLPT_3,"A$,U3V5z/a"
+勤め,つとめ,"work, employment",JLPT JLPT_2 JLPT_3,jyI}</P9|V
+務め,つとめ,duty,JLPT JLPT_2 JLPT_3,HBnD=Z&jL.
+繋がる,つながる,"to be connected to, to be related to",JLPT JLPT_2 JLPT_3,o>5Zj80/>t
+繋ぐ,つなぐ,"to tie, to fasten, to connect",JLPT JLPT_2 JLPT_3,dvYDG|g:)z
+繋げる,つなげる,to connect,JLPT JLPT_2 JLPT_3,CaP($Be11=
+常に,つねに,always (same as いつも) (written expression),JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.11,"bxwo]l,au."
+翼,つばさ,wings,JLPT JLPT_2 JLPT_3,h7J%]@@_.i
+つまり,つまり,namely; in other words; in short,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.2,Qct:$c#r&I
+罪,つみ,"crime, fault, indiscretion",JLPT JLPT_2 JLPT_3,MgWjvX`Yu]
+積む,つむ,"to pile up, to stack",JLPT JLPT_2 JLPT_3,"j$?]*}X8^,"
+詰める,つめる,"to pack, to shorten, to work out (details)",JLPT JLPT_2 JLPT_3,r`t;z%W._9
+積もる,つもる,to pile up,JLPT JLPT_2 JLPT_3,B|7C=u@tnY
+梅雨,つゆ,rainy season,JLPT JLPT_2 JLPT_3,Kq1aO&o3e~
+辛い,つらい,"painful, heart-breaking",JLPT JLPT_2 JLPT_3,x#3!zMZ{Ua
+釣,つり,fishing,JLPT JLPT_2 JLPT_3,hp*Ne3T*|9
+連れ,つれ,"companion, company",JLPT JLPT_2 JLPT_3,"M#vEpHbV,1"
+出,で,"outflow, coming (going) out, graduate (of)",JLPT JLPT_2 JLPT_3,w{EtNFmA(5
+出会い,であい,"meeting, rendezvous, encounter",JLPT JLPT_2 JLPT_3,d]*3#}qvAo
+出合い,であい,an encounter,JLPT JLPT_2 JLPT_3,NNhd{.G%>}
+出会う,であう,"to meet by chance, to come across, to happen to encounter",JLPT JLPT_2 JLPT_3,OTct<~-|UE
+提案,ていあん,"proposal, proposition, suggestion",JLPT JLPT_2 JLPT_3,"iGm7,)MoHt"
+定期,ていき,fixed term,JLPT JLPT_2 JLPT_3,A!sHO/~:s^
+抵抗,ていこう,"resistance, opposition",JLPT JLPT_2 JLPT_3,N(w.Tb~N=E
+提出,ていしゅつ,"presentation, submission, filing",JLPT JLPT_2 JLPT_3,_gNbOk8-6
+停電,ていでん,failure of electricity,JLPT JLPT_2 JLPT_3,H}DrQpl/{h
+程度,ていど,"degree, amount, level",JLPT JLPT_2 JLPT_3,F`R&X?&TVu
+停留所,ていりゅうじょ,bus or tram stop,JLPT JLPT_2 JLPT_3,Awx`muH^bu
+デート,デート,date (in the sense of 'social engagement' only),JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.5 Genki_Ln.3 Genki,OE9g6(Wr!Q
+敵,てき,"enemy, rival",JLPT JLPT_2 JLPT_3,Ea+9Js(Fd+
+出来事,できごと,"incident happening, event",JLPT JLPT_2 JLPT_3,jSaj(o[]4Q
+適する,てきする,"to fit, to suit",JLPT JLPT_2 JLPT_3,BBp^;rnN&Z
+適切,てきせつ,"appropriate, adequate, relevance",JLPT JLPT_2 JLPT_3,GJ78SM<nAC
+適度,てきど,moderate,JLPT JLPT_2 JLPT_3,"P,Aa?trXr^"
+適用,てきよう,applying,JLPT JLPT_2 JLPT_3,F[1:.C?p}A
+できれば,できれば,if possible…,JLPT JLPT_2 JLPT_3,Nl1_P@+[2J
+手品,てじな,"conjuring trick, magic",JLPT JLPT_2 JLPT_3,Bmip}Vg}I5
+ですから,ですから,therefore,JLPT JLPT_2 JLPT_3,Jo!p#Qfr#o
+鉄,てつ,iron,JLPT JLPT_2 JLPT_3,u7QQ@g<pTi
+哲学,てつがく,philosophy,JLPT JLPT_2 JLPT_3,w4;9Z6RDj*
+手伝い,てつだい,"help, helper, assistant",JLPT JLPT_2 JLPT_3,KsJJ=HC*D~
+徹底,てってい,"thoroughness, completeness",JLPT JLPT_2 JLPT_3,u^FH5{m=7A
+鉄道,てつどう,railway; railroad,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.10,fH8D~mT1*!
+徹夜,てつや,"staying up all night, sleepless night",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.7,"Lx.`K,!_&%"
+手間,てま,"time, labor",JLPT JLPT_2 JLPT_3,zh##v%wLiw
+デモ,デモ,"demo, demonstration",JLPT JLPT_2 JLPT_3,zxldW(*v39
+典型,てんけい,"type, pattern, archetypal",JLPT JLPT_2 JLPT_3,b#]l?Jh5h
+天候,てんこう,weather,JLPT JLPT_2 JLPT_3,Du(D%o0?(h
+電子,でんし,electron; electronic,JLPT JLPT_2 JLPT_3,KF~X[<t._6
+テント,テント,tent,JLPT JLPT_2 JLPT_3,C+]@`|c9$-
+伝統,でんとう,"tradition, convention",JLPT JLPT_2 JLPT_3,b?a#:(nI:=
+天然,てんねん,"nature, spontaneity",JLPT JLPT_2 JLPT_3,mJ@k+Q+jCj
+問い,とい,"question, query",JLPT JLPT_2 JLPT_3,qN5[}C*k;Z
+党,とう,party (political),JLPT JLPT_2 JLPT_3,CwN*@P-oun
+塔,とう,"tower, pagoda",JLPT JLPT_2 JLPT_3,K]pA87hQ2g
+答案,とうあん,"examination paper, examination script",JLPT JLPT_2 JLPT_3,MoK&)Fu]bx
+同一,どういつ,"identity, sameness, similarity",JLPT JLPT_2 JLPT_3,l<daK{7I?K
+銅貨,どうか,copper coin,JLPT JLPT_2 JLPT_3,v?#F}bohO.
+当時,とうじ,"at that time, in those days (same as そのころ)",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.13,cAqI6F$%jo
+動詞,どうし,verb,JLPT JLPT_2 JLPT_3,Jt^|GpM7=V
+同時,どうじ,"simultaneous(ly), same time",JLPT JLPT_2 JLPT_3,yvg^A$k^a|
+どうしても,どうしても,"at any cost, no matter what, no matter how hard one tries",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.11,u>t|EJmDdT
+どうぞよろしく,どうぞよろしく,pleased to meet you,JLPT JLPT_2 JLPT_3,k:&n.w>9]!
+到着,とうちゃく,arrival,JLPT JLPT_2 JLPT_3,i)aR;Wlc03
+道徳,どうとく,morals,JLPT JLPT_2 JLPT_3,F<|nkQy)11
+投票,とうひょう,"voting, poll",JLPT JLPT_2 JLPT_3,NlT[;z*wrK
+東洋,とうよう,Orient,JLPT JLPT_2 JLPT_3,kzZ}UECtrI
+同様,どうよう,"identical, same (kind), like",JLPT JLPT_2 JLPT_3,w[nqm0x.)$
+童謡,どうよう,"children's song, nursery rhyme",JLPT JLPT_2 JLPT_3,pW$[md&UnE
+同僚,どうりょう,colleague; co-worker,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.6 Genki Genki_Ln.21,Ra.t5JBS3r
+道路,どうろ,road,JLPT JLPT_2 JLPT_3,zy.8&725kR
+通す,とおす,"to let pass, to overlook, to continue",JLPT JLPT_2 JLPT_3,iHbDjUw`ah
+通り過ぎる,とおりすぎる,"to pass, to pass through",JLPT JLPT_2 JLPT_3,n%iou*]&!6
+都会,とかい,city,JLPT JLPT_2 JLPT_3,p*_|WF)kYy
+溶く,とく,to dissolve (paint),JLPT JLPT_2 JLPT_3,M1t!(0fZzF
+解く,とく,"to unfasten; answer, solve",JLPT JLPT_2 JLPT_3,b.j;M[.:j7
+退く,どく,"to retreat, to recede, to withdraw",JLPT JLPT_2 JLPT_3,c$$~C+pfb}
+毒,どく,"poison, toxicant",JLPT JLPT_2 JLPT_3,DARItH3te]
+得意,とくい,"pride, triumph, prosperity",JLPT JLPT_2 JLPT_3,w<S{;~)l0:
+読書,どくしょ,reading,JLPT JLPT_2 JLPT_3,F6~L<UDvE+
+独身,どくしん,"single, unmarried",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14,img~a/~?x<
+特徴,とくちょう,characteristic(s); feature(s); trait(s),JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.10,dd#*-FyzHW
+特長,とくちょう,"forte, merit",JLPT JLPT_2 JLPT_3,e_t7Cd~09D
+独特,どくとく,"peculiarity, uniqueness, characteristic",JLPT JLPT_2 JLPT_3,"hWn,<pPOA"
+独立,どくりつ,"independence (e.g., Ind. Day), self-support",JLPT JLPT_2 JLPT_3,wgVbY)l!G:
+溶ける,とける,"to melt, to thaw, to dissolve",JLPT JLPT_2 JLPT_3,Go3eNt+^C%
+解ける,とける,"to come untied, to come apart",JLPT JLPT_2 JLPT_3,E_4w+LM=cF
+どこか,どこか,"somewhere, anywhere",JLPT JLPT_2 JLPT_3,n<7QA|Q%GZ
+ところが,ところが,"however, while, even if",JLPT JLPT_2 JLPT_3,m-8$vGofT(
+ところで,ところで,by the way; even if,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.1,yzfKCn.aBb
+登山,とざん,mountain-climbing,JLPT JLPT_2 JLPT_3,N-%3i1PqFk
+都市,とし,"town, city, urban",JLPT JLPT_2 JLPT_3,tNXI!+#v:`
+年月,としつき,months and years,JLPT JLPT_2 JLPT_3,b%`/I;RJ$^
+図書,としょ,books,JLPT JLPT_2 JLPT_3,e>Nm^AgJ])
+年寄,としより,"old people, the aged",JLPT JLPT_2 JLPT_3,dH(n+sRgp{
+閉じる,とじる,"to close (e.g., book, eyes), to shut",JLPT JLPT_2 JLPT_3,JWs?hJ:*yD
+途端,とたん,"just (now, at the moment, etc.)",JLPT JLPT_2 JLPT_3,hC>h/uXgyk
+土地,とち,"plot of land, lot, soil",JLPT JLPT_2 JLPT_3,d;>FkWx>zj
+突然,とつぜん,"abruptly, suddenly, unexpectedly",JLPT JLPT_2 JLPT_3,u9EG(SkQ{j
+トップ,トップ,top,JLPT JLPT_2 JLPT_3,q]>Jr![.(N
+届く,とどく,to reach,JLPT JLPT_2 JLPT_3,e?<7!g}yZ;
+とにかく,とにかく,"anyhow, at any rate, anyway",JLPT JLPT_3 JLPT_2 Genki Genki_Ln.21,im{&K_@wV
+飛ばす,とばす,"to skip over, to omit",JLPT JLPT_2 JLPT_3,Hs}AOgVJU~
+飛び出す,とびだす,"to jump out, to rush out, to fly out",JLPT JLPT_2 JLPT_3,jD`AkcS%la
+留める,とめる,"to fasten, to turn off, to detain",JLPT JLPT_2 JLPT_3,EluezN4]RV
+泊める,とめる,to have someone stay (over night) (v.t.),JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.1,sr$3#;WnNi
+友,とも,"friend, companion, pal",JLPT JLPT_2 JLPT_3,I(06/Hp@B7
+共に,ともに,"sharing with, participate in",JLPT JLPT_2 JLPT_3,J&blXp45W[
+虎,とら,tiger,JLPT JLPT_2 JLPT_3,q3*!nq{_pc
+ドライブ,ドライブ,"drive, driving",JLPT Genki_Ln.11 JLPT_3 JLPT_2 Genki,"I,~F.X8Z8F"
+トラック,トラック,truck; (running) track,JLPT JLPT_2 JLPT_3,q*_SbJJ@!!
+ドラマ,ドラマ,drama,JLPT JLPT_2 JLPT_3,mL~N]Bfwf}
+トランプ,トランプ,playing cards (lit: trump),JLPT JLPT_2 JLPT_3,m&n=U!*VAu
+取り上げる,とりあげる,"to take up, to pick up; to confiscate",JLPT JLPT_2 JLPT_3,hUa->MmssI
+努力,どりょく,"great effort, exertion, endeavor",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14,P$}d5=b$SY
+トレーニング,トレーニング,training,JLPT JLPT_2 JLPT_3,h-6r=v)@/P
+ドレス,ドレス,dress,JLPT JLPT_2 JLPT_3,wj.H_PUH[6
+取れる,とれる,"to come off, to be taken off",JLPT JLPT_2 JLPT_3,Hw{&qvpk7n
+泥,どろ,mud,JLPT JLPT_2 JLPT_3,d(Q$9Oy/;r
+トン,トン,ton (1000 lbs.),JLPT JLPT_2 JLPT_3,c$BFN)`=lz
+とんでもない,とんでもない,"outrageous, No way!",JLPT JLPT_2 JLPT_3,bl*lVwAn^S
+どんなに,どんなに,"how, how much",JLPT JLPT_2 JLPT_3,AecyZ~s0IY
+トンネル,トンネル,tunnel,JLPT JLPT_2 JLPT_3,"gyvzV/QL,O"
+名,な,"name, reputation",JLPT JLPT_2 JLPT_3,O0j|#CZ{DW
+内容,ないよう,"subject, contents, detail",JLPT JLPT_2 JLPT_3,i{JT|O:vZ0
+なお,なお,"still, yet",JLPT JLPT_2 JLPT_3,x$e]XDdzMn
+仲,なか,"relation, relationship",JLPT JLPT_2 JLPT_3,x6DIm?q|TP
+流す,ながす,"to drain, to float, to shed (e.g., blood, tears)",JLPT JLPT_2 JLPT_3,b9+3bd5x%g
+半ば,なかば,"middle, halfway",JLPT JLPT_2 JLPT_3,m<2jyxDj3g
+仲間,なかま,"company, fellow, colleague, associate",JLPT JLPT_2 JLPT_3,O~m#4j_48)
+中身,なかみ,content(s); substance,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.13,J`BoSI)KdS
+中味,なかみ,"contents, interior, filling",JLPT JLPT_2 JLPT_3,iXe{m_#VVd
+眺め,ながめ,scene; view; prospect; outlook,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.10,q7BF&&<kDs
+眺める,ながめる,"to view, to gaze at",JLPT JLPT_2 JLPT_3,Jux]l79hU7
+流れ,ながれ,"stream, current",JLPT JLPT_2 JLPT_3,d.aR+yRU]C
+流れる,ながれる,"to flow, to be washed away",JLPT JLPT_2 JLPT_3,L(]6kjxkO5
+亡くす,なくす,to lose someone,JLPT JLPT_2 JLPT_3,KL@%|R=4Tw
+殴る,なぐる,to strike; to hit; to punch,JLPT JLPT_3 JLPT_2 Genki Genki_Ln.21,eS]UZnH]O8
+無し,なし,without,JLPT JLPT_2 JLPT_3,tUofx+jM%K
+なぜなら,なぜなら,because,JLPT JLPT_2 JLPT_3,H{Gk:ou^*M
+謎,なぞ,"riddle, puzzle, enigma",JLPT JLPT_2 JLPT_3,"NDO,I}[;_1"
+納得,なっとく,"consent, assent, understanding",JLPT JLPT_2 JLPT_3,JuwJ4CGSR`
+何か,なにか,something,JLPT JLPT_3 JLPT_2 Genki_Ln.8 Genki,j.C?;uY)C5
+なにも,なにも,nothing,JLPT JLPT_2 JLPT_3,MXWN];^p1V
+鍋,なべ,"saucepan, pot",JLPT JLPT_2 JLPT_3,mwf<LRd<l+
+生,なま,"raw, unprocessed",JLPT JLPT_2 JLPT_3,r*Fk8g)/r@
+怠ける,なまける,"to be idle, to neglect",JLPT JLPT_2 JLPT_3,"yx?2EFwB,]"
+波,なみ,wave,JLPT JLPT_2 JLPT_3,pN{_T4/c^1
+涙,なみだ,tear,JLPT JLPT_2 JLPT_3,oRUb;($Ghp
+悩む,なやむ,"to agonize, to be troubled",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14,bu-LsE_(B1
+鳴らす,ならす,"to ring, to sound",JLPT JLPT_2 JLPT_3,i97JG)YBV+
+為る,なる,"to change, to be of use, to reach to",JLPT JLPT_2 JLPT_3,bNL#{T]zX=
+生る,なる,to bear fruit,JLPT JLPT_2 JLPT_3,L4foi?c6%U
+馴れる,なれる,"to become domesticated, to become tame",JLPT JLPT_2 JLPT_3,ol(4_S7K{0
+縄,なわ,rope,JLPT JLPT_2 JLPT_3,n`oE5IcC;2
+何で,なんで,"Why, What for",JLPT JLPT_2 JLPT_3,HqNM3@mEGg
+何でも,なんでも,"by all means, everything",JLPT JLPT_2 JLPT_3,KLOu@z)~5u
+何とか,なんとか,"somehow, anyhow, one way or another",JLPT JLPT_2 JLPT_3,PsxfE&mMV)
+似合う,にあう,"to suit (a person), to match (clothing), (something) becomes (someone)",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.11,jtNV<xuHWD
+煮える,にえる,"to boil, to cook, to be cooked",JLPT JLPT_2 JLPT_3,"bik,,M3:tN"
+苦手,にがて,"poor (at), weak (in), dislike (of)",JLPT JLPT_2 JLPT_3,M3gYUPwtEh
+握る,にぎる,"to grasp, to seize, to mold sushi",JLPT JLPT_2 JLPT_3,vmSd+R!f5d
+日,にち,day,JLPT JLPT_2 JLPT_3,Nod.Sq)g|g
+日常,にちじょう,"ordinary, regular, everyday",JLPT JLPT_2 JLPT_3,m=K]ZkdB>_
+日光,にっこう,sunlight,JLPT JLPT_2 JLPT_3,O|V6=xs6Hv
+日中,にっちゅう,"daytime, broad daylight",JLPT JLPT_2 JLPT_3,1%wJTAZoF
+にっこり,にっこり,"smile sweetly, smile, grin",JLPT JLPT_2 JLPT_3,A?rMl+E(~y
+日本,にっぽん,Japan,JLPT JLPT_2 JLPT_3,xVTGJL[~Hv
+日本,にほん,Japan,JLPT JLPT_3 JLPT_2 Genki_Ln.1 Genki,"PdXU2>,+,$"
+入場,にゅうじょう,"entrance, admission, entering",JLPT JLPT_2 JLPT_3,zYrH7+;Jc+
+煮る,にる,"to boil, to cook",JLPT JLPT_2 JLPT_3,"GsAuw,hW%."
+人気,にんき,popularity,JLPT JLPT_2 JLPT_3,IO!K5zC:])
+人間,にんげん,"human being, person",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.11,to[4Ed0}
+抜く,ぬく,"to extract, to omit, to unplug",JLPT JLPT_2 JLPT_3,J$S#dr#O.=
+抜ける,ぬける,"to come out, to fall out, to be omitted",JLPT JLPT_2 JLPT_3,J{iiC<@SQ{
+布,ぬの,cloth,JLPT JLPT_2 JLPT_3,q$ysjT]VCx
+濡らす,ぬらす,"to wet, to soak",JLPT JLPT_2 JLPT_3,z@Vcw1=;j2
+根,ね,root,JLPT JLPT_2 JLPT_3,d=p6h26.c<
+値,ね,"value, price, cost",JLPT JLPT_2 JLPT_3,EQ[K4a8j3!
+願い,ねがい,"desire, wish, request",JLPT JLPT_2 JLPT_3,sUyGKFZ%Xv
+願う,ねがう,"to desire, to wish, to request",JLPT JLPT_2 JLPT_3,2e?!QE;A1
+鼠,ねずみ,"mouse, rat",JLPT JLPT_2 JLPT_3,G}*K+YvkrL
+熱帯,ねったい,tropics,JLPT JLPT_2 JLPT_3,kkWXGyi|&~
+熱中,ねっちゅう,"enthusiasm, zeal, mania",JLPT JLPT_2 JLPT_3,lPMoEzcLqx
+年間,ねんかん,year,JLPT JLPT_2 JLPT_3,d_NdY-B:AA
+年月,ねんげつ,months and years,JLPT JLPT_2 JLPT_3,p^QZ#pHDS+
+年中,ねんじゅう,"whole year, always, everyday",JLPT JLPT_2 JLPT_3,E0SJPrLvM7
+年代,ねんだい,"age, era, period",JLPT JLPT_2 JLPT_3,wqq!d<%$gr
+年齢,ねんれい,"age, years",JLPT JLPT_2 JLPT_3,"lI,ZQ1?Z/$"
+野,の,field,JLPT JLPT_2 JLPT_3,y-+2`{({f&
+能,のう,"being skilled in, nicely, properly",JLPT JLPT_2 JLPT_3,m[Pt*UAu7d
+農家,のうか,"farmer, farm family",JLPT JLPT_2 JLPT_3,v*vXrV&l.l
+農業,のうぎょう,agriculture,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.10,A3L<i~4B/)
+農民,のうみん,"farmers, peasants",JLPT JLPT_2 JLPT_3,l^C||-Q@FF
+能力,のうりょく,"ability, faculty",JLPT JLPT_2 JLPT_3,PQ%>W3<m<u
+ノー,ノー,no,JLPT JLPT_2 JLPT_3,A$DCH!&r|T
+軒,のき,eaves,JLPT JLPT_2 JLPT_3,DjCz-B0?P;
+残す,のこす,"to leave (behind, over), to save, to reserve",JLPT JLPT_2 JLPT_3,G9}3C/kn`n
+残り,のこり,"remaining, left-over",JLPT JLPT_2 JLPT_3,1Ev%4g:!#
+乗せる,のせる,"to place on (something), to take on board",JLPT JLPT_2 JLPT_3,P;&]8~|B5t
+載せる,のせる,to place on (something); to publish,JLPT JLPT_2 JLPT_3,c~;t;&Vnza
+覗く,のぞく,"to peek in, to look in",JLPT JLPT_2 JLPT_3,Hy+I.kN0`%
+除く,のぞく,"to remove, to exclude, to except",JLPT JLPT_2 JLPT_3,y<H]05[a~3
+望み,のぞみ,"wish, desire, (a) hope",JLPT JLPT_2 JLPT_3,QMT.-k$<Eb
+望む,のぞむ,"to desire, to wish for; to view",JLPT JLPT_2 JLPT_3,"eI17,m{o4{"
+後,のち,"afterwards, since then",JLPT JLPT_2 JLPT_3,Rbg3w%yZT]
+ノック,ノック,knock; fungo (baseball),JLPT JLPT_2 JLPT_3,I|?mZ`76Sc
+伸ばす,のばす,"to extend, to stretch, to reach out",JLPT JLPT_2 JLPT_3,xaB1#1Nz$
+延ばす,のばす,"to extend, to stretch, to reach out",JLPT JLPT_2 JLPT_3,MCU^h_@4jl
+伸びる,のびる,"to extend, to make progress, to grow",JLPT JLPT_2 JLPT_3,BVa+StSI^2
+延びる,のびる,to be prolonged,JLPT JLPT_2 JLPT_3,h;x99>{wy|
+述べる,のべる,"to state, to express, to mention",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.13,vf(j*ek(yX
+上る,のぼる,"to ascend, to go up, to climb",JLPT JLPT_2 JLPT_3,n99IdD&<1l
+昇る,のぼる,"to arise, to ascend, to go up",JLPT JLPT_2 JLPT_3,B@kvH2BlIF
+載る,のる,"to appear (in print), to be recorded",JLPT JLPT_2 JLPT_3,Nibr^Gs/g<
+のんびり,のんびり,"carefree, at leisure",JLPT JLPT_3 JLPT_2 Genki_Ln.22 Genki,lW(_0K#qr1
+場,ば,"place, field (physics)",JLPT JLPT_2 JLPT_3,GDd)tLjDFI
+はあ (かん),はあ (かん),(sigh),JLPT JLPT_2 JLPT_3,q->2~QuZ7t
+パーセント,パーセント,percent,JLPT JLPT_2 JLPT_3,tRJyHS5V6y
+灰,はい,ash,JLPT JLPT_2 JLPT_3,yp;].asZlp
+梅雨,ばいう,rainy season,JLPT JLPT_2 JLPT_3,PSy.Vi_[#
+バイオリン,バイオリン,violin,JLPT Genki_Ln.13 JLPT_3 JLPT_2 Genki,P0|;%A4sXQ
+ハイキング,ハイキング,hiking,JLPT JLPT_2 JLPT_3,HcQ1$Os%x4
+配達,はいたつ,"delivery, distribution",JLPT JLPT_2 JLPT_3,xw:Qj132Wm
+パイプ,パイプ,pipe; channels official or otherwise,JLPT JLPT_2 JLPT_3,l4YS(}+dg9
+俳優,はいゆう,"actor, actress, performer",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.13,fZuFXWr:[`
+パイロット,パイロット,pilot,JLPT JLPT_2 JLPT_3,bJuDn%>JBm
+生える,はえる,"to grow, to spring up; to cut (teeth)",JLPT JLPT_2 JLPT_3,H`:KnzwCJZ
+墓,はか,"grave, tomb",JLPT JLPT_2 JLPT_3,"wyd?,|D3$8"
+馬鹿,ばか,"fool, idiot",JLPT JLPT_2 JLPT_3,NNq|t=8Aut
+博士,はかせ,"doctorate, PhD., doctor",JLPT JLPT_2 JLPT_3,ya}G1t{rx^
+計る,はかる,"to measure, to weigh, to survey",JLPT JLPT_2 JLPT_3,r=0WeQKi!d
+量る,はかる,"to measure, to weigh, to survey",JLPT JLPT_2 JLPT_3,CRts&/>]cr
+測る,はかる,"to measure, to weigh, to survey",JLPT JLPT_2 JLPT_3,E)0?EIUz7g
+掃く,はく,"to sweep, to brush, to gather up",JLPT JLPT_2 JLPT_3,vSCJIFU380
+吐く,はく,"to throw up, to vomit",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.12,wVP@*4xm(:
+拍手,はくしゅ,"clapping hands, applause",JLPT JLPT_2 JLPT_3,QlF4N)gbDJ
+莫大,ばくだい,"enormous, vast",JLPT JLPT_2 JLPT_3,E~?/H3*fy6
+爆発,ばくはつ,"explosion, detonation, eruption",JLPT JLPT_2 JLPT_3,g9VYFn:WwV
+博物館,はくぶつかん,museum,JLPT JLPT_2 JLPT_3,LpU/`O$e<h
+激しい,はげしい,"violent, vehement, intense",JLPT JLPT_2 JLPT_3,v6}uu]rF:b
+はさみ,はさみ,scissors,JLPT JLPT_2 JLPT_3,eD|fBc0re3
+破産,はさん,(personal) bankruptcy,JLPT JLPT_2 JLPT_3,f7-bX^)CWC
+端,はし,"end (e.g., of street), edge, margin",JLPT JLPT_2 JLPT_3,lap$^>s}*W
+始まり,はじまり,"origin, beginning",JLPT JLPT_2 JLPT_3,I]JL:M+y+M
+パス,パス,"path, pass (in games)",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.10,hnnWC$6?3f
+外す,はずす,"to unfasten, to remove",JLPT JLPT_2 JLPT_3,nj2An#}L(c
+パスポート,パスポート,passport,JLPT JLPT_2 JLPT_3,jjzXZ[V)~Q
+外れる,はずれる,"to be disconnected, to be out (e.g., of gear)",JLPT JLPT_2 JLPT_3,r]URt`fp_5
+旗,はた,flag,JLPT JLPT_2 JLPT_3,dNY/1a;w#%
+肌,はだ,skin,JLPT JLPT_2 JLPT_3,gmj^ZD0zR@
+裸,はだか,"naked, nude",JLPT JLPT_2 JLPT_3,O|p6i=|2+#
+畑,はたけ,"field, patch",JLPT JLPT_2 JLPT_3,rk<p3A[!PW
+働き,はたらき,"work, labor",JLPT JLPT_2 JLPT_3,G[F:Wb:]Y%
+バッグ,バッグ,bag,JLPT JLPT_2 JLPT_3,^7.n+J;iq
+発見,はっけん,"discovery, detection, finding",JLPT JLPT_2 JLPT_3,e1V)m7Fw)7
+発行,はっこう,issue (publications),JLPT JLPT_2 JLPT_3,O3&*)a48ia
+発車,はっしゃ,departure of a vehicle,JLPT JLPT_2 JLPT_3,ml<@&G38CG
+発射,はっしゃ,"firing, shooting, discharge",JLPT JLPT_2 JLPT_3,F/fE`P6yl-
+罰する,ばっする,"to punish, to penalize",JLPT JLPT_2 JLPT_3,hbPUdBho_q
+発達,はったつ,"development, growth",JLPT JLPT_2 JLPT_3,Fi-WS4m5Vq
+ばったり,ばったり,(to meet) by chance,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.11,hf@ltuFXs9
+発展,はってん,"development, growth, progress",JLPT JLPT_2 JLPT_3,niC<3l*Uz&
+発表,はっぴょう,announcement; publication; presentation,Genki_Ln.15 JLPT JLPT_3 JLPT_2 Genki,q#5&i-N|DX
+発明,はつめい,invention,JLPT JLPT_2 JLPT_3,"m%u/3I%I,u"
+派手,はで,"showy, flashy, gaudy",JLPT JLPT_2 JLPT_3,t&Cvj}ttRu
+話し合う,はなしあう,"to discuss, to talk together",JLPT JLPT_2 JLPT_3,nVR8y%BClP
+離す,はなす,"to part, to separate",JLPT JLPT_2 JLPT_3,"zQ6Rm,}F5G"
+放す,はなす,"to separate, to set free",JLPT JLPT_2 JLPT_3,P8H2t4/rp$
+離れる,はなれる,"(something, someone) separates; parts from; to be apart",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.15 Genki_Ln.23 Genki,Gk<MF_X=YD
+放れる,はなれる,"to leave, to get free, to cut oneself off",JLPT JLPT_2 JLPT_3,pQ8K=L1K+c
+羽,はね,wing,JLPT JLPT_2 JLPT_3,LCMy2UZmN
+羽根,はね,feather,JLPT JLPT_2 JLPT_3,IFw6^-Jg|1
+幅,はば,"width, breadth",JLPT JLPT_2 JLPT_3,yuqlNtOC6P
+母親,ははおや,mother,JLPT JLPT_2 JLPT_3,gl#dQh*e=R
+省く,はぶく,"to omit, to eliminate",JLPT JLPT_2 JLPT_3,hA|}BeGd!`
+場面,ばめん,"scene, setting (e.g., of novel)",JLPT JLPT_2 JLPT_3,wCW&}Thr>1
+流行る,はやる,"to be popular, to come into fashion",JLPT JLPT_2 JLPT_3,l+WfR9cGsI
+腹,はら,"abdomen, belly, stomach",JLPT JLPT_2 JLPT_3,sfZ+Z?`&!R
+原,はら,"field, plain",JLPT JLPT_2 JLPT_3,c<(AEgR!*z
+バランス,バランス,balance,JLPT JLPT_2 JLPT_3,QVn*9^P55E
+針,はり,"needle, hand (e.g., clock)",JLPT JLPT_2 JLPT_3,QA`E9TI{mo
+範囲,はんい,"extent, scope, range",JLPT JLPT_2 JLPT_3,r:1!2<WUUN
+反抗,はんこう,"opposition, resistance",JLPT JLPT_2 JLPT_3,"IDJ,GPHc09"
+犯罪,はんざい,crime,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.10,h9%1~S`/5q
+ハンサム,ハンサム,handsome,JLPT JLPT_2 JLPT_3,F8GaX2S*6r
+反省,はんせい,"reflection, reconsideration, regret",JLPT JLPT_2 JLPT_3,jl_=K>.y=r
+判断,はんだん,"judgment, decision",JLPT JLPT_2 JLPT_3,v@gzHM&*wS
+犯人,はんにん,"offender, criminal",JLPT JLPT_3 JLPT_2 Genki Genki_Ln.21,KepmoPPwL&
+販売,はんばい,"sale, selling, marketing",JLPT JLPT_2 JLPT_3,c`5qHhM#2.
+灯,ひ,light,JLPT JLPT_2 JLPT_3,I||i~_;O|L
+ビール,ビール,beer,JLPT Genki_Ln.11 JLPT_3 JLPT_2 Genki,l^Yo8c$buu
+被害,ひがい,damage,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.10,tAfC4<pK2g
+比較,ひかく,comparison,JLPT JLPT_2 JLPT_3,JGY{<0z3/z
+ピクニック,ピクニック,picnic,JLPT JLPT_2 JLPT_3,oc^zhI)pBK
+悲劇,ひげき,tragedy,JLPT JLPT_2 JLPT_3,EzhU5X_S}(
+飛行,ひこう,"aviation, flight",JLPT JLPT_2 JLPT_3,rAR4=4~Jb^
+膝,ひざ,"knee, lap",JLPT JLPT_2 JLPT_3,I?$>s3Mj7%
+非常,ひじょう,"emergency, extraordinary, unusual",JLPT JLPT_2 JLPT_3,jIVGL0x@qc
+美人,びじん,beautiful person (woman),JLPT JLPT_2 JLPT_3,g|cQb(%])I
+額,ひたい,"forehead, brow",JLPT JLPT_2 JLPT_3,K}(BncWd~a
+日付,ひづけ,"date, dating",JLPT JLPT_2 JLPT_3,jl00WKL;dH
+引越し,ひっこし,"moving, changing residence",JLPT JLPT_2 JLPT_3,"rxV,INx<Hk"
+必死,ひっし,"desperation, frantic, inevitable result",JLPT JLPT_2 JLPT_3,nC7R$*m=)e
+ぴったり,ぴったり,"exactly, neatly, sharp",JLPT JLPT_2 JLPT_3,gEO0@gf40A
+引っ張る,ひっぱる,"to pull, to stretch, to drag",JLPT JLPT_2 JLPT_3,FzRJSNQfTY
+否定,ひてい,"negation, denial",JLPT JLPT_2 JLPT_3,hq]bB}D.D
+ビデオ,ビデオ,video tape; VCR,JLPT JLPT_3 JLPT_2 Genki_Ln.3 Genki,fVfQ41zUR-
+一言,ひとこと,one word,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.12,cb)`=-[#ld
+人込み,ひとごみ,crowd of people,JLPT JLPT_2 JLPT_3,ew])gT]]&]
+等しい,ひとしい,equal,JLPT JLPT_2 JLPT_3,g*T^:&)[`f
+独り,ひとり,"alone, unmarried",JLPT JLPT_2 JLPT_3,CIC9}ZNl+]
+一人一人,ひとりひとり,"one by one, each",JLPT JLPT_2 JLPT_3,g/LDWyd~bV
+批判,ひはん,criticism,JLPT JLPT_2 JLPT_3,sSt}v%TolX
+批評,ひひょう,"criticism, review, commentary",JLPT JLPT_2 JLPT_3,nZusJ0/%}S
+秘密,ひみつ,"secret, secrecy",Genki_Ln.17 JLPT JLPT_3 JLPT_2 Genki,K8:/c`_D0>
+微妙,びみょう,"delicate, subtle",JLPT JLPT_2 JLPT_3,y[W__*[UUc
+紐,ひも,"string, cord",JLPT JLPT_2 JLPT_3,p`?=+t<[ZR
+冷やす,ひやす,"to cool, to refrigerate",JLPT JLPT_2 JLPT_3,DSr^r:qjw.
+費用,ひよう,"cost, expense",JLPT JLPT_2 JLPT_3,r1KmsC-Y<P
+表,ひょう,"table (e.g., Tab 1), chart, list",JLPT JLPT_2 JLPT_3,C+2G67mxr#
+秒,びょう,second (60th min),JLPT JLPT_2 JLPT_3,yX.tO*9QI!
+評価,ひょうか,"assessment, evaluation",JLPT JLPT_2 JLPT_3,u;D]S#_>Xe
+表現,ひょうげん,"expression, presentation",JLPT JLPT_2 JLPT_3,luB++%rSgA
+表情,ひょうじょう,facial expression,JLPT JLPT_2 JLPT_3,hyoeK91[Bh
+平等,びょうどう,"equality, impartiality, evenness",JLPT JLPT_2 JLPT_3,AJ(ugjSc/!
+評判,ひょうばん,"fame, reputation",JLPT JLPT_2 JLPT_3,wS@|p-w%.R
+表面,ひょうめん,"surface, outside, face",JLPT JLPT_2 JLPT_3,u`tQMUrn$Y
+広がる,ひろがる,"to spread (out), to extend, to stretch, to reach to, to get around",JLPT JLPT_2 JLPT_3,uwnemtdnp7
+広げる,ひろげる,"to spread, to extend, to expand, to enlarge",JLPT JLPT_2 JLPT_3,",acb]qNE)"
+広める,ひろめる,"to broaden, to propagate",JLPT JLPT_2 JLPT_3,A(+H=R:mLS
+品,ひん,"goods; taste, elegance",JLPT JLPT_2 JLPT_3,G((JK!Y$Y=
+瓶,びん,bottle,JLPT JLPT_2 JLPT_3,s2SgOi7f``
+便,びん,"way, means; flight",JLPT Genki_Ln.10 JLPT_3 JLPT_2 Genki,"hW&&,9z!hz"
+ピン,ピン,pin,JLPT JLPT_2 JLPT_3,w[{)#&AAgf
+不,ふ,"un(~), non(~), negative prefix",JLPT JLPT_2 JLPT_3,DaVjdKEUb@
+不,ぶ,"un(~), non(~), negative prefix",JLPT JLPT_2 JLPT_3,xWoO+hKXb|
+無,ぶ,"nothing, naught, nil, zero",JLPT JLPT_2 JLPT_3,"F0,T~)w`pd"
+分,ぶ,"dividing, part",JLPT JLPT_2 JLPT_3,o4et&;Hn=[
+不安,ふあん,"anxiety, uneasiness",JLPT JLPT_2 JLPT_3,B.}P5XzBC<
+風景,ふうけい,scenery,JLPT JLPT_2 JLPT_3,K|bB_b5g2q
+夫婦,ふうふ,"married couple, husband and wife",JLPT Genki_Ln.14 Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14 Genki,vE=+[H1Y=?
+笛,ふえ,"flute, whistle",JLPT JLPT_2 JLPT_3,j~98+xAGu/
+不可,ふか,"wrong, bad, impossible",JLPT JLPT_2 JLPT_3,c4*Ann{K[p
+深まる,ふかまる,to deepen,JLPT JLPT_2 JLPT_3,nFYj_QbHY$
+武器,ぶき,"weapon, arms",JLPT JLPT_2 JLPT_3,"k{:ASZ}`4,"
+拭く,ふく,"to wipe, to dry",JLPT JLPT_2 JLPT_3,C+1a]]!)6B
+服装,ふくそう,"clothes, attire",JLPT JLPT_2 JLPT_3,zfH3Izi6=g
+含む,ふくむ,"to contain, to include",JLPT JLPT_2 JLPT_3,qU@`!oQ_~}
+含める,ふくめる,to include,JLPT JLPT_2 JLPT_3,Lp<OS_$:v^
+袋,ふくろ,"bag, sack",JLPT JLPT_2 JLPT_3,fF&Fkk&[N(
+不幸,ふこう,"unhappiness, sorrow, misfortune",JLPT JLPT_2 JLPT_3,n27gAU4MS<
+節,ふし,"tune, tone, knob",JLPT JLPT_2 JLPT_3,meTR#p8LaO
+無事,ぶじ,"safety, peace",JLPT JLPT_2 JLPT_3,c|X1eKToE(
+不思議,ふしぎ,"mystery, curiosity",JLPT JLPT_2 JLPT_3,i2aoaA[Rbt
+不自由,ふじゆう,"discomfort, disability, inconvenience",JLPT JLPT_2 JLPT_3,OXxKs56cIo
+夫人,ふじん,"wife, Mrs, madam",JLPT JLPT_2 JLPT_3,"L,Jr>b/Q=,"
+婦人,ふじん,woman (same as 女性 (じょせい)、女の人 (おんなのひと)),JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.13,MGNGYZeM?*
+不正,ふせい,"injustice, unfairness",JLPT JLPT_2 JLPT_3,J.&5HDb8II
+防ぐ,ふせぐ,"to defend (against), to protect, to prevent",JLPT JLPT_2 JLPT_3,O_+;lEJg#]
+不足,ふそく,"insufficiency, shortage",JLPT JLPT_2 JLPT_3,Ip|9ih@[9P
+舞台,ぶたい,stage (theater),JLPT JLPT_2 JLPT_3,rkMf{ZSRD@
+双子,ふたご,"twins, a twin",JLPT JLPT_2 JLPT_3,Bb6Pii78=4
+再び,ふたたび,"again, once more, a second time",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.13,C$(!v<U~%+
+普段,ふだん,"in everyday situations, usually, ordinarily",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.15,scK7$1)*7n
+縁,ふち,"edge, rim",JLPT JLPT_2 JLPT_3,Nc2^vNEcht
+打つ,ぶつ,"to hit, to strike",JLPT JLPT_2 JLPT_3,rp}j9GjVWq
+不通,ふつう,"blockade, interruption, stoppage",JLPT JLPT_2 JLPT_3,qN|Fjh.;To
+物価,ぶっか,(commodity/consumer) prices,JLPT Genki_Ln.13 Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.6 Genki,ihU<14Ch9m
+ぶつかる,ぶつかる,"to strike, to collide with",JLPT JLPT_2 JLPT_3,l|QjAIGc3_
+ぶつける,ぶつける,"to knock, to strike hard, to hit and attack",JLPT JLPT_2 JLPT_3,F|EgJ%pFG_
+物質,ぶっしつ,"material, substance",JLPT JLPT_2 JLPT_3,Au^iDD.N(f
+物理,ぶつり,physics,JLPT JLPT_2 JLPT_3,vOwM[uj*81
+筆,ふで,writing brush,JLPT JLPT_2 JLPT_3,AAA2r[Yuck
+ふと,ふと,"suddenly, accidentally, incidentally",JLPT JLPT_2 JLPT_3,ueC<>j12PB
+部分,ぶぶん,"portion, section, part",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.12,"iSJ`*:5M,+"
+不平,ふへい,"complaint, discontent, dissatisfaction",JLPT JLPT_2 JLPT_3,xl2t9%M;*h
+不満,ふまん,"dissatisfaction, discontent, complaints",JLPT JLPT_2 JLPT_3,I5+Cu{SM(2
+増やす,ふやす,"to increase (v.t.), to add to",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.14,Ar(_{MW+^n
+殖やす,ふやす,"to increase, to add to",JLPT JLPT_2 JLPT_3,yaa{zbSv|8
+プラス,プラス,plus,JLPT JLPT_2 JLPT_3,IhKRA}1l&s
+プラスチック,プラスチック,plastic,JLPT JLPT_2 JLPT_3,fkV!PD4#0R
+プラン,プラン,plan,JLPT JLPT_2 JLPT_3,E)+h>:kQ+P
+不利,ふり,"disadvantage, drawback",JLPT JLPT_2 JLPT_3,uWj1Y*sKn!
+振る,ふる,"to wave, to shake; to sprinkle; to cast (actor)",JLPT JLPT_2 JLPT_3,"re,?~GZ/4O"
+震える,ふるえる,"to shiver, to shake, to quake",JLPT JLPT_2 JLPT_3,"E(?h_-A^M,"
+ブレーキ,ブレーキ,a brake,JLPT JLPT_2 JLPT_3,J$]6GJ*G:F
+触れる,ふれる,"to touch, to feel, to violate",JLPT JLPT_2 JLPT_3,GdRl?vrR-7
+プロ,プロ,professional,JLPT JLPT_2 JLPT_3,r@c|.GwEZG
+分,ぶん,"dividing, part, segment",JLPT JLPT_2 JLPT_3,B<D}`v5/5#
+文,ぶん,sentence,JLPT JLPT_2 JLPT_3,rA-6gilLFb
+雰囲気,ふんいき,"atmosphere (e.g., musical), mood, ambiance",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.12,u~WAeLx^(1
+分析,ぶんせき,analysis,JLPT JLPT_2 JLPT_3,BW:70ufQAS
+文明,ぶんめい,civilization,JLPT JLPT_2 JLPT_3,sa[`h{Q=[9
+分野,ぶんや,"field, sphere",JLPT JLPT_2 JLPT_3,H9@l-COvuo
+塀,へい,"wall, fence",JLPT JLPT_2 JLPT_3,b`Q#tC3%LL
+平均,へいきん,"equilibrium, balance, average",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.5,"Ipp8-,$Ihp"
+平和,へいわ,peace,JLPT JLPT_2 JLPT_3,pDR:k1Uvab
+別に,べつに,"(not) particularly, nothing",JLPT JLPT_2 JLPT_3,N>j!Oh:%5^
+減らす,へらす,"to decrease, to diminish",JLPT JLPT_2 JLPT_3,L|9vM+.g[_
+減る,へる,"to decrease (in size or number), to diminish",JLPT JLPT_2 JLPT_3,M^Mg^hFF~i
+ベルト,ベルト,Belt for western clothes,JLPT JLPT_2 JLPT_3,GTcb.}|Giw
+変化,へんか,"change, variation, shift",JLPT JLPT_2 JLPT_3,j9UWX/@2ih
+ペンキ,ペンキ,paint,JLPT JLPT_2 JLPT_3,DLO8LLG3|x
+変更,へんこう,"change, modification, alteration",JLPT JLPT_2 JLPT_3,bB&QqdWqmy
+ベンチ,ベンチ,bench,JLPT JLPT_2 JLPT_3,"l,WHbG]2JH"
+弁当,べんとう,box lunch,JLPT JLPT_2 JLPT_3,zNBqv(&}s^
+方,ほう,side,JLPT JLPT_2 JLPT_3,gma?L!#ps{
+法,ほう,Act (law: the X Act),JLPT JLPT_2 JLPT_3,okCQ@hxlIS
+棒,ぼう,"pole, rod, stick",JLPT JLPT_2 JLPT_3,funENr~TQC
+冒険,ぼうけん,"risk, venture, adventure",JLPT JLPT_2 JLPT_3,Fyl;77x&X*
+方向,ほうこう,"direction, course, way",JLPT JLPT_2 JLPT_3,QgNti^#[oD
+報告,ほうこく,"report, information",JLPT JLPT_2 JLPT_3,y4Y?|#~uOX
+宝石,ほうせき,"gem, jewel",JLPT JLPT_2 JLPT_3,Dj6XgRBu}x
+包装,ほうそう,"packing, wrapping",JLPT JLPT_2 JLPT_3,Otsl}ZzWXb
+豊富,ほうふ,"abundance, plenty",JLPT JLPT_2 JLPT_3,Cs6%u[Qn0$
+方法,ほうほう,"method, means, technique",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.8,isN8<2KrA#
+方々,ほうぼう,"here and there, everywhere",JLPT JLPT_2 JLPT_3,wl^OUsh)0d
+訪問,ほうもん,"call, visit",JLPT JLPT_2 JLPT_3,hsC[X6BGUF
+吠える,ほえる,"to bark, to howl",JLPT JLPT_2 JLPT_3,r$WR%olfa6
+ボーイ,ボーイ,porter; boy,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.6,Im8]7VT7{#
+ボート,ボート,rowing boat,JLPT JLPT_2 JLPT_3,xMp/lL<RR-
+ホーム,ホーム,platform; home,JLPT JLPT_2 JLPT_3,EyGV_xL&38
+ボール,ボール,ball; bowl,JLPT JLPT_3 JLPT_2 Genki_Ln.22 Genki,CO}gO)BA1a
+他,ほか,other (esp. places and things),JLPT JLPT_2 JLPT_3,vw>|`^Bt^u
+誇り,ほこり,pride,JLPT JLPT_2 JLPT_3,yj*)/<J;Jj
+埃,ほこり,dust,JLPT JLPT_2 JLPT_3,AO.~g!:dGf
+保証,ほしょう,"guarantee, assurance, warranty",JLPT JLPT_2 JLPT_3,oroU@#(;}/
+保存,ほぞん,"preservation, conservation",JLPT JLPT_2 JLPT_3,hSWOh8}x1v
+歩道,ほどう,walkway,JLPT JLPT_2 JLPT_3,oWq+gh5t1f
+仏,ほとけ,Buddha,JLPT JLPT_2 JLPT_3,r;K:#?B1W_
+骨,ほね,bone,JLPT JLPT_2 JLPT_3,F)(n<tky^7
+炎,ほのお,flame,JLPT JLPT_2 JLPT_3,td^&#ApIPe
+頬,ほほ,cheek (of face),JLPT JLPT_2 JLPT_3,MW?sJAMVg:
+頬,ほお,cheek (of face),JLPT JLPT_2 JLPT_3,eOL%=W-J#7
+ほぼ,ほぼ,"almost, roughly",JLPT JLPT_2 JLPT_3,d^=kc;gm+o
+微笑む,ほほえむ,to smile,JLPT JLPT_2 JLPT_3,wVB=qNZz4J
+堀,ほり,"moat, canal",JLPT JLPT_2 JLPT_3,FxbDaPc9#x
+濠,ほり,moat,JLPT JLPT_2 JLPT_3,tU(_Pmvb9R
+本当,ほんと,"truth, reality",JLPT JLPT_2 JLPT_3,b&f5kLt[Ac
+本人,ほんにん,the person himself,JLPT JLPT_2 JLPT_3,I0[E+qY%jw
+本物,ほんもの,genuine article,JLPT JLPT_2 JLPT_3,yGED#ay|.7
+ぼんやり,ぼんやり,"dim, faint, vague",JLPT JLPT_2 JLPT_3,Bu_{)ZzPr#
+間,ま,"space, room, pause",JLPT JLPT_2 JLPT_3,_MKZD^wW5
+まあ,まあ,well (used when making a modest or hesitant statement),JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.13,gK]=+G-`a3
+マーケット,マーケット,market,JLPT JLPT_2 JLPT_3,"z,Yj6>]ZS]"
+マイク,マイク,mic,JLPT JLPT_2 JLPT_3,r0v`jqD@%T
+迷子,まいご,lost (stray) child,JLPT JLPT_2 JLPT_3,FT#CRKr^or
+マイナス,マイナス,minus,JLPT JLPT_2 JLPT_3,d7Qaj7)8Wq
+任せる,まかせる,"to entrust to another, to leave to",JLPT JLPT_2 JLPT_3,L[Sv^|TveX
+巻く,まく,"to wind, to coil, to roll",JLPT JLPT_2 JLPT_3,bZ[[^glA1W
+蒔く,まく,to sow (seeds),JLPT JLPT_2 JLPT_3,H=Zk$-##fv
+撒く,まく,"to scatter, to sprinkle, to sow",JLPT JLPT_2 JLPT_3,elIwgF9#tO
+幕,まく,"curtain, act (in play)",JLPT JLPT_2 JLPT_3,p/poyGf`R=
+負け,まけ,"defeat, loss",JLPT JLPT_2 JLPT_3,Gm;-Q!$V98
+孫,まご,grandchild,JLPT JLPT_2 JLPT_3,IHHk^Ab_ve
+まさか,まさか,by no means,JLPT JLPT_2 JLPT_3,M*J/_!BP[F
+まさに,まさに,"correctly, surely",JLPT JLPT_2 JLPT_3,PW-SB}B+g9
+混ざる,まざる,"to be mixed, to mingle with",JLPT JLPT_2 JLPT_3,r;?[!)ts`(
+交ざる,まざる,"to be mixed, to mingle with",JLPT JLPT_2 JLPT_3,4K$w~U;He
+混じる,まじる,"to be mixed, to mingle with",JLPT JLPT_2 JLPT_3,"d#EkI,dbkR"
+交じる,まじる,"to be mixed, to mingle with",JLPT JLPT_2 JLPT_3,Ek]^@FM&X:
+増す,ます,"to increase, to gain",JLPT JLPT_2 JLPT_3,igA/Wx5uJY
+貧しい,まずしい,"poor, needy",JLPT JLPT_2 JLPT_3,yhxCEWNSqv
+マスター,マスター,"bar owner, master (e.g., arts, science)",JLPT JLPT_2 JLPT_3,wPc=w@;W9x
+ますます,ますます,"increasingly (same as もっと), more and more",JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.9,tuWAGYc>]J
+混ぜる,まぜる,"to mix, to stir",JLPT JLPT_2 JLPT_3,J@;szQ>5H7
+交ぜる,まぜる,"to be mixed, to be blended with",JLPT JLPT_2 JLPT_3,PxviWu8b^f
+街,まち,"town; street, road",JLPT JLPT_2 JLPT_3,HfD?AV.2#Q
+間違い,まちがい,mistake,JLPT Genki_Ln.19 JLPT_3 JLPT_2 Genki,BDS-:};NM$
+松,まつ,pine tree,JLPT JLPT_2 JLPT_3,q{u(t.GeD(
+真っ赤,まっか,"deep red, flushed (of face)",JLPT JLPT_2 JLPT_3,NaIP;.$n/b
+全く,まったく,"really, completely",JLPT JLPT_2 JLPT_3,N~j_lRE~H>
+祭,まつり,"festival, feast",JLPT JLPT_2 JLPT_3,b~w=W0;TL7
+まとまる,まとまる,"to be collected, to be settled, to be in order",JLPT JLPT_2 JLPT_3,x(|HBhj.8
+まとめる,まとめる,"to put in order, to collect, to bring to a conclusion",JLPT JLPT_2 JLPT_3,iFaV|KCNxw
+学ぶ,まなぶ,to learn; to study,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.8,E-![dvkug}
+真似,まね,"mimicry, imitation, behavior",JLPT JLPT_2 JLPT_3,Ha/*s9C{]A
+招く,まねく,to invite,JLPT Intermediate_Japanese JLPT_3 JLPT_2 Intermediate_Japanese_Ln.13,rQ0-*9mHkN
+まぶしい,まぶしい,"dazzling, radiant",JLPT JLPT_2 JLPT_3,JQkYs:8mnj
+柵,さく,"fence, paling",JLPT_1 JLPT JLPT_3,y#vU&Fd{*`
+裂ける,さける,"to split, to tear, to burst",JLPT_1 JLPT JLPT_3,duhUDkU~WK
+裁く,さばく,to judge,JLPT_1 JLPT JLPT_3,xRke1sza<m
+酸化,さんか,oxidation,JLPT_1 JLPT JLPT_3,D1MP^#_z1B
+死,し,"death, decease",JLPT_1 JLPT JLPT_3,t06OltNZyD
+資格,しかく,"qualifications, requirements, capabilities",JLPT_1 JLPT JLPT_3,wi++wC}pSU
+視覚,しかく,"sense of sight, vision",JLPT_1 JLPT JLPT_3,E=/?Opn_[&
+指揮,しき,"command, direction",JLPT_1 JLPT JLPT_3,I~OJZxTkqT
+磁気,じき,magnetism,JLPT_1 JLPT JLPT_3,"c,aD*!!MOk"
+磁器,じき,"porcelain, china",JLPT_1 JLPT JLPT_3,Q82E>*!xNX
+自己,じこ,"self, oneself",JLPT_1 JLPT JLPT_3,:az?1DOih
+字体,じたい,"font, lettering",JLPT_1 JLPT JLPT_3,jz(I1Q*KVQ
+辞退,じたい,refusal,JLPT_1 JLPT JLPT_3,s^yuvY0jMN
+視点,してん,"opinion, point of view, visual point",JLPT_1 JLPT JLPT_3,"fg,X`JJ|Co"
+脂肪,しぼう,"fat, grease",JLPT_1 JLPT JLPT_3,z48jHbiC_$
+志望,しぼう,"wish, desire, ambition",JLPT_1 JLPT JLPT_3,r-E-GUEXsY
+衆,しゅう,"masses, people",JLPT_1 JLPT JLPT_3,rXpmbk8=bE
+住,じゅう,"dwelling, living",JLPT_1 JLPT JLPT_3,Gr~DDJR6l}
+修飾,しゅうしょく,ornamentation; modification (gram),JLPT_1 JLPT JLPT_3,O}Nr9R^}M5
+私用,しよう,"personal use, private business",JLPT_1 JLPT JLPT_3,BnE{ivc`n=
+仕様,しよう,"way, method, specification",JLPT_1 JLPT JLPT_3,oE!*S&aFqD
+情,じょう,"feelings, emotion, passion",JLPT_1 JLPT JLPT_3,bl3-{=5!X[
+生涯,しょうがい,one's lifetime,JLPT_1 JLPT JLPT_3,Pie[%Re:m6
+上司,じょうし,one's superior,JLPT Intermediate_Japanese JLPT_1 JLPT_3 Intermediate_Japanese_Ln.9,u|7SjLmC*W
+正体,しょうたい,"natural shape, one's true colors, true character",JLPT_1 JLPT JLPT_3,PK*KgnJaC
+照明,しょうめい,illumination,JLPT_1 JLPT JLPT_3,D&z&8>sgOU
+女史,じょし,Ms.,JLPT_1 JLPT JLPT_3,"b7C,wG{C22"
+助詞,じょし,"(gram) particle(s), postposition",JLPT Intermediate_Japanese JLPT_1 JLPT_3 Intermediate_Japanese_Ln.13,"MG<?XdN0,Z"
+ショック,ショック,shock,JLPT Intermediate_Japanese JLPT_1 JLPT_3 Intermediate_Japanese_Ln.4,Od5f@HtWc-
+進行,しんこう,advance,JLPT_1 JLPT JLPT_3,i:ZPt9q4?b
+新興,しんこう,"rising, developing, emergent",JLPT_1 JLPT JLPT_3,e=XTe9$}W6
+振興,しんこう,"promotion, encouragement",JLPT_1 JLPT JLPT_3,w.^ogJW1(4
+申告,しんこく,"report, statement",JLPT_1 JLPT JLPT_3,bpPy/Tdvi5
+真理,しんり,truth,JLPT_1 JLPT JLPT_3,o~g13?^$If
+水洗,すいせん,flushing,JLPT_1 JLPT JLPT_3,uGMalIYW7L
+ストレス,ストレス,stress,JLPT_1 JLPT JLPT_3,.v(A*gC%Q
+擦る,する,"to rub, to chafe",JLPT_1 JLPT JLPT_3,BR[lU_Z<4K
+正規,せいき,"regular, legitimate",JLPT_1 JLPT JLPT_3,qB)0/c?(Sj
+精巧,せいこう,"elaborate, delicate, exquisite",JLPT_1 JLPT JLPT_3,O4>$NE8IPr
+精算,せいさん,"exact calculation, adjustment",JLPT_1 JLPT JLPT_3,ovctUT)$>z
+成年,せいねん,"majority, adult age",JLPT_1 JLPT JLPT_3,xePq0XBgP_
+声明,せいめい,"declaration, statement, proclamation",JLPT_1 JLPT JLPT_3,B$[eh>:mkl
+姓名,せいめい,full name,JLPT_1 JLPT JLPT_3,C]0w+PhetE
+生理,せいり,"physiology, menses",JLPT_1 JLPT JLPT_3,f73PQXWx7=
+節,せつ,"when, if; section; clause",JLPT_1 JLPT JLPT_3,oxQV.29qE;
+膳,ぜん,"(small) table, tray, meal",JLPT_1 JLPT JLPT_3,p1wC]g~$`W
+禅,ぜん,Zen (Buddhism),JLPT_1 JLPT JLPT_3,iyz0<Gw>w^
+選挙,せんきょ,election,JLPT JLPT_1 JLPT_3 Genki_Ln.23 Genki,"E:w+vZ=[*,"
+先行,せんこう,"preceding, going first",JLPT_1 JLPT JLPT_3,H}S`T5a4|Z
+選考,せんこう,"selection, screening",JLPT_1 JLPT JLPT_3,f>TTKs[_O7
+相,そう,"aspect, phase, countenance",JLPT_1 JLPT JLPT_3,"uspMV-,ze1"
+沿う,そう,"to run along, to follow",JLPT_1 JLPT JLPT_3,p/frNLfSx`
+添う,そう,"to accompany, to comply with",JLPT_1 JLPT JLPT_3,hF`[B^>-hS
+僧,そう,"monk, priest",JLPT_1 JLPT JLPT_3,yw]w|=zm=s
+像,ぞう,"statue, image",JLPT_1 JLPT JLPT_3,nI=^X@DZIN
+捜査,そうさ,"search (esp. in criminal investigations, investigation)",JLPT_1 JLPT JLPT_3,"uDX,}/x@{/"
+操縦,そうじゅう,"management, control, manipulation",JLPT_1 JLPT JLPT_3,M>/Rq`boN-
+創造,そうぞう,creation,JLPT_1 JLPT JLPT_3,"dp,2/)bOJR"
+隊,たい,"party, troops",JLPT_1 JLPT JLPT_3,oOV`L+=72#
+退学,たいがく,dropping out of school,JLPT_1 JLPT JLPT_3,A4yM&A#+4L
+タイトル,タイトル,title,JLPT_1 JLPT JLPT_3,C>q:RF*.r8
+ダウン,ダウン,down,JLPT_1 JLPT JLPT_3,P@qEmViSUu
+高まる,たかまる,to rise; to grow; to mount (v.i.),JLPT Intermediate_Japanese JLPT_1 JLPT_3 Intermediate_Japanese_Ln.14,p=9SjD]i]q
+断つ,たつ,"to sever, to cut off",JLPT_1 JLPT JLPT_3,P?^bp-(y]k
+盾,たて,shield,JLPT_1 JLPT JLPT_3,ol51jAu^|h
+例え,たとえ,example; even though,JLPT_1 JLPT JLPT_3,vD1pJmAKj2
+チャイム,チャイム,chime,JLPT_1 JLPT JLPT_3,MQLqaV0IiT
+挑戦,ちょうせん,"challenge, defiance",JLPT_1 JLPT JLPT_3,Fo2(&vWuR<
+治療,ちりょう,medical treatment,JLPT_1 JLPT JLPT_3,yw{9Y;C!G/
+対,つい,"pair, couple, set",JLPT_1 JLPT JLPT_3,C;9I#$4SFJ
+接ぐ,つぐ,to join; to piece together; to set (bones); to graft (trees),JLPT_1 JLPT JLPT_3,iNY(7WR;G%
+継ぐ,つぐ,to succeed (someone in a business or inheritance,JLPT_1 JLPT JLPT_3,L=(nKj-342
+摘む,つむ,"to pluck, to pick, to trim",JLPT_1 JLPT JLPT_3,F?B0wE`T~h
+露,つゆ,dew,JLPT_1 JLPT JLPT_3,nf%]9K}w$o
+強まる,つよまる,"to get strong, to gain strength",JLPT_1 JLPT JLPT_3,"c,02yf|3E;"
+強める,つよめる,"to strengthen, to emphasize",JLPT_1 JLPT JLPT_3,r51ril#).:
+データ,データ,data,JLPT_1 JLPT JLPT_3,mIV8F#]3m7
+デザイン,デザイン,design,JLPT_1 JLPT JLPT_3,L|t?~XL)K}
+デザート,デザート,dessert,JLPT_1 JLPT JLPT_3,bL1L]V?.Fr
+転校,てんこう,change schools,JLPT_1 JLPT JLPT_3,OJyP}KWKG|
+伝言,でんごん,verbal message,JLPT_1 JLPT JLPT_3,GvqvJ@T>v!
+と,と,and,JLPT_1 JLPT JLPT_3,M:Axq>|(Kg
+問う,とう,"to ask, to question",JLPT_1 JLPT JLPT_3,liQ|$R<T6G
+棟,とう,ridge (of roof,JLPT_1 JLPT JLPT_3,DbAa])9/F(
+倒産,とうさん,"(corporate) bankruptcy, insolvency",JLPT_1 JLPT JLPT_3,z@^@3D{^xO
+同士,どうし,"one another, companion, comrade",JLPT Intermediate_Japanese JLPT_1 JLPT_3 Intermediate_Japanese_Ln.9,LZ;*se^02u
+同志,どうし,"same mind, comrade, kindred soul",JLPT_1 JLPT JLPT_3,hK!%#l^Nm>
+当然,とうぜん,obvious; natural,JLPT Intermediate_Japanese JLPT_1 JLPT_3 Intermediate_Japanese_Ln.15,cz-NMt}<Am
+動揺,どうよう,"disturbance, flutter shock",JLPT_1 JLPT JLPT_3,A!=y9>sh0L
+説く,とく,"to explain, to advocate",JLPT_1 JLPT JLPT_3,oUk1CBesl;
+綴じる,とじる,"to bind, to file",JLPT_1 JLPT JLPT_3,]ZHD4IQ@J
+供,とも,"accompanying, attendant, companion, retinue",JLPT_1 JLPT JLPT_3,sml:7Y1}f0
+並,なみ,"medium (e.g., food serving size, quality, price, etc.), ordinary",JLPT Intermediate_Japanese JLPT_1 JLPT_3 Intermediate_Japanese_Ln.6,w_{us|Bt(V
+慣らす,ならす,to accustom,JLPT_1 JLPT JLPT_3,KYq0Q{!HJ_
+馴らす,ならす,"to domesticate, to tame",JLPT_1 JLPT JLPT_3,OBi-;rN&v.
+難,なん,"difficulty, hardships, defect",JLPT_1 JLPT JLPT_3,HB%n)kg>!j
+音,ね,"sound, note",JLPT_1 JLPT JLPT_3,m2~M4cm)mU
+年鑑,ねんかん,yearbook,JLPT_1 JLPT JLPT_3,i1+!b-Tw6h
+脳,のう,"brain, memory",JLPT_1 JLPT JLPT_3,GA>&i45J`=
+臨む,のぞむ,"to look out on, to face, to attend (function)",JLPT_1 JLPT JLPT_3,KS-n)JUr1X
+肺,はい,lung,JLPT_1 JLPT JLPT_3,NQ;dD{HA.l
+～敗,はい,"counter for loss, defeat",JLPT_1 JLPT JLPT_3,Jfw=ThK<1_
+映える,はえる,"to shine, to look attractive, to look pretty",JLPT_1 JLPT JLPT_3,c_<of-R32q
+諮る,はかる,"to consult with, to confer",JLPT_1 JLPT JLPT_3,zH?Q%7Y|:s
+図る,はかる,"to plot, to attempt, to devise, to design, to refer A to B",JLPT_1 JLPT JLPT_3,oSV1hDA!z4
+生やす,はやす,"to grow, to cultivate, to wear beard",JLPT_1 JLPT JLPT_3,yqCGb?6_?M
+班,はん,"group, party, section (mil)",JLPT_1 JLPT JLPT_3,oiqC3{QOR3
+判,はん,size (of paper or books),JLPT_1 JLPT JLPT_3,"FxD*L0,Q6x"
+版,はん,edition,JLPT_1 JLPT JLPT_3,wusB`V9s1U
+碑,ひ,stone monument bearing an inscription,JLPT_1 JLPT JLPT_3,Kaa{nE*EBz
+非行,ひこう,"delinquency, misconduct",JLPT_1 JLPT JLPT_3,E<wpvtAJG)
+票,ひょう,"label, ballot, sign",JLPT_1 JLPT JLPT_3,"i*<L4C^,UW"
+広まる,ひろまる,"to spread, to be propagated",JLPT_1 JLPT JLPT_3,c8ONuWuz#:
+深める,ふかめる,"to deepen, to heighten, to intensify",JLPT_1 JLPT JLPT_3,c0BKoo3/`
+福,ふく,good fortune,JLPT_1 JLPT JLPT_3,m_8f-@p-oN
+振り,ふり,"style, manner",JLPT_1 JLPT JLPT_3,Cb|X]Z#30A
+経る,へる,"to pass, to elapse, to experience",JLPT_1 JLPT JLPT_3,"xYI,72?]/M"
+保護,ほご,"care, protection, shelter",JLPT_1 JLPT JLPT_3,P&2:@t7Bp.
+保障,ほしょう,"guarantee, security, warranty",JLPT_1 JLPT JLPT_3,ge$.nEK~0J
+補償,ほしょう,"compensation, reparation",JLPT_1 JLPT JLPT_3,n@O).>E`E!
+ほっと,ほっと,feel relieved,JLPT_1 JLPT JLPT_3,IA36R!IvOE
+前もって,まえもって,"in advance, beforehand, previously",JLPT_1 JLPT JLPT_3,wlgn+RR?9d
+膜,まく,"membrane, film",JLPT_1 JLPT JLPT_3,eczkIybUVQ
+マスコミ,マスコミ,mass communication,JLPT_1 JLPT JLPT_3,c~yMgKSxj{
+股,また,"thigh, crotch",JLPT_1 JLPT JLPT_3,M~8AlqEF!|
+末,まつ,the end of,JLPT_1 JLPT JLPT_3,c](L`Ctg(*
+マッサージ,マッサージ,massage,JLPT_1 JLPT JLPT_3,CIT-/$8F-&
+見掛ける,みかける,"to (happen to see), to notice, to catch sight of",JLPT_1 JLPT JLPT_3,x5#*oa=f1j
+捲る,めくる,"to turn over, to turn pages of a book",JLPT_1 JLPT JLPT_3,iY1_V_W5ZM
+メッセージ,メッセージ,message,JLPT_1 JLPT JLPT_3,DIKKB*kyMZ
+野党,やとう,opposition party,JLPT_1 JLPT JLPT_3,L$j=XCFoNq
+優,ゆう,"superiority, high grade",JLPT_1 JLPT JLPT_3,J%>HVQ7M=`
+有機,ゆうき,organic,JLPT_1 JLPT JLPT_3,m7Y{=QxsB-
+世,よ,"world, society, generation",JLPT_1 JLPT JLPT_3,E|]o*tNk82
+良い,よい,"good, nice",JLPT_1 JLPT JLPT_3,zu]*YPRXMm
+予想,よそう,"expectation, anticipation, prediction",JLPT_1 JLPT JLPT_3,E0D`K(E!7;
+弱まる,よわまる,"to weaken, to be emaciated, to be dejected",JLPT_1 JLPT JLPT_3,tRU<avrq6-
+弱める,よわめる,to weaken,JLPT_1 JLPT JLPT_3,n@|3sdAzme
+ラベル,ラベル,label,JLPT_1 JLPT JLPT_3,Ni5Si{<X/E
+ルール,ルール,rule,JLPT_1 JLPT JLPT_3,J<OIlv-=I*
+枠,わく,"frame, slide",JLPT_1 JLPT JLPT_3,l.gbfy2Op+

--- a/src/n4.csv
+++ b/src/n4.csv
@@ -1,669 +1,669 @@
-expression,reading,meaning,tags
-踏む,ふむ,"to step on, to tread on",JLPT JLPT_N4
-～区,～く,"~ district, ~ ward, ~ borough",JLPT JLPT_N4
-すっと,すっと,"straight, quickly",JLPT JLPT_N4
-盗む,ぬすむ,to steal; to rob,Genki Genki_Ln.21 JLPT JLPT_N4
-大抵,たいてい,"generally, usually",Genki Genki_Ln.3 JLPT JLPT_N4
-とうとう,とうとう,"finally, at last",JLPT JLPT_N4
-ガソリン,ガソリン,"gasoline, petrol",Genki Genki_Ln.21 JLPT JLPT_N4
-鳴る,なる,"to sound, to ring (v.i.)",Intermediate_Japanese_Ln.2 JLPT JLPT_N4
-しっかり,しっかり,"firmly, steady",JLPT JLPT_N4
-生きる,いきる,to live,JLPT JLPT_N4
-苦い,にがい,bitter,JLPT JLPT_N4
-沸く,わく,"to boil, to grow hot",JLPT JLPT_N4
-意見,いけん,"opinion, view, idea",JLPT JLPT_N4
-やはり; やっぱり,やはり; やっぱり,"as I thought, absolutely",JLPT JLPT_N4
-漫画,まんが,"comic (book), cartoon",Genki Genki_Ln.14 JLPT JLPT_N4
-ステレオ,ステレオ,stereo,JLPT JLPT_N4
-医学,いがく,medical science,JLPT JLPT_N4
-テキスト,テキスト,text; text book,JLPT JLPT_N4
-～月,～つき,month,JLPT JLPT_N4
-折る,おる,"to snap, to break; to bend",JLPT JLPT_N4
-～会,～かい,~ meeting,JLPT JLPT_N4
-うかがう,うかがう,to ask,JLPT JLPT_N4
-聞こえる,きこえる,"to be heard, to be audible",JLPT JLPT_N4
-僕,ぼく,I (used by men towards those of equal or lower status),Genki Genki_Ln.5 JLPT JLPT_N4
-必ず,かならず,"surely, certainly",Intermediate_Japanese_Ln.8 JLPT JLPT_N4
-壊す,こわす,"to break, to break down",JLPT JLPT_N4
-怒る,おこる,to get angry; to scold angrily,Genki Genki_Ln.19 JLPT JLPT_N4
-床屋,とこや,barber's (shop),Genki Genki_Ln.10 Intermediate_Japanese_Ln.6 JLPT JLPT_N4
-オートバイ,オートバイ,motorcycle (lit: auto-bi(ke)),JLPT JLPT_N4
-運動,うんどうする,exercise,JLPT JLPT_N4
-止む,やむ,"to cease, to stop",JLPT JLPT_N4
-もし,もし,if,JLPT JLPT_N4
-表,おもて,surface; front; outside,JLPT JLPT_N4
-大学生,だいがくせい,"college student, university student",Genki Genki_Ln.1 Genki_Ln.8 JLPT JLPT_N4
-運転手,うんてんしゅ,driver (by occupation),Intermediate_Japanese_Ln.6 JLPT JLPT_N4
-予習,よしゅう,preparation of lessons (for class),Genki Genki_Ln.22 Intermediate_Japanese_Ln.5 JLPT JLPT_N4
-心配,しんぱいする,"worry, concern",JLPT JLPT_N4
-別,べつ,"distinction, different",JLPT JLPT_N4
-非常に,ひじょうに,extremely; very,Intermediate_Japanese_Ln.2 JLPT JLPT_N4
-お宅,おたく,(someone else's) house; home -- polite word for 家 (いえ) --,Genki Genki_Ln.13 Intermediate_Japanese_Ln.7 JLPT JLPT_N4
-柔らかい,やわらかい,"soft (in reference to texture), tender",JLPT JLPT_N4
-拾う,ひろう,"to pick up (something), to find",Genki Genki_Ln.22 JLPT JLPT_N4
-～ございます,～ございます,"to be (polite), to exist",JLPT JLPT_N4
-気,き,"spirit, mood",JLPT JLPT_N4
-比べる,くらべる,to compare,JLPT JLPT_N4
-ほとんど,ほとんど,"mostly, almost",Intermediate_Japanese_Ln.7 JLPT JLPT_N4
-つもり,つもり,"intention, plan",JLPT JLPT_N4
-郊外,こうがい,"suburb, outskirts",JLPT JLPT_N4
-だめ,だめ,"useless, no good, hopeless",JLPT JLPT_N4
-売り場,うりば,place where things are sold,JLPT JLPT_N4
-正月,しょうがつ,"New Year, New Year's Day",JLPT JLPT_N4
-規則,きそく,"rule, regulation",JLPT JLPT_N4
-うん,うん,"yes (informal), all right (ok)",Genki Genki_Ln.8 JLPT JLPT_N4
-発音,はつおん,pronunciation,JLPT JLPT_N4
-焼く,やく,"to bake, to grill",Genki Genki_Ln.21 JLPT JLPT_N4
-屋上,おくじょう,rooftop,JLPT JLPT_N4
-失礼,しつれい,"discourtesy, impoliteness; Excuse me",JLPT JLPT_N4
-ごみ,ごみ,"trash, garbage",Genki Genki_Ln.16 JLPT JLPT_N4
-アフリカ,アフリカ,Africa,JLPT JLPT_N4
-点,てん,"mark, score, grade; point, dot",Intermediate_Japanese_Ln.5 JLPT JLPT_N4
-一生懸命,いっしょうけんめい,"very hard (as in ""to work hard""), with utmost effort",Intermediate_Japanese_Ln.5 JLPT JLPT_N4
-今度,こんど,"now, this time, near future, one of these days, next time",Genki Genki_Ln.9 JLPT JLPT_N4
-機会,きかい,"chance, opportunity",JLPT JLPT_N4
-建てる,たてる,to build,JLPT JLPT_N4
-複雑,ふくざつ,"complexity, complication",JLPT JLPT_N4
-彼,かれ,"he, boyfriend",Genki Genki_Ln.12 Intermediate_Japanese_Ln.8 JLPT JLPT_N4
-いらっしゃる,いらっしゃる,"-- honorific expression for いく, くる, and いる --",Genki Genki_Ln.19 JLPT JLPT_N4
-布団,ふとん,futon,JLPT JLPT_N4
-大事,だいじ,"important, valuable, serious matter",JLPT JLPT_N4
-贈り物,おくりもの,a gift; a present,Intermediate_Japanese_Ln.9 JLPT JLPT_N4
-泥棒,どろぼう,thief; burglar,Genki Genki_Ln.21 JLPT JLPT_N4
-～製,～せい,made in ~,JLPT JLPT_N4
-注意,ちゅうい,"caution, attention",JLPT JLPT_N4
-台風,たいふう,typhoon,Genki Genki_Ln.16 JLPT JLPT_N4
-日,ひ,"sun, sunshine, day",Genki Genki_Ln.16 JLPT JLPT_N4
-～軒,～けん,counter for houses,JLPT JLPT_N4
-そう,そう,"really, (is that) so; yes, right",JLPT JLPT_N4
-通る,とおる,"to pass (by), to go through",JLPT JLPT_N4
-過ぎる,すぎる,"to exceed, to go beyond",JLPT JLPT_N4
-レポート; リポート,レポート; リポート,report,JLPT JLPT_N4
-葉,は,leaf,JLPT JLPT_N4
-必要,ひつよう,necessary,JLPT JLPT_N4
-課長,かちょう,section manager,Intermediate_Japanese_Ln.7 JLPT JLPT_N4
-地震,じしん,earthquake,Genki Genki_Ln.15 JLPT JLPT_N4
-すると,すると,"and, then",JLPT JLPT_N4
-止める,やめる,"to end, to stop",JLPT JLPT_N4
-ガラス,ガラス,"glass, pane",JLPT JLPT_N4
-～学部,～がくぶ,department of a university,JLPT JLPT_N4
-厳しい,きびしい,hard; rigorous; strict,Genki Genki_Ln.13 Intermediate_Japanese_Ln.5 JLPT JLPT_N4
-エスカレーター,エスカレーター,escalator,JLPT JLPT_N4
-人口,じんこう,population,Intermediate_Japanese_Ln.4 JLPT JLPT_N4
-月,つき,moon,Genki Genki_Ln.20 JLPT JLPT_N4
-絹,きぬ,silk,JLPT JLPT_N4
-ちっとも,ちっとも,not at all (neg. verb),JLPT JLPT_N4
-深い,ふかい,"deep, profound",JLPT JLPT_N4
-壊れる,こわれる,"to be broken, to break",JLPT JLPT_N4
-揺れる,ゆれる,"to shake, to sway",JLPT JLPT_N4
-落る,おちる,"to fall, to drop",JLPT JLPT_N4
-できるだけ,できるだけ,"if at all possible, as much as possible",JLPT JLPT_N4
-悲しい,かなしい,"sad, sorrowful",Genki Genki_Ln.13 JLPT JLPT_N4
-中学校,ちゅうがっこう,junior high school pupil,JLPT JLPT_N4
-ガス,ガス,gas,JLPT JLPT_N4
-祈る,いのる,to pray; to wish,JLPT JLPT_N4
-盛ん,さかん,"prosperous, active, thriving",JLPT JLPT_N4
-アルバイト,アルバイト,part-time job,Genki Genki_Ln.4 JLPT JLPT_N4
-起こす,おこす,to wake (someone) up,Genki Genki_Ln.16 JLPT JLPT_N4
-致す,いたす,-- extra-modest expression for する --,Genki Genki_Ln.20 JLPT JLPT_N4
-噛む,かむ,"to bite, to chew",JLPT JLPT_N4
-赤ちゃん,あかちゃん,"baby, infant",Genki Genki_Ln.21 JLPT JLPT_N4
-浅い,あさい,"shallow, superficial",JLPT JLPT_N4
-嘘,うそ,lie,JLPT JLPT_N4
-小説,しょうせつ,novel,Genki Genki_Ln.20 JLPT JLPT_N4
-親,おや,a parent,Genki Genki_Ln.16 Intermediate_Japanese_Ln.6 JLPT JLPT_N4
-それに,それに,moreover; besides,Intermediate_Japanese_Ln.2 JLPT JLPT_N4
-西洋,せいよう,"the West, Western countries",JLPT JLPT_N4
-思う,おもう,"to think, to feel",Genki Genki_Ln.8 JLPT JLPT_N4
-パート (タイム),パート (タイム),part time (esp. female part time employees),JLPT JLPT_N4
-時代,じだい,"age, period, epoch, era",JLPT JLPT_N4
-申し上げる,もうしあげる,"(humble)to say, to tell",JLPT JLPT_N4
-～式,～しき,~ ceremony; ~ style,JLPT JLPT_N4
-出席,しゅっせきする,attendance,JLPT JLPT_N4
-～家,～か,person who is specialized in ~,JLPT JLPT_N4
-迎える,むかえる,to welcome; to meet; to greet,JLPT JLPT_N4
-触る,さわる,"to touch, to feel",JLPT JLPT_N4
-建て,～だて,"~ storied, separate housing",JLPT JLPT_N4
-社長,しゃちょう,president of a company,Genki Genki_Ln.11 JLPT JLPT_N4
-動物園,どうぶつえん,zoo,JLPT JLPT_N4
-捕まえる,つかまえる,"to catch, to arrest",JLPT JLPT_N4
-季節,きせつ,season (in reference to weather),Genki Genki_Ln.10 Intermediate_Japanese_Ln.9 JLPT JLPT_N4
-寄る,よる,to stop by,Genki Genki_Ln.19 Intermediate_Japanese_Ln.3 JLPT JLPT_N4
-決まる,きまる,to be set; fixed (v.i.),Intermediate_Japanese_Ln.2 JLPT JLPT_N4
-開く,ひらく,to open; to hold (an event),JLPT JLPT_N4
-逃げる,にげる,"to escape, to run away",JLPT JLPT_N4
-だから,だから,so; therefore,Genki Genki_Ln.4 JLPT JLPT_N4
-残念,ざんねん,regret; regrettable,Intermediate_Japanese_Ln.7 JLPT JLPT_N4
-畳,たたみ,tatami mat (Japanese straw mat),JLPT JLPT_N4
-丁寧,ていねい,"polite, courteous, careful",JLPT JLPT_N4
-地理,ちり,geography,JLPT JLPT_N4
-さっき,さっき,a little while ago,Genki Genki_Ln.4 JLPT JLPT_N4
-怖い,こわい,"scary, frightening",Genki Genki_Ln.5 JLPT JLPT_N4
-包む,つつむ,"to wrap, to cover",Genki Genki_Ln.21 JLPT JLPT_N4
-なるべく,なるべく,"if possible, as much as possible",Intermediate_Japanese_Ln.3 JLPT JLPT_N4
-無理,むり,"unreasonable, impossible",JLPT JLPT_N4
-サンドイッチ,サンドイッチ,sandwich,JLPT JLPT_N4
-会議室,かいぎしつ,conference room,JLPT JLPT_N4
-品物,しなもの,goods,JLPT JLPT_N4
-人形,にんぎょう,"doll, figure",JLPT JLPT_N4
-利用,りよう,"use, utilization",JLPT JLPT_N4
-飾る,かざる,"to decorate, to adorn",JLPT JLPT_N4
-止める,とめる,to stop (something),JLPT JLPT_N4
-恥ずかしい,はずかしい,"ashamed, embarrassed",Genki Genki_Ln.18 JLPT JLPT_N4
-いくら～ても,いくら～ても,however much one may ~,JLPT JLPT_N4
-用事,ようじ,business to take care of; tasks; errands,Genki Genki_Ln.12 JLPT JLPT_N4
-ビル,ビル,(abbr.) building,JLPT JLPT_N4
-けんかする,けんかする,quarrel,JLPT JLPT_N4
-頑張る,がんばる,"to try one's best, to try hard, to persist",Genki Genki_Ln.13 JLPT JLPT_N4
-投げる,なげる,"to pitch, to cast away",Intermediate_Japanese_Ln.7 JLPT JLPT_N4
-故障,こしょうする,breakdown,JLPT JLPT_N4
-力,ちから,"strength, power",JLPT JLPT_N4
-受ける,うける,"to take (an examination, interview, etc.); to receive",JLPT JLPT_N4
-気分,きぶん,"feeling, mood",JLPT JLPT_N4
-間違える,まちがえる,to make a mistake,Genki Genki_Ln.21 JLPT JLPT_N4
-そんな,そんな,"such, like that, that sort of",JLPT JLPT_N4
-星,ほし,star,JLPT JLPT_N4
-場合,ばあい,"case, situation",JLPT JLPT_N4
-やっと,やっと,"at last, finally",JLPT JLPT_N4
-足りる,たりる,to be sufficient; to be enough,Genki Genki_Ln.17 Intermediate_Japanese_Ln.4 JLPT JLPT_N4
-行う,おこなう,to carry out; to conduct (typically used in written language),Intermediate_Japanese_Ln.3 JLPT JLPT_N4
-ぶどう,ぶどう,grapes,JLPT JLPT_N4
-無くなる,なくなる,"to disappear, to get lost",JLPT JLPT_N4
-準備,じゅんびする,prepare,JLPT JLPT_N4
-世界,せかい,world,Genki Genki_Ln.10 JLPT JLPT_N4
-住所,じゅうしょ,address; place of residence,JLPT JLPT_N4
-再来月,さらいげつ,the month after next,JLPT JLPT_N4
-林,はやし,"woods, forest",JLPT JLPT_N4
-倍,ばい,double,JLPT JLPT_N4
-痩せる,やせる,to lose weight,Genki Genki_Ln.7 JLPT JLPT_N4
-線,せん,"line, wire",JLPT JLPT_N4
-戦争,せんそう,war,JLPT JLPT_N4
-決める,きめる,to decide (v.t.),Genki Genki_Ln.10 Intermediate_Japanese_Ln.9 JLPT JLPT_N4
-調べる,しらべる,to check; to look up; to inquire; to search,JLPT JLPT_N4
-寝坊,ねぼう,sleeping in late,JLPT JLPT_N4
-パパ,パパ,"papa, daddy",JLPT JLPT_N4
-光る,ひかる,"to shine, to glitter",JLPT JLPT_N4
-夫,おっと,husband,JLPT JLPT_N4
-雲,くも,cloud,JLPT JLPT_N4
-坂,さか,"slope, hill",JLPT JLPT_N4
-～(て) しまう,～(て) しまう,to end up ~,JLPT JLPT_N4
-飛行場,ひこうじょう,airport,JLPT JLPT_N4
-柔道,じゅうどう,judo,JLPT JLPT_N4
-決して,けっして,never,JLPT JLPT_N4
-事務所,じむしょ,office,JLPT JLPT_N4
-連絡,れんらく,"communication, contact, connection",JLPT JLPT_N4
-小学校,しょうがっこう,elementary school,Genki Genki_Ln.23 JLPT JLPT_N4
-客,きゃく,"guest, customer",Intermediate_Japanese_Ln.2 JLPT JLPT_N4
-昔,むかし,old days; past,Genki Genki_Ln.21 JLPT JLPT_N4
-美しい,うつくしい,"beautiful, lovely",JLPT JLPT_N4
-捨てる,すてる,"throw away (trash), dump, discard",Genki Genki_Ln.15 JLPT JLPT_N4
-なさる,なさる,-- honorific expression for する --,Genki Genki_Ln.19 JLPT JLPT_N4
-事,こと,"thing(s), matter(s), fact",Genki Genki_Ln.21 JLPT JLPT_N4
-どんどん,どんどん,quickly and steadily; at a rapid pace,JLPT JLPT_N4
-試合,しあい,"match, game, competition",Genki Genki_Ln.12 Intermediate_Japanese_Ln.7 JLPT JLPT_N4
-適当,てきとう,"fitness, suitability",JLPT JLPT_N4
-素晴らしい,すばらしい,wonderful; terrific,Intermediate_Japanese_Ln.4 JLPT JLPT_N4
-美術館,びじゅつかん,"art gallery, art museum",Genki Genki_Ln.11 JLPT JLPT_N4
-文法,ぶんぽう,grammar,Genki Genki_Ln.13 JLPT JLPT_N4
-終わり,おわり,end,JLPT JLPT_N4
-壁,かべ,wall,JLPT JLPT_N4
-一度,いちど,"once, one time",JLPT JLPT_N4
-お礼,おれい,expression of gratitude; thanking; gift of appreciation; bow,Genki Genki_Ln.19 Intermediate_Japanese_Ln.9 JLPT JLPT_N4
-親切,しんせつ,kindness,JLPT JLPT_N4
-知らせる,しらせる,to notify,JLPT JLPT_N4
-歯医者,はいしゃ,dentist,JLPT JLPT_N4
-熱心,ねっしん,enthusiasm,JLPT JLPT_N4
-始める,はじめる,"to start, to begin",Genki Genki_Ln.8 JLPT JLPT_N4
-もらう,もらう,to receive,JLPT JLPT_N4
-泣く,なく,to cry,Genki Genki_Ln.13 JLPT JLPT_N4
-治る,なおる,to get better; to recover from illness (v.i.),JLPT JLPT_N4
-熱,ねつ,"fever, temperature",Intermediate_Japanese_Ln.3 JLPT JLPT_N4
-お祭り,おまつり,festival,JLPT JLPT_N4
-水道,すいどう,"water service, water line",JLPT JLPT_N4
-匂い,におい,"odor, smell",JLPT JLPT_N4
-ベル,ベル,bell,JLPT JLPT_N4
-赤ん坊,あかんぼう,baby,JLPT JLPT_N4
-おかしい,おかしい,strange; odd; funny,Intermediate_Japanese_Ln.2 JLPT JLPT_N4
-事故,じこ,accident,JLPT JLPT_N4
-変,へん,"strange, odd",JLPT JLPT_N4
-辞典,じてん,"encyclopedia, reference book",JLPT JLPT_N4
-残る,のこる,"to remain (v.i.), to be left",JLPT JLPT_N4
-立てる,たてる,"to stand (something) up, to erect (something)",JLPT JLPT_N4
-くれる,くれる,"to give, to do for",JLPT JLPT_N4
-～員,～いん,member of ~,JLPT JLPT_N4
-原因,げんいん,"cause, origin, source",JLPT JLPT_N4
-驚く,おどろく,"to be surprised, to be astonished",Intermediate_Japanese_Ln.8 JLPT JLPT_N4
-いただく,頂く,-- extra-modest expression for たべる and のむ; humble expression for もらう --,Genki Genki_Ln.20 JLPT JLPT_N4
-祖母,そぼ,grandmother,JLPT JLPT_N4
-場所,ばしょ,"place, location",Genki Genki_Ln.23 Intermediate_Japanese_Ln.5 JLPT JLPT_N4
-答,こたえ,"answer, response",JLPT JLPT_N4
-もちろん,もちろん,"certainly, of course",Genki Genki_Ln.7 Intermediate_Japanese_Ln.5 JLPT JLPT_N4
-漬ける,つける,"to soak, to moisten, to pickle",JLPT JLPT_N4
-受付,うけつけ,reception(ist) desk,Genki Genki_Ln.22 Intermediate_Japanese_Ln.8 JLPT JLPT_N4
-内,うち,"within, inside",JLPT JLPT_N4
-スクリーン,スクリーン,screen,JLPT JLPT_N4
-増える,ふえる,"to increase, to multiply",JLPT JLPT_N4
-または,または,"or, otherwise",JLPT JLPT_N4
-けがする,けがする,"injury (to animate object), hurt",JLPT JLPT_N4
-以下,いか,"less than, below",JLPT JLPT_N4
-選ぶ,えらぶ,to choose; to select,Genki Genki_Ln.17 Intermediate_Japanese_Ln.3 JLPT JLPT_N4
-～ばかり,～ばかり,"just did ~, only",JLPT JLPT_N4
-心,こころ,"heart, mind",JLPT JLPT_N4
-～だす,～だす,to start doing ~,JLPT JLPT_N4
-サラダ,サラダ,salad,JLPT JLPT_N4
-届ける,とどける,to deliver (v.t.),Intermediate_Japanese_Ln.9 JLPT JLPT_N4
-挨拶,あいさつする,greet(ing),JLPT JLPT_N4
-景色,けしき,"scenery, landscape",JLPT JLPT_N4
-確か,たしか,"if I remember correctly; certain, definite",Intermediate_Japanese_Ln.4 JLPT JLPT_N4
-ステーキ,ステーキ,steak,JLPT JLPT_N4
-食料品,しょくりょうひん,"foodstuff, groceries",JLPT JLPT_N4
-森,もり,forest,JLPT JLPT_N4
-以内,いない,"within, less (no more) than",JLPT JLPT_N4
-予定,よてい,"plans, arrangement, schedule",Genki Genki_Ln.15 Intermediate_Japanese_Ln.15 JLPT JLPT_N4
-オーバー,オーバー,"overcoat; over, exceeding, exaggeration",JLPT JLPT_N4
-乾く,かわく,to get dry,JLPT JLPT_N4
-石,いし,stone,JLPT JLPT_N4
-思い出す,おもいだす,"to recall, to remember",Intermediate_Japanese_Ln.8 JLPT JLPT_N4
-踊る,おどる,to dance,Genki Genki_Ln.9 JLPT JLPT_N4
-細かい,こまかい,"small; fine, minute",JLPT JLPT_N4
-塗る,ぬる,"to paint, to plaster",JLPT JLPT_N4
-ご主人,ごしゅじん,"(your, her) husband",Genki Genki_Ln.14 JLPT JLPT_N4
-珍しい,めずらしい,"unusual, rare",Intermediate_Japanese_Ln.4 JLPT JLPT_N4
-用,よう,"errand, task, business (to take care of)",Intermediate_Japanese_Ln.9 JLPT JLPT_N4
-公務員,こうむいん,"government worker, public servant",JLPT JLPT_N4
-お嬢さん,おじょうさん,(someone's) daughter (polite),Genki Genki_Ln.22 JLPT JLPT_N4
-用意,ようい,preparation,JLPT JLPT_N4
-探す,さがす,"to search, to seek, to look for",Genki Genki_Ln.15 Intermediate_Japanese_Ln.8 JLPT JLPT_N4
-形,かたち,shape,JLPT JLPT_N4
-運転,うんてんする,driving,JLPT JLPT_N4
-すっかり,すっかり,"all, completely",JLPT JLPT_N4
-アナウンサー,アナウンサー,announcer,JLPT JLPT_N4
-お土産,おみやげ,souvenir,Genki Genki_Ln.4 JLPT JLPT_N4
-消しゴム,けしゴム,eraser,JLPT JLPT_N4
-旅館,りょかん,a Japanese inn,Genki Genki_Ln.15 Intermediate_Japanese_Ln.6 JLPT JLPT_N4
-海岸,かいがん,"coast, seashore",JLPT JLPT_N4
-寂しい,さびしい,"lonely, lonesome",Genki Genki_Ln.9 JLPT JLPT_N4
-火,ひ,fire,JLPT JLPT_N4
-育てる,そだてる,to raise (v.t.); to bring up,Genki Genki_Ln.22 JLPT JLPT_N4
-味噌,みそ,"miso, bean paste",JLPT JLPT_N4
-お祝い,おいわい,"congratulation, celebration",Intermediate_Japanese_Ln.7 JLPT JLPT_N4
-乗り物,のりもの,vehicle,JLPT JLPT_N4
-案内,あんないする,"information, guidance",JLPT JLPT_N4
-通う,かよう,to go back and forth; to commute,JLPT JLPT_N4
-連れる,つれる,"to lead, to take (a person)",JLPT JLPT_N4
-技術,ぎじゅつ,"technique, technology, skill",JLPT JLPT_N4
-小鳥,ことり,small bird,JLPT JLPT_N4
-下宿,げしゅく,"lodging, boarding house",JLPT JLPT_N4
-ジャム,ジャム,jam,JLPT JLPT_N4
-招待,しょうたいする,invitation,JLPT JLPT_N4
-鏡,かがみ,mirror,JLPT JLPT_N4
-はず,はず,it should be so,JLPT JLPT_N4
-法律,ほうりつ,law,JLPT JLPT_N4
-進む,すすむ,"to advance, to proceed",JLPT JLPT_N4
-楽む,たのしむ,to enjoy,JLPT JLPT_N4
-貿易,ぼうえき,trade,JLPT JLPT_N4
-反対,はんたい,"oppose, opposition, resistance",JLPT JLPT_N4
-おる,おる,-- extra-modest expression for いる --,Genki Genki_Ln.20 JLPT JLPT_N4
-申す,もうす,-- extra-modest (humble) expression for 言う (いう) --,Genki Genki_Ln.20 JLPT JLPT_N4
-試験,しけん,an exam,Genki Genki_Ln.9 JLPT JLPT_N4
-真面目,まじめ,"diligent, serious",JLPT JLPT_N4
-ごらんになる,,-- honorific expression for みる --,Genki Genki_Ln.19 JLPT JLPT_N4
-店員,てんいん,clerk; shop-employee,Intermediate_Japanese_Ln.6 JLPT JLPT_N4
-泊まる,とまる,to stay (over night) (v.i.),JLPT JLPT_N4
-よろしい,よろしい,"(hon.) good, OK, all right",JLPT JLPT_N4
-今夜,こんや,"this evening, tonight",JLPT JLPT_N4
-おつり,おつり,change; balance of money returned to the purchaser,JLPT JLPT_N4
-チェックする,チェックする,check,JLPT JLPT_N4
-会話,かいわ,conversation,JLPT JLPT_N4
-空気,くうき,"air, atmosphere",Genki Genki_Ln.8 JLPT JLPT_N4
-交通,こうつう,"traffic, transportation",JLPT JLPT_N4
-ワープロ,ワープロ,word processor,JLPT JLPT_N4
-喜ぶ,よろこぶ,"to rejoice, to be delighted, to be glad",JLPT JLPT_N4
-急行,きゅうこう,express train or bus,Intermediate_Japanese_Ln.7 JLPT JLPT_N4
-皆,みな,everyone,JLPT JLPT_N4
-味,あじ,"flavor, taste",JLPT JLPT_N4
-空港,くうこう,airport,Genki Genki_Ln.20 JLPT JLPT_N4
-手袋,てぶくろ,glove(s),Genki Genki_Ln.10 JLPT JLPT_N4
-校長,こうちょう,"principal, headmaster",JLPT JLPT_N4
-ごちそう,ごちそう,"feast, treating (someone)",JLPT JLPT_N4
-踊り,おどり,dance,JLPT JLPT_N4
-興味,きょうみ,interest (in something),JLPT JLPT_N4
-引っ越す,ひっこす,to move to a new place of residence,JLPT JLPT_N4
-冷房,れいぼう,"cooling, air conditioning",JLPT JLPT_N4
-都合,つごう,"circumstances, convenience",JLPT JLPT_N4
-遠慮,えんりょする,"restraint, reserve, hesitate",JLPT JLPT_N4
-亡くなる,なくなる,to pass away,JLPT JLPT_N4
-科学,かがく,science,Genki Genki_Ln.1 JLPT JLPT_N4
-はっきり,はっきり,"clearly, distinctly",JLPT JLPT_N4
-差し上げる,さしあげる,-- humble expression for あげる --,Genki Genki_Ln.20 JLPT JLPT_N4
-気持ち,きもち,"feeling, sensation, mood",JLPT JLPT_N4
-祖父,そふ,grandfather,JLPT JLPT_N4
-港,みなと,"harbor, port",JLPT JLPT_N4
-予約,よやく,reservation,Genki Genki_Ln.10 JLPT JLPT_N4
-凄い,すごい,"terrific, great",JLPT JLPT_N4
-入学,にゅうがくする,entry to school or university,JLPT JLPT_N4
-片付ける,かたづける,"to (clean) tidy up (v.t.), to put away",JLPT JLPT_N4
-写す,うつす,to copy (v.t.); to photograph,JLPT JLPT_N4
-パソコン,パソコン,(personal) computer,JLPT JLPT_N4
-部長,ぶちょう,department (division) manager,Genki Genki_Ln.19 Intermediate_Japanese_Ln.15 JLPT JLPT_N4
-火事,かじ,fire,JLPT JLPT_N4
-足す,たす,to add (numbers),JLPT JLPT_N4
-教会,きょうかい,church,Intermediate_Japanese_Ln.9 JLPT JLPT_N4
-彼ら,かれら,they (usually male),JLPT JLPT_N4
-一杯,いっぱい,"full, to the utmost",JLPT JLPT_N4
-アメリカ,アメリカ,"America, U.S.A.",Genki Genki_Ln.1 Genki_Ln.2 JLPT JLPT_N4
-男性,だんせい,man; male,JLPT JLPT_N4
-理由,りゆう,reason,JLPT JLPT_N4
-生産,せいさんする,production; to produce,JLPT JLPT_N4
-着物,きもの,kimono; Japanese traditional dress,Genki Genki_Ln.13 JLPT JLPT_N4
-おもちゃ,おもちゃ,a toy,Genki Genki_Ln.11 JLPT JLPT_N4
-暮れる,くれる,"to get dark, to come to an end",JLPT JLPT_N4
-釣る,つる,to fish,JLPT JLPT_N4
-～ちゃん,～ちゃん,suffix for familiar (female) person,JLPT JLPT_N4
-打つ,うつ,"to hit, to strike",JLPT JLPT_N4
-あんな,あんな,"such, like that",JLPT JLPT_N4
-謝る,あやまる,to apologize,JLPT JLPT_N4
-昼間,ひるま,"daytime, during the day",JLPT JLPT_N4
-教育,きょういく,education,JLPT JLPT_N4
-女性,じょせい,woman,JLPT JLPT_N4
-米,こめ,uncooked rice,JLPT JLPT_N4
-邪魔,じゃま,"hindrance, intrusion",JLPT JLPT_N4
-国際,こくさい,international,JLPT JLPT_N4
-隅,すみ,corner,JLPT JLPT_N4
-伺う,うかがう,"humble form of 行く (いく), 聞く (きく) and 来る (くる)",JLPT JLPT_N4
-再来週,さらいしゅう,the week after next,JLPT JLPT_N4
-夢,ゆめ,a dream,Genki Genki_Ln.11 JLPT JLPT_N4
-喉,のど,throat,JLPT JLPT_N4
-最近,さいきん,"recently, nowadays, in recent years, most recent, latest",Genki Genki_Ln.15 Intermediate_Japanese_Ln.9 JLPT JLPT_N4
-周り,まわり,surroundings,JLPT JLPT_N4
-歴史,れきし,history,Genki Genki_Ln.1 Genki_Ln.2 Intermediate_Japanese_Ln.3 JLPT JLPT_N4
-不便,ふべん,inconvenience,JLPT JLPT_N4
-血,ち,blood,JLPT JLPT_N4
-～続ける,～つづける,to continue doing ~,JLPT JLPT_N4
-毛,け,"hair, fur",JLPT JLPT_N4
-ひどい,ひどい,"terrible, awful, unfair, cruel",Genki Genki_Ln.21 Intermediate_Japanese_Ln.4 JLPT JLPT_N4
-例えば,たとえば,"for example, e.g.",Genki Genki_Ln.17 Intermediate_Japanese_Ln.2 JLPT JLPT_N4
-中々,なかなか,"very, considerably, quite",JLPT JLPT_N4
-随分,ずいぶん,extremely,JLPT JLPT_N4
-～やすい,～やすい,easy to do ~,JLPT JLPT_N4
-押し入れ,おしいれ,closet,JLPT JLPT_N4
-電灯,でんとう,electric light,JLPT JLPT_N4
-叱る,しかる,to scold,JLPT JLPT_N4
-サンダル,サンダル,sandal,JLPT JLPT_N4
-びっくりする,びっくりする,to be surprised,Genki Genki_Ln.21 JLPT JLPT_N4
-うまい,うまい,delicious; skillful; fortunate,JLPT JLPT_N4
-変える,かえる,"to change, to alter, to vary",JLPT JLPT_N4
-講堂,こうどう,auditorium,JLPT JLPT_N4
-子,こ,child,JLPT JLPT_N4
-沸かす,わかす,to boil,JLPT JLPT_N4
-レジ,レジ,register,JLPT JLPT_N4
-しばらく,しばらく,little while,JLPT JLPT_N4
-特に,とくに,particularly,Intermediate_Japanese_Ln.3 JLPT JLPT_N4
-空く,あく,"to open, to become empty (vacant)",JLPT JLPT_N4
-計画,けいかくする,"plan, project, schedule",JLPT JLPT_N4
-通り,とおり,"~ Street, ~ Avenue",JLPT JLPT_N4
-下着,したぎ,underwear,JLPT JLPT_N4
-経済,けいざい,"economics, finance, economy",JLPT JLPT_N4
-こう,こう,"like this, this way",JLPT JLPT_N4
-是非,ぜひ,"certainly, by all means; without fail",Genki Genki_Ln.9 Intermediate_Japanese_Ln.15 Intermediate_Japanese_Ln.8 JLPT JLPT_N4
-裏,うら,"reverse side, back",JLPT JLPT_N4
-為,ため,"good, advantage, in order to",JLPT JLPT_N4
-おいでになる,おいでになる,(hon.) to be,JLPT JLPT_N4
-変わる,かわる,"to change (v.i.), to be transformed, to vary",Intermediate_Japanese_Ln.4 JLPT JLPT_N4
-以外,いがい,"other than, with the exception of, excepting",Intermediate_Japanese_Ln.3 JLPT JLPT_N4
-済む,すむ,"to finish, to end",JLPT JLPT_N4
-ハンバーグ,ハンバーグ,hamburger steak,JLPT JLPT_N4
-市,し,city,JLPT JLPT_N4
-引き出し,ひきだし,drawer,JLPT JLPT_N4
-遊び,あそび,play,JLPT JLPT_N4
-支度,したくする,preparation,JLPT JLPT_N4
-～始める,～はじめる,to start doing ~,JLPT JLPT_N4
-見える,みえる,to be visible; -- polite verb meaning 来る (くる) --,Genki Genki_Ln.15 JLPT JLPT_N4
-十分,じゅうぶん,enough,JLPT JLPT_N4
-音,おと,"sound, note",Genki Genki_Ln.20 JLPT JLPT_N4
-きっと,きっと,"surely, definitely, undoubtedly, certainly",Intermediate_Japanese_Ln.7 JLPT JLPT_N4
-まず,まず,"first (of all), to start with",Genki Genki_Ln.18 JLPT JLPT_N4
-遠く,とおく,"far away, distant",JLPT JLPT_N4
-大体,だいたい,approximately; in most cases; in general; to begin with (same as もともと),Intermediate_Japanese_Ln.15 Intermediate_Japanese_Ln.3 JLPT JLPT_N4
-折れる,おれる,"to break, to be folded, to give in; to turn (a corner)",JLPT JLPT_N4
-正しい,ただしい,correct,JLPT JLPT_N4
-輸入,ゆにゅう,import,JLPT JLPT_N4
-返事,へんじ,"reply, answer",JLPT JLPT_N4
-都,と,metropolitan,JLPT JLPT_N4
-産業,さんぎょう,industry,JLPT JLPT_N4
-伝える,つたえる,"to convey (a message); to tell, to report",Genki Genki_Ln.20 Intermediate_Japanese_Ln.15 JLPT JLPT_N4
-お金持ち,かねもち; おかねもち,rich person,JLPT JLPT_N4
-説明,せつめい,explanation,JLPT JLPT_N4
-島,しま,island,Intermediate_Japanese_Ln.5 JLPT JLPT_N4
-道具,どうぐ,tool,JLPT JLPT_N4
-滑る,すべる,"to slide, to slip",JLPT JLPT_N4
-それほど,それほど,to that degree; extent,JLPT JLPT_N4
-以上,いじょう,more than; this is all,JLPT JLPT_N4
-～まま,～まま,as it is,JLPT JLPT_N4
-特急,とっきゅう,limited express (train faster than an express),JLPT JLPT_N4
-プレゼント,プレゼント,"present, gift",Genki Genki_Ln.12 JLPT JLPT_N4
-～(に) よると,～(に) よると,according to ~,JLPT JLPT_N4
-妻,つま,wife (humble),JLPT JLPT_N4
-帰り,かえり,"return, coming back",JLPT JLPT_N4
-具合,ぐあい,"condition, state, health",JLPT JLPT_N4
-堅; 硬; 固い,かたい,"solid, hard, firm",JLPT JLPT_N4
-駐車場,ちゅうしゃじょう,parking lot,JLPT JLPT_N4
-スーツ,スーツ,suit,JLPT JLPT_N4
-危険,きけん,"danger, risk, hazard",Intermediate_Japanese_Ln.15 JLPT JLPT_N4
-髪,かみ,hair,Genki Genki_Ln.7 JLPT JLPT_N4
-天気予報,てんきよほう,weather forecast,Genki Genki_Ln.8 JLPT JLPT_N4
-彼女,かのじょ,girlfriend; she,Genki Genki_Ln.12 JLPT JLPT_N4
-間,あいだ,"space, interval",JLPT JLPT_N4
-卒業,そつぎょう,graduation,JLPT JLPT_N4
-それで,それで,"and (conj.), thereupon, because of that",JLPT JLPT_N4
-枝,えだ,"branch, twig",JLPT JLPT_N4
-専門,せんもん,major; speciality,Genki Genki_Ln.1 JLPT JLPT_N4
-そろそろ,そろそろ,"gradually, soon",JLPT JLPT_N4
-送る,おくる,"to send, to dispatch",Genki Genki_Ln.14 Intermediate_Japanese_Ln.3 JLPT JLPT_N4
-あげる,あげる,to give,JLPT JLPT_N4
-騒ぐ,さわぐ,"to make noise, to clamor",JLPT JLPT_N4
-尋ねる,たずねる,to inquire (same as 質問する),JLPT JLPT_N4
-放送,ほうそうする,broadcasting,JLPT JLPT_N4
-政治,せいじ,politics,Genki Genki_Ln.1 Genki_Ln.12 Intermediate_Japanese_Ln.3 JLPT JLPT_N4
-市民,しみん,citizen,JLPT JLPT_N4
-ファックス,ファックス,fax,JLPT JLPT_N4
-負ける,まける,"to lose (a game) (v.i.), to be defeated",Intermediate_Japanese_Ln.7 JLPT JLPT_N4
-指輪,ゆびわ,(finger) ring,Genki Genki_Ln.14 JLPT JLPT_N4
-田舎,いなか,"rural, countryside",JLPT JLPT_N4
-見つける,みつける,"to discover, to find (v.t.)",Genki Genki_Ln.21 JLPT JLPT_N4
-高校生,こうこうせい,high school student,Genki Genki_Ln.1 JLPT JLPT_N4
-講義,こうぎ,a lecture,Intermediate_Japanese_Ln.5 JLPT JLPT_N4
-そんなに,そんなに,"so much, like that",JLPT JLPT_N4
-昼休み,ひるやすみ,"lunch break, noon recess",JLPT JLPT_N4
-忘れ物,わすれもの,"lost article, something forgotten",JLPT JLPT_N4
-下りる,おりる,"to get down, to go; come down",JLPT JLPT_N4
-腕,うで,arm (in reference to body),Intermediate_Japanese_Ln.7 JLPT JLPT_N4
-訳,わけ,reason; explanation,JLPT JLPT_N4
-承知,しょうちする,"consent, acceptance",JLPT JLPT_N4
-日記,にっき,"diary, journal",Genki Genki_Ln.18 JLPT JLPT_N4
-高校; 高等学校,こうこう; こうとうがっこう,high school; senior high school,JLPT JLPT_N4
-似る,にる,"to resemble, to be similar",JLPT JLPT_N4
-～おわる,～おわる,to finish doing ~,JLPT JLPT_N4
-暖房,だんぼう,heating,JLPT JLPT_N4
-留守,るす,absence; not at home,Genki Genki_Ln.21 JLPT JLPT_N4
-割合,わりあい,"rate, ratio, percentage",JLPT JLPT_N4
-寺,てら,Buddhist temple,JLPT JLPT_N4
-慣れる,なれる,to grow accustomed to,JLPT JLPT_N4
-普通,ふつう,common; usual,Intermediate_Japanese_Ln.2 Intermediate_Japanese_Ln.3 JLPT JLPT_N4
-手伝う,てつだう,to help,JLPT JLPT_N4
-なるほど,なるほど,I see; I now understand,Intermediate_Japanese_Ln.6 JLPT JLPT_N4
-くださる,くださる,"(hon.) to give, to confer",JLPT JLPT_N4
-息子,むすこ,(humble) son,JLPT JLPT_N4
-お子さん,おこさん,(someone else's) child (polite),Genki Genki_Ln.19 JLPT JLPT_N4
-会場,かいじょう,"venue, meeting place",JLPT JLPT_N4
-笑う,わらう,"to laugh, to smile",JLPT JLPT_N4
-運ぶ,はこぶ,"to transport, to carry",Genki Genki_Ln.22 Intermediate_Japanese_Ln.6 JLPT JLPT_N4
-文学,ぶんがく,literature,Genki Genki_Ln.1 Intermediate_Japanese_Ln.3 JLPT JLPT_N4
-光,ひかり,light,JLPT JLPT_N4
-お見舞い,おみまい,"calling on someone who is ill, visit",JLPT JLPT_N4
-席,せき,a seat,Intermediate_Japanese_Ln.7 JLPT JLPT_N4
-～様,～さま,"Mr., Mrs., Ms.",JLPT JLPT_N4
-ご存じ,ごぞんじ,"knowing, acquaintance",JLPT JLPT_N4
-下る,さがる,"to descend, to drop, to fall",JLPT JLPT_N4
-字,じ,letter; character,Genki Genki_Ln.20 JLPT JLPT_N4
-アジア,アジア,Asia,JLPT JLPT_N4
-褒める,ほめる,to praise; to say nice things,Genki Genki_Ln.21 JLPT JLPT_N4
-空く,すく,"to be empty (in reference to people), to be less crowded",JLPT JLPT_N4
-あ,あ,Ah,JLPT JLPT_N4
-最も,もっとも,most,JLPT JLPT_N4
-合う,あう,"to fit, to match",JLPT JLPT_N4
-～代,～だい,~ age; period,JLPT JLPT_N4
-最後,さいご,"last, end",JLPT JLPT_N4
-値段,ねだん,price,JLPT JLPT_N4
-退院,たいいんする,leaving hospital,JLPT JLPT_N4
-展覧会,てんらんかい,exhibition,JLPT JLPT_N4
-久しぶり,ひさしぶり,it has been a long time; for the first time in a long time,Genki Genki_Ln.11 Intermediate_Japanese_Ln.4 JLPT JLPT_N4
-カーテン,カーテン,curtain,Genki Genki_Ln.18 JLPT JLPT_N4
-汽車,きしゃ,train (steam),JLPT JLPT_N4
-遅れる,おくれる,to (be) become late,Genki Genki_Ln.19 Intermediate_Japanese_Ln.2 JLPT JLPT_N4
-見つかる,みつかる,"to be found (v.i.), to be discovered",JLPT JLPT_N4
-召し上がる,めしあがる,-- honorific form of 食べる (たべる) and 飲む (のむ) --,Genki Genki_Ln.19 Intermediate_Japanese_Ln.6 JLPT JLPT_N4
-太る,ふとる,to gain weight,Genki Genki_Ln.7 JLPT JLPT_N4
-注射,ちゅうしゃ,injection,JLPT JLPT_N4
-様,よう,"way, manner, kind",JLPT JLPT_N4
-～おき,～おき,after every ~,JLPT JLPT_N4
-最初,さいしょ,"beginning, first",JLPT JLPT_N4
-御～,ご～,honorable ~,JLPT JLPT_N4
-安心,あんしん,"peace of mind, relief",JLPT JLPT_N4
-直る,なおる,to be fixed,JLPT JLPT_N4
-集める,あつめる,"to collect, to gather (v.t.), to assemble",Genki Genki_Ln.16 Intermediate_Japanese_Ln.7 JLPT JLPT_N4
-直す,なおす,to correct (v.t.); to fix,Genki Genki_Ln.16 JLPT JLPT_N4
-続く,つづく,to be continued,JLPT JLPT_N4
-先輩,せんぱい,senior members of a group,Genki Genki_Ln.22 JLPT JLPT_N4
-約束,やくそく,"arrangement, appointment, promise",Genki Genki_Ln.13 JLPT JLPT_N4
-世話,せわする,looking after; to look after,JLPT JLPT_N4
-近所,きんじょ,neighborhood,JLPT JLPT_N4
-将来,しょうらい,(in the) future; prospects,Genki Genki_Ln.11 Intermediate_Japanese_Ln.5 JLPT JLPT_N4
-億,おく,hundred million,JLPT JLPT_N4
-数学,すうがく,mathematics,JLPT JLPT_N4
-文化,ぶんか,culture,Genki Genki_Ln.19 JLPT JLPT_N4
-払う,はらう,to pay,Genki Genki_Ln.10 Intermediate_Japanese_Ln.3 JLPT JLPT_N4
-習慣,しゅうかん,custom (in reference to culture),JLPT JLPT_N4
-焼ける,やける,"to burn, to be roasted",JLPT JLPT_N4
-君,きみ,you (informal for men),JLPT JLPT_N4
-冷える,ひえる,"to grow cold, to cool down",JLPT JLPT_N4
-点く,つく,"to be started, to be switched on",JLPT JLPT_N4
-この間,このあいだ,"the other day, recently",Genki Genki_Ln.16 JLPT JLPT_N4
-格好,かっこう,"appearance, manner, shape, form, posture",JLPT JLPT_N4
-かまう,,"to mind, to care about, to be concerned about",JLPT JLPT_N4
-続ける,つづける,"to continue, to keep up",Genki Genki_Ln.21 JLPT JLPT_N4
-落す,おとす,"to drop, to lose",JLPT JLPT_N4
-明日,あす,tomorrow,JLPT JLPT_N4
-出発,しゅっぱつする,departure,JLPT JLPT_N4
-拝見,はいけんする,"(humble) (polite) seeing, look at",JLPT JLPT_N4
-割れる,われる,to break,JLPT JLPT_N4
-背中,せなか,back (of body),JLPT JLPT_N4
-新聞社,しんぶんしゃ,newspaper company,JLPT JLPT_N4
-いじめる,いじめる,"to bully, to torment",Genki Genki_Ln.21 JLPT JLPT_N4
-回る、回す,まわる、まわす,"to go around, to revolve",JLPT JLPT_N4
-～君,～くん,"Mr. (junior) ~, master ~",JLPT JLPT_N4
-おっしゃる,おっしゃる,-- honorific expression for いう --,Genki Genki_Ln.19 JLPT JLPT_N4
-眠い,ねむい,"sleepy, drowsy",Genki Genki_Ln.10 JLPT JLPT_N4
-濡れる,ぬれる,to get wet,JLPT JLPT_N4
-倒れる,たおれる,"to collapse, to break down",JLPT JLPT_N4
-スーパー (マーケット),スーパー (マーケット),supermarket,JLPT JLPT_N4
-アクセサリー,アクセサリー,accessory,JLPT JLPT_N4
-考える,かんがえる,to think (about); to consider,Genki Genki_Ln.18 JLPT JLPT_N4
-向かう,むかう,"to face, to go towards",JLPT JLPT_N4
-自由,じゆう,freedom,Genki Genki_Ln.22 JLPT JLPT_N4
-仕方,しかた,way (of doing something),JLPT JLPT_N4
-首,くび,neck,JLPT JLPT_N4
-程,ほど,"degree, extent",JLPT JLPT_N4
-代わり,かわり,"substitute, replacement",JLPT JLPT_N4
-失敗,しっぱい,"failure, mistake",JLPT JLPT_N4
-工業,こうぎょう,(manufacturing) industry,JLPT JLPT_N4
-移る,うつる,to move (from a house); to transfer (from a department); to shift,JLPT JLPT_N4
-スーツケース,スーツケース,suitcase,JLPT JLPT_N4
-ひげ,ひげ,beard,Genki Genki_Ln.17 JLPT JLPT_N4
-研究室,けんきゅうしつ,the professor's office; laboratory,Intermediate_Japanese_Ln.3 JLPT JLPT_N4
-工場,こうじょう,factory,Genki Genki_Ln.21 Intermediate_Japanese_Ln.15 JLPT JLPT_N4
-紹介,しょうかい,an introduction,JLPT JLPT_N4
-けれど; けれども,けれど; けれども,"but, although",JLPT JLPT_N4
-舟,ふね,"ship, boat",JLPT JLPT_N4
-動く,うごく,to move,JLPT JLPT_N4
-～(に) ついて,～(に) ついて,"about, concerning",JLPT JLPT_N4
-コンサート,コンサート,concert,Genki Genki_Ln.9 JLPT JLPT_N4
-虫,むし,insect,JLPT JLPT_N4
-優しい,やさしい,"kind (person), gentle (person), easy (problem)",Genki Genki_Ln.5 JLPT JLPT_N4
-コンピュータ; コンピューター,コンピュータ; コンピューター,computer,JLPT JLPT_N4
-植える,うえる,to plant,JLPT JLPT_N4
-両方,りょうほう,"both sides, both parties",JLPT JLPT_N4
-汚れる,よごれる,to become dirty,JLPT JLPT_N4
-水泳,すいえい,swimming,JLPT JLPT_N4
-経験,けいけんする,experience,JLPT JLPT_N4
-勝つ,かつ,to win,JLPT JLPT_N4
-砂,すな,sand,JLPT JLPT_N4
-警察,けいさつ,police; police station,Genki Genki_Ln.21 JLPT JLPT_N4
-取り替える,とりかえる,"to exchange, to replace",JLPT JLPT_N4
-急ぐ,いそぐ,"to hurry, to be in a hurry, to rush",Genki Genki_Ln.6 Intermediate_Japanese_Ln.2 JLPT JLPT_N4
-簡単,かんたん,simple,JLPT JLPT_N4
-参る,まいる,humble expression for 行く and 来る,Genki Genki_Ln.20 Intermediate_Japanese_Ln.6 JLPT JLPT_N4
-全然,ぜんぜん,"not at all; wholly, entirely",JLPT JLPT_N4
-特別,とくべつ,special,JLPT JLPT_N4
-復習,ふくしゅう,"review (of lessons), revision",JLPT JLPT_N4
-間に合う,まにあう,to be in time for,JLPT JLPT_N4
-役に立つ,やくにたつ,"to be helpful, to be useful",Intermediate_Japanese_Ln.4 JLPT JLPT_N4
-もうすぐ,もうすぐ,very soon; in a few moments; days,Genki Genki_Ln.12 JLPT JLPT_N4
-真中,まんなか,"middle, center",JLPT JLPT_N4
-戻る,もどる,to return (v.i.); to come back,Genki Genki_Ln.20 Intermediate_Japanese_Ln.8 JLPT JLPT_N4
-研究,けんきゅう,"study, research, investigation",JLPT JLPT_N4
-ケーキ,ケーキ,cake,Genki Genki_Ln.13 JLPT JLPT_N4
-草,くさ,grass,JLPT JLPT_N4
-込む,こむ,to be crowded,JLPT JLPT_N4
-この頃,このごろ,"these days, nowadays",Genki Genki_Ln.10 JLPT JLPT_N4
-訪ねる,たずねる,to visit,JLPT JLPT_N4
-下げる,さげる,to lower (v.t.); to hang,Intermediate_Japanese_Ln.2 JLPT JLPT_N4
-花見,はなみ,cherry-blossom viewing,JLPT JLPT_N4
-途中,とちゅう,"on the way, midway",JLPT JLPT_N4
-入院,にゅういんする,hospitalization,JLPT JLPT_N4
-乗り換える,のりかえる,"to transfer (trains), to change (bus, train, etc.)",JLPT JLPT_N4
-別れる,わかれる,"to part from, to separate",JLPT JLPT_N4
-～町,～ちょう,the town of ~,JLPT JLPT_N4
-安全,あんぜん,"safety, security",JLPT JLPT_N4
-看護婦,かんごふ,(female) nurse,JLPT JLPT_N4
-見物,けんぶつ,sightseeing,JLPT JLPT_N4
-相談,そうだんする,consultation,JLPT JLPT_N4
-ガソリンスタンド,ガソリンスタンド,"gas station, service station",JLPT JLPT_N4
-テニス,テニス,tennis,Genki Genki_Ln.3 JLPT JLPT_N4
-眠る,ねむる,to sleep,JLPT JLPT_N4
-上がる,あがる,"to rise, to go up",JLPT JLPT_N4
-翻訳,ほんやく,translation,Intermediate_Japanese_Ln.8 JLPT JLPT_N4
-食事,しょくじする,meal,JLPT JLPT_N4
-お陰,おかげ,thanks or owing to,JLPT JLPT_N4
-娘,むすめ,daughter (humble),JLPT JLPT_N4
-湯,ゆ,hot water,JLPT JLPT_N4
-競争,きょうそう,"competition, contest",JLPT JLPT_N4
-会議,かいぎ,business meeting; conference,Genki Genki_Ln.21 JLPT JLPT_N4
-湖,みずうみ,lake,Genki Genki_Ln.11 Intermediate_Japanese_Ln.4 JLPT JLPT_N4
-集まる,あつまる,"to gather (v.i.), to collect",Intermediate_Japanese_Ln.7 JLPT JLPT_N4
-～にくい,～にくい,difficult to do ~,JLPT JLPT_N4
-生活,せいかつする,"living, life; to live",JLPT JLPT_N4
-糸,いと,thread,JLPT JLPT_N4
-関係,かんけい,"relation(ship), connection",JLPT JLPT_N4
-ピアノ,ピアノ,piano,Genki Genki_Ln.9 JLPT JLPT_N4
-～目,～め,"number ~ sequence, ~nd; ~th",JLPT JLPT_N4
-番組,ばんぐみ,broadcast program,Genki Genki_Ln.15 JLPT JLPT_N4
-急,きゅう,"urgent, sudden; steep",JLPT JLPT_N4
-棚,たな,"shelves, rack",JLPT JLPT_N4
-木綿,もめん,cotton,JLPT JLPT_N4
-輸出,ゆしゅつする,export,JLPT JLPT_N4
-タイプ,タイプ,"type, style",JLPT JLPT_N4
-すり,すり,pickpocket,JLPT JLPT_N4
-嬉しい,うれしい,to be happy; to be glad,Genki Genki_Ln.13 JLPT JLPT_N4
-アルコール,アルコール,alcohol,JLPT JLPT_N4
-ソフト,ソフト,soft; soft hat; software,JLPT JLPT_N4
-神社,じんじゃ,Shinto shrine,JLPT JLPT_N4
-大分,だいぶ,"fairly well, to a large extent, considerably, pretty much",Intermediate_Japanese_Ln.4 JLPT JLPT_N4
-楽しみ,たのしみ,"pleasure, joy",JLPT JLPT_N4
-趣味,しゅみ,hobby; pastime,Genki Genki_Ln.20 JLPT JLPT_N4
-電報,でんぽう,telegram,JLPT JLPT_N4
-家内,かない,(one's own) wife,Intermediate_Japanese_Ln.7 JLPT JLPT_N4
-指,ゆび,finger,JLPT JLPT_N4
-これから,これから,"from now on, after this",JLPT JLPT_N4
-たまに,たまに,occasionally,JLPT JLPT_N4
-社会,しゃかい,society,JLPT JLPT_N4
+expression,reading,meaning,tags,guid
+踏む,ふむ,"to step on, to tread on",JLPT JLPT_N4,MD)?c2/f%j
+～区,～く,"~ district, ~ ward, ~ borough",JLPT JLPT_N4,jyNlO!<_rh
+すっと,すっと,"straight, quickly",JLPT JLPT_N4,k|7>>bJ_;p
+盗む,ぬすむ,to steal; to rob,Genki Genki_Ln.21 JLPT JLPT_N4,yRRr.o{S!G
+大抵,たいてい,"generally, usually",Genki Genki_Ln.3 JLPT JLPT_N4,F4RWhn9KV7
+とうとう,とうとう,"finally, at last",JLPT JLPT_N4,b~a!BAlss]
+ガソリン,ガソリン,"gasoline, petrol",Genki Genki_Ln.21 JLPT JLPT_N4,DtjnF2f-}S
+鳴る,なる,"to sound, to ring (v.i.)",Intermediate_Japanese_Ln.2 JLPT JLPT_N4,N2XM.u#*9T
+しっかり,しっかり,"firmly, steady",JLPT JLPT_N4,s1@<ogH]|l
+生きる,いきる,to live,JLPT JLPT_N4,PsYPR<^eS}
+苦い,にがい,bitter,JLPT JLPT_N4,s7onh_qmu>
+沸く,わく,"to boil, to grow hot",JLPT JLPT_N4,PG:x_[8:n{
+意見,いけん,"opinion, view, idea",JLPT JLPT_N4,rm|oi`$1Dg
+やはり; やっぱり,やはり; やっぱり,"as I thought, absolutely",JLPT JLPT_N4,uKv@@b~bnv
+漫画,まんが,"comic (book), cartoon",Genki Genki_Ln.14 JLPT JLPT_N4,l|R^YmR+|c
+ステレオ,ステレオ,stereo,JLPT JLPT_N4,j)<hxBenH^
+医学,いがく,medical science,JLPT JLPT_N4,j>$AcgpmMe
+テキスト,テキスト,text; text book,JLPT JLPT_N4,tNueVeWq/i
+～月,～つき,month,JLPT JLPT_N4,fmd>SOFFek
+折る,おる,"to snap, to break; to bend",JLPT JLPT_N4,yVVu7>5}8_
+～会,～かい,~ meeting,JLPT JLPT_N4,q`5&BgJq(Y
+うかがう,うかがう,to ask,JLPT JLPT_N4,i(<6VU5W9O
+聞こえる,きこえる,"to be heard, to be audible",JLPT JLPT_N4,quf~I<>p>
+僕,ぼく,I (used by men towards those of equal or lower status),Genki Genki_Ln.5 JLPT JLPT_N4,sZrMWgN[D[
+必ず,かならず,"surely, certainly",Intermediate_Japanese_Ln.8 JLPT JLPT_N4,t=>{J>bIy^
+壊す,こわす,"to break, to break down",JLPT JLPT_N4,d^9}5OH`;*
+怒る,おこる,to get angry; to scold angrily,Genki Genki_Ln.19 JLPT JLPT_N4,Ib^RmCfT#f
+床屋,とこや,barber's (shop),Genki Genki_Ln.10 Intermediate_Japanese_Ln.6 JLPT JLPT_N4,t^jDr`iefA
+オートバイ,オートバイ,motorcycle (lit: auto-bi(ke)),JLPT JLPT_N4,Pt[L]fX^FJ
+運動,うんどうする,exercise,JLPT JLPT_N4,=pK+M[-/J
+止む,やむ,"to cease, to stop",JLPT JLPT_N4,i[hf?*~a)V
+もし,もし,if,JLPT JLPT_N4,oLI2n{GVOs
+表,おもて,surface; front; outside,JLPT JLPT_N4,qP[jTS0$-o
+大学生,だいがくせい,"college student, university student",Genki Genki_Ln.1 Genki_Ln.8 JLPT JLPT_N4,cCEA>;7p%n
+運転手,うんてんしゅ,driver (by occupation),Intermediate_Japanese_Ln.6 JLPT JLPT_N4,c=1Zd>L>/{
+予習,よしゅう,preparation of lessons (for class),Genki Genki_Ln.22 Intermediate_Japanese_Ln.5 JLPT JLPT_N4,A$348:bL<R
+心配,しんぱいする,"worry, concern",JLPT JLPT_N4,reB^;ntMm;
+別,べつ,"distinction, different",JLPT JLPT_N4,pvVM*k}K*D
+非常に,ひじょうに,extremely; very,Intermediate_Japanese_Ln.2 JLPT JLPT_N4,Ih.~ep.W8C
+お宅,おたく,(someone else's) house; home -- polite word for 家 (いえ) --,Genki Genki_Ln.13 Intermediate_Japanese_Ln.7 JLPT JLPT_N4,"G:h,g@5k[b"
+柔らかい,やわらかい,"soft (in reference to texture), tender",JLPT JLPT_N4,Mb;<89jf/c
+拾う,ひろう,"to pick up (something), to find",Genki Genki_Ln.22 JLPT JLPT_N4,A7mxJIkuGg
+～ございます,～ございます,"to be (polite), to exist",JLPT JLPT_N4,kMO?quX[B$
+気,き,"spirit, mood",JLPT JLPT_N4,N`FU2bb#2c
+比べる,くらべる,to compare,JLPT JLPT_N4,OXHWkwV:?8
+ほとんど,ほとんど,"mostly, almost",Intermediate_Japanese_Ln.7 JLPT JLPT_N4,nQ>_aG@b-U
+つもり,つもり,"intention, plan",JLPT JLPT_N4,fOH84**JB]
+郊外,こうがい,"suburb, outskirts",JLPT JLPT_N4,m[#TphS~Yp
+だめ,だめ,"useless, no good, hopeless",JLPT JLPT_N4,F`}=@;2gGr
+売り場,うりば,place where things are sold,JLPT JLPT_N4,g8Zs2)0MYs
+正月,しょうがつ,"New Year, New Year's Day",JLPT JLPT_N4,z?cV&4IRT$
+規則,きそく,"rule, regulation",JLPT JLPT_N4,"fX,<9qoCbI"
+うん,うん,"yes (informal), all right (ok)",Genki Genki_Ln.8 JLPT JLPT_N4,AU=4aGU<;g
+発音,はつおん,pronunciation,JLPT JLPT_N4,ij2OK3T1KH
+焼く,やく,"to bake, to grill",Genki Genki_Ln.21 JLPT JLPT_N4,ze5y7QDk;*
+屋上,おくじょう,rooftop,JLPT JLPT_N4,dNyWHH2le2
+失礼,しつれい,"discourtesy, impoliteness; Excuse me",JLPT JLPT_N4,i}rJ2aUEQY
+ごみ,ごみ,"trash, garbage",Genki Genki_Ln.16 JLPT JLPT_N4,l0zGWz;u*B
+アフリカ,アフリカ,Africa,JLPT JLPT_N4,s(eSC66i0(
+点,てん,"mark, score, grade; point, dot",Intermediate_Japanese_Ln.5 JLPT JLPT_N4,xl]z9.M3ii
+一生懸命,いっしょうけんめい,"very hard (as in ""to work hard""), with utmost effort",Intermediate_Japanese_Ln.5 JLPT JLPT_N4,x}#WG:x<B%
+今度,こんど,"now, this time, near future, one of these days, next time",Genki Genki_Ln.9 JLPT JLPT_N4,"c3M,%sgpuH"
+機会,きかい,"chance, opportunity",JLPT JLPT_N4,QN(r}6a#1P
+建てる,たてる,to build,JLPT JLPT_N4,p>?r}3Zl{s
+複雑,ふくざつ,"complexity, complication",JLPT JLPT_N4,CH}=lqHM1.
+彼,かれ,"he, boyfriend",Genki Genki_Ln.12 Intermediate_Japanese_Ln.8 JLPT JLPT_N4,t}ZPEKulM{
+いらっしゃる,いらっしゃる,"-- honorific expression for いく, くる, and いる --",Genki Genki_Ln.19 JLPT JLPT_N4,q4xt(yor`^
+布団,ふとん,futon,JLPT JLPT_N4,o9cl6;pq_D
+大事,だいじ,"important, valuable, serious matter",JLPT JLPT_N4,K-;(kx?ed|
+贈り物,おくりもの,a gift; a present,Intermediate_Japanese_Ln.9 JLPT JLPT_N4,ea]7XukKd^
+泥棒,どろぼう,thief; burglar,Genki Genki_Ln.21 JLPT JLPT_N4,q/[sonb>SP
+～製,～せい,made in ~,JLPT JLPT_N4,I|]_Gf;YLD
+注意,ちゅうい,"caution, attention",JLPT JLPT_N4,tSqn:MggQx
+台風,たいふう,typhoon,Genki Genki_Ln.16 JLPT JLPT_N4,uFiu<};|%T
+日,ひ,"sun, sunshine, day",Genki Genki_Ln.16 JLPT JLPT_N4,Ap$ELNr5>B
+～軒,～けん,counter for houses,JLPT JLPT_N4,"KbFf,NH{5y"
+そう,そう,"really, (is that) so; yes, right",JLPT JLPT_N4,wr0#d-auwR
+通る,とおる,"to pass (by), to go through",JLPT JLPT_N4,z?tZP}u#Ea
+過ぎる,すぎる,"to exceed, to go beyond",JLPT JLPT_N4,O_}jg<!z1-
+レポート; リポート,レポート; リポート,report,JLPT JLPT_N4,xai}>:G-4a
+葉,は,leaf,JLPT JLPT_N4,xQbxW<V1k4
+必要,ひつよう,necessary,JLPT JLPT_N4,ty_M]/QA_N
+課長,かちょう,section manager,Intermediate_Japanese_Ln.7 JLPT JLPT_N4,Q;5M-:Rtr;
+地震,じしん,earthquake,Genki Genki_Ln.15 JLPT JLPT_N4,DGTtnnC4Nd
+すると,すると,"and, then",JLPT JLPT_N4,Fz>2(<Q3D%
+止める,やめる,"to end, to stop",JLPT JLPT_N4,w08D;C[*x`
+ガラス,ガラス,"glass, pane",JLPT JLPT_N4,Wl!XdU*F<
+～学部,～がくぶ,department of a university,JLPT JLPT_N4,qq2at6CGnZ
+厳しい,きびしい,hard; rigorous; strict,Genki Genki_Ln.13 Intermediate_Japanese_Ln.5 JLPT JLPT_N4,pjG^I!L.;w
+エスカレーター,エスカレーター,escalator,JLPT JLPT_N4,y6e9BNnN(6
+人口,じんこう,population,Intermediate_Japanese_Ln.4 JLPT JLPT_N4,h:04.`><%U
+月,つき,moon,Genki Genki_Ln.20 JLPT JLPT_N4,g.!8Tz-L0l
+絹,きぬ,silk,JLPT JLPT_N4,tNV0})jEsh
+ちっとも,ちっとも,not at all (neg. verb),JLPT JLPT_N4,p(lsw|$R1V
+深い,ふかい,"deep, profound",JLPT JLPT_N4,N%G$/Va72i
+壊れる,こわれる,"to be broken, to break",JLPT JLPT_N4,PH#eB=.[|i
+揺れる,ゆれる,"to shake, to sway",JLPT JLPT_N4,CJT@S-rGcq
+落る,おちる,"to fall, to drop",JLPT JLPT_N4,QEWE{hX5.8
+できるだけ,できるだけ,"if at all possible, as much as possible",JLPT JLPT_N4,z|27hHgqS.
+悲しい,かなしい,"sad, sorrowful",Genki Genki_Ln.13 JLPT JLPT_N4,P[6ROxur[z
+中学校,ちゅうがっこう,junior high school pupil,JLPT JLPT_N4,o@F6a}&sDT
+ガス,ガス,gas,JLPT JLPT_N4,J0vS6#XFQP
+祈る,いのる,to pray; to wish,JLPT JLPT_N4,gOVf)x5I|I
+盛ん,さかん,"prosperous, active, thriving",JLPT JLPT_N4,iN0&Vv}z1G
+アルバイト,アルバイト,part-time job,Genki Genki_Ln.4 JLPT JLPT_N4,uhbB_H_zmK
+起こす,おこす,to wake (someone) up,Genki Genki_Ln.16 JLPT JLPT_N4,e)?&!q93%0
+致す,いたす,-- extra-modest expression for する --,Genki Genki_Ln.20 JLPT JLPT_N4,s{uMBFr}QR
+噛む,かむ,"to bite, to chew",JLPT JLPT_N4,E0N_YXN>-x
+赤ちゃん,あかちゃん,"baby, infant",Genki Genki_Ln.21 JLPT JLPT_N4,s09]7w9[]D
+浅い,あさい,"shallow, superficial",JLPT JLPT_N4,Bq97rav-&k
+嘘,うそ,lie,JLPT JLPT_N4,dDVZZUX$0%
+小説,しょうせつ,novel,Genki Genki_Ln.20 JLPT JLPT_N4,k;Wm8^zP:1
+親,おや,a parent,Genki Genki_Ln.16 Intermediate_Japanese_Ln.6 JLPT JLPT_N4,EM~YxWr$Fw
+それに,それに,moreover; besides,Intermediate_Japanese_Ln.2 JLPT JLPT_N4,q*Vh;RO@9L
+西洋,せいよう,"the West, Western countries",JLPT JLPT_N4,CYHizo6/]:
+思う,おもう,"to think, to feel",Genki Genki_Ln.8 JLPT JLPT_N4,bu>M]5SnGX
+パート (タイム),パート (タイム),part time (esp. female part time employees),JLPT JLPT_N4,v_m4?zP2.9
+時代,じだい,"age, period, epoch, era",JLPT JLPT_N4,L?Q&>175XG
+申し上げる,もうしあげる,"(humble)to say, to tell",JLPT JLPT_N4,GF+@f2CV$T
+～式,～しき,~ ceremony; ~ style,JLPT JLPT_N4,"r&5Ybsff,l"
+出席,しゅっせきする,attendance,JLPT JLPT_N4,veUCYD:#[?
+～家,～か,person who is specialized in ~,JLPT JLPT_N4,jmL@^X(3xD
+迎える,むかえる,to welcome; to meet; to greet,JLPT JLPT_N4,c)r?fC@d`X
+触る,さわる,"to touch, to feel",JLPT JLPT_N4,EE}]!?vk-o
+建て,～だて,"~ storied, separate housing",JLPT JLPT_N4,O;BgWj4xcP
+社長,しゃちょう,president of a company,Genki Genki_Ln.11 JLPT JLPT_N4,esu`;_q%~}
+動物園,どうぶつえん,zoo,JLPT JLPT_N4,LA>0An]TpD
+捕まえる,つかまえる,"to catch, to arrest",JLPT JLPT_N4,"dxA,$K8Jjo"
+季節,きせつ,season (in reference to weather),Genki Genki_Ln.10 Intermediate_Japanese_Ln.9 JLPT JLPT_N4,"H-HO2,.Mf&"
+寄る,よる,to stop by,Genki Genki_Ln.19 Intermediate_Japanese_Ln.3 JLPT JLPT_N4,wowQrA=!@I
+決まる,きまる,to be set; fixed (v.i.),Intermediate_Japanese_Ln.2 JLPT JLPT_N4,ftU/w6Rm9)
+開く,ひらく,to open; to hold (an event),JLPT JLPT_N4,EqW3}ML(%4
+逃げる,にげる,"to escape, to run away",JLPT JLPT_N4,olt^H[(k%k
+だから,だから,so; therefore,Genki Genki_Ln.4 JLPT JLPT_N4,"l,%/>C{Y}S"
+残念,ざんねん,regret; regrettable,Intermediate_Japanese_Ln.7 JLPT JLPT_N4,u8P;}KnN>M
+畳,たたみ,tatami mat (Japanese straw mat),JLPT JLPT_N4,K6&+!%&]%g
+丁寧,ていねい,"polite, courteous, careful",JLPT JLPT_N4,y#[3yo1.4|
+地理,ちり,geography,JLPT JLPT_N4,L>P&NZL8Ln
+さっき,さっき,a little while ago,Genki Genki_Ln.4 JLPT JLPT_N4,K6.[:IAM|.
+怖い,こわい,"scary, frightening",Genki Genki_Ln.5 JLPT JLPT_N4,oO+f.U&hT(
+包む,つつむ,"to wrap, to cover",Genki Genki_Ln.21 JLPT JLPT_N4,j.kjH)CP:g
+なるべく,なるべく,"if possible, as much as possible",Intermediate_Japanese_Ln.3 JLPT JLPT_N4,N|K[$y_r^[
+無理,むり,"unreasonable, impossible",JLPT JLPT_N4,i]oOmAHlg9
+サンドイッチ,サンドイッチ,sandwich,JLPT JLPT_N4,"Lah$0,$FHs"
+会議室,かいぎしつ,conference room,JLPT JLPT_N4,oxHUFdCY;/
+品物,しなもの,goods,JLPT JLPT_N4,kiGyZq*rIU
+人形,にんぎょう,"doll, figure",JLPT JLPT_N4,vPlJ&v75[Q
+利用,りよう,"use, utilization",JLPT JLPT_N4,Rh@8N~e0eQ
+飾る,かざる,"to decorate, to adorn",JLPT JLPT_N4,"OaqvYHn98,"
+止める,とめる,to stop (something),JLPT JLPT_N4,uL2<QDM;W:
+恥ずかしい,はずかしい,"ashamed, embarrassed",Genki Genki_Ln.18 JLPT JLPT_N4,e$Mth*I+Cg
+いくら～ても,いくら～ても,however much one may ~,JLPT JLPT_N4,I]og(vfh}t
+用事,ようじ,business to take care of; tasks; errands,Genki Genki_Ln.12 JLPT JLPT_N4,p$RznpfpCY
+ビル,ビル,(abbr.) building,JLPT JLPT_N4,H[!Yph0[mz
+けんかする,けんかする,quarrel,JLPT JLPT_N4,Oc14`ELpiF
+頑張る,がんばる,"to try one's best, to try hard, to persist",Genki Genki_Ln.13 JLPT JLPT_N4,Mz@9d9PizL
+投げる,なげる,"to pitch, to cast away",Intermediate_Japanese_Ln.7 JLPT JLPT_N4,"A%8%S+mN,O"
+故障,こしょうする,breakdown,JLPT JLPT_N4,mP~NCidGL7
+力,ちから,"strength, power",JLPT JLPT_N4,t<Fy!4ZXqc
+受ける,うける,"to take (an examination, interview, etc.); to receive",JLPT JLPT_N4,d#N;{6r~iD
+気分,きぶん,"feeling, mood",JLPT JLPT_N4,GJl$1:;vCi
+間違える,まちがえる,to make a mistake,Genki Genki_Ln.21 JLPT JLPT_N4,Q5b~VM7IRc
+そんな,そんな,"such, like that, that sort of",JLPT JLPT_N4,ei/O3MuiLE
+星,ほし,star,JLPT JLPT_N4,h=LT];WutA
+場合,ばあい,"case, situation",JLPT JLPT_N4,qV-2<HJ$$5
+やっと,やっと,"at last, finally",JLPT JLPT_N4,Qf-Nk|9F8D
+足りる,たりる,to be sufficient; to be enough,Genki Genki_Ln.17 Intermediate_Japanese_Ln.4 JLPT JLPT_N4,tSHDO2cb1M
+行う,おこなう,to carry out; to conduct (typically used in written language),Intermediate_Japanese_Ln.3 JLPT JLPT_N4,kSwpIk>RTo
+ぶどう,ぶどう,grapes,JLPT JLPT_N4,qtf+q-Z+n]
+無くなる,なくなる,"to disappear, to get lost",JLPT JLPT_N4,QEFsGzu!|/
+準備,じゅんびする,prepare,JLPT JLPT_N4,h&P$N~U6-[
+世界,せかい,world,Genki Genki_Ln.10 JLPT JLPT_N4,e<Tae_jQo4
+住所,じゅうしょ,address; place of residence,JLPT JLPT_N4,fPoS$h^c(u
+再来月,さらいげつ,the month after next,JLPT JLPT_N4,Zux^JW=t?
+林,はやし,"woods, forest",JLPT JLPT_N4,@LWUXw-^>
+倍,ばい,double,JLPT JLPT_N4,k.0mCWDs+|
+痩せる,やせる,to lose weight,Genki Genki_Ln.7 JLPT JLPT_N4,A[Q-]LV0S:
+線,せん,"line, wire",JLPT JLPT_N4,dK0yR1DBK`
+戦争,せんそう,war,JLPT JLPT_N4,l@;Cq/&#91
+決める,きめる,to decide (v.t.),Genki Genki_Ln.10 Intermediate_Japanese_Ln.9 JLPT JLPT_N4,p(qb/m`R:b
+調べる,しらべる,to check; to look up; to inquire; to search,JLPT JLPT_N4,Ov6y=mBwgM
+寝坊,ねぼう,sleeping in late,JLPT JLPT_N4,B(>pXN{@@q
+パパ,パパ,"papa, daddy",JLPT JLPT_N4,v.-(XP=XJY
+光る,ひかる,"to shine, to glitter",JLPT JLPT_N4,xp|/7BLK40
+夫,おっと,husband,JLPT JLPT_N4,zDF$wWIUs8
+雲,くも,cloud,JLPT JLPT_N4,"C3Z1{X<H,4"
+坂,さか,"slope, hill",JLPT JLPT_N4,fMGrCf7XcB
+～(て) しまう,～(て) しまう,to end up ~,JLPT JLPT_N4,us+Z5ns><g
+飛行場,ひこうじょう,airport,JLPT JLPT_N4,A2O=3b{hXI
+柔道,じゅうどう,judo,JLPT JLPT_N4,d[2qz9jnc7
+決して,けっして,never,JLPT JLPT_N4,Kd9N)Izj!4
+事務所,じむしょ,office,JLPT JLPT_N4,wxgf%k:fc2
+連絡,れんらく,"communication, contact, connection",JLPT JLPT_N4,"v[($g<|S,F"
+小学校,しょうがっこう,elementary school,Genki Genki_Ln.23 JLPT JLPT_N4,f^*MMB(l>o
+客,きゃく,"guest, customer",Intermediate_Japanese_Ln.2 JLPT JLPT_N4,xF)V^}awc{
+昔,むかし,old days; past,Genki Genki_Ln.21 JLPT JLPT_N4,hUjfJU~9){
+美しい,うつくしい,"beautiful, lovely",JLPT JLPT_N4,OB^[>@2T05
+捨てる,すてる,"throw away (trash), dump, discard",Genki Genki_Ln.15 JLPT JLPT_N4,G;1IJzl`jC
+なさる,なさる,-- honorific expression for する --,Genki Genki_Ln.19 JLPT JLPT_N4,zj*av$=2pO
+事,こと,"thing(s), matter(s), fact",Genki Genki_Ln.21 JLPT JLPT_N4,ca&G<Ve~Nx
+どんどん,どんどん,quickly and steadily; at a rapid pace,JLPT JLPT_N4,q0h/etzyxE
+試合,しあい,"match, game, competition",Genki Genki_Ln.12 Intermediate_Japanese_Ln.7 JLPT JLPT_N4,Hv/PI<4cqa
+適当,てきとう,"fitness, suitability",JLPT JLPT_N4,HX3el]3jvP
+素晴らしい,すばらしい,wonderful; terrific,Intermediate_Japanese_Ln.4 JLPT JLPT_N4,Mq|7Xt}rKi
+美術館,びじゅつかん,"art gallery, art museum",Genki Genki_Ln.11 JLPT JLPT_N4,Lovq=LkX$G
+文法,ぶんぽう,grammar,Genki Genki_Ln.13 JLPT JLPT_N4,"h2m8,%coR8"
+終わり,おわり,end,JLPT JLPT_N4,j1fvX?gG0M
+壁,かべ,wall,JLPT JLPT_N4,um!T&Q*O[?
+一度,いちど,"once, one time",JLPT JLPT_N4,z3&2cN)6^e
+お礼,おれい,expression of gratitude; thanking; gift of appreciation; bow,Genki Genki_Ln.19 Intermediate_Japanese_Ln.9 JLPT JLPT_N4,IzFCHK5nu1
+親切,しんせつ,kindness,JLPT JLPT_N4,lZWRz?K3ET
+知らせる,しらせる,to notify,JLPT JLPT_N4,mORr*vy|g/
+歯医者,はいしゃ,dentist,JLPT JLPT_N4,"<G@n,w<8p"
+熱心,ねっしん,enthusiasm,JLPT JLPT_N4,bLrU`I|/*{
+始める,はじめる,"to start, to begin",Genki Genki_Ln.8 JLPT JLPT_N4,"g,>$G?*/Q&"
+もらう,もらう,to receive,JLPT JLPT_N4,MhXS3i[O39
+泣く,なく,to cry,Genki Genki_Ln.13 JLPT JLPT_N4,wS:0`lVju$
+治る,なおる,to get better; to recover from illness (v.i.),JLPT JLPT_N4,J-V8gKft=&
+熱,ねつ,"fever, temperature",Intermediate_Japanese_Ln.3 JLPT JLPT_N4,D9dKTYQi:O
+お祭り,おまつり,festival,JLPT JLPT_N4,n=i-:`LzjX
+水道,すいどう,"water service, water line",JLPT JLPT_N4,FV`Tc-%-nK
+匂い,におい,"odor, smell",JLPT JLPT_N4,P&q^w6d0fO
+ベル,ベル,bell,JLPT JLPT_N4,D!1f]e)iSX
+赤ん坊,あかんぼう,baby,JLPT JLPT_N4,I>S)eTr_]B
+おかしい,おかしい,strange; odd; funny,Intermediate_Japanese_Ln.2 JLPT JLPT_N4,O9;m#]XEB2
+事故,じこ,accident,JLPT JLPT_N4,K(yw!r=B:1
+変,へん,"strange, odd",JLPT JLPT_N4,e/SMd06F!x
+辞典,じてん,"encyclopedia, reference book",JLPT JLPT_N4,brNC9/_sI`
+残る,のこる,"to remain (v.i.), to be left",JLPT JLPT_N4,INR^BBo=#J
+立てる,たてる,"to stand (something) up, to erect (something)",JLPT JLPT_N4,O9fk.~k_.E
+くれる,くれる,"to give, to do for",JLPT JLPT_N4,hSC5|:)aVz
+～員,～いん,member of ~,JLPT JLPT_N4,QHO%z16SSs
+原因,げんいん,"cause, origin, source",JLPT JLPT_N4,y8<@Y+?o6j
+驚く,おどろく,"to be surprised, to be astonished",Intermediate_Japanese_Ln.8 JLPT JLPT_N4,qBeaklesW+
+いただく,頂く,-- extra-modest expression for たべる and のむ; humble expression for もらう --,Genki Genki_Ln.20 JLPT JLPT_N4,J*KGnzk|Z2
+祖母,そぼ,grandmother,JLPT JLPT_N4,x!LCLRW]y2
+場所,ばしょ,"place, location",Genki Genki_Ln.23 Intermediate_Japanese_Ln.5 JLPT JLPT_N4,qw3.O}/lOC
+答,こたえ,"answer, response",JLPT JLPT_N4,xmTYLgV-T_
+もちろん,もちろん,"certainly, of course",Genki Genki_Ln.7 Intermediate_Japanese_Ln.5 JLPT JLPT_N4,"m8,NutV2dG"
+漬ける,つける,"to soak, to moisten, to pickle",JLPT JLPT_N4,h!i?H{d*F@
+受付,うけつけ,reception(ist) desk,Genki Genki_Ln.22 Intermediate_Japanese_Ln.8 JLPT JLPT_N4,"uraaf1,;7Q"
+内,うち,"within, inside",JLPT JLPT_N4,G1H0$T!7Vl
+スクリーン,スクリーン,screen,JLPT JLPT_N4,"L/njBN,iH6"
+増える,ふえる,"to increase, to multiply",JLPT JLPT_N4,QW.w#0qn}8
+または,または,"or, otherwise",JLPT JLPT_N4,J-^^Uw<Tl~
+けがする,けがする,"injury (to animate object), hurt",JLPT JLPT_N4,NP:|wpXW(M
+以下,いか,"less than, below",JLPT JLPT_N4,DS5y_+4p`Y
+選ぶ,えらぶ,to choose; to select,Genki Genki_Ln.17 Intermediate_Japanese_Ln.3 JLPT JLPT_N4,Jo*`4U5e.W
+～ばかり,～ばかり,"just did ~, only",JLPT JLPT_N4,vbW68h-IIc
+心,こころ,"heart, mind",JLPT JLPT_N4,Fkhe%Dz2nb
+～だす,～だす,to start doing ~,JLPT JLPT_N4,B+=k~owmr!
+サラダ,サラダ,salad,JLPT JLPT_N4,J3A=]P#ec<
+届ける,とどける,to deliver (v.t.),Intermediate_Japanese_Ln.9 JLPT JLPT_N4,tA&cXA55C=
+挨拶,あいさつする,greet(ing),JLPT JLPT_N4,h|NjvFq!b]
+景色,けしき,"scenery, landscape",JLPT JLPT_N4,Cd#u9/v:Pu
+確か,たしか,"if I remember correctly; certain, definite",Intermediate_Japanese_Ln.4 JLPT JLPT_N4,v&7%T>e{{z
+ステーキ,ステーキ,steak,JLPT JLPT_N4,K0B$/YQ?Op
+食料品,しょくりょうひん,"foodstuff, groceries",JLPT JLPT_N4,kg/Pg!K6&w
+森,もり,forest,JLPT JLPT_N4,mJkKf?UAUT
+以内,いない,"within, less (no more) than",JLPT JLPT_N4,EyK>c0C[$K
+予定,よてい,"plans, arrangement, schedule",Genki Genki_Ln.15 Intermediate_Japanese_Ln.15 JLPT JLPT_N4,I$<#IwHCvW
+オーバー,オーバー,"overcoat; over, exceeding, exaggeration",JLPT JLPT_N4,umd4AX=/RI
+乾く,かわく,to get dry,JLPT JLPT_N4,s+Ju<mmF]C
+石,いし,stone,JLPT JLPT_N4,gg2=(OnQKh
+思い出す,おもいだす,"to recall, to remember",Intermediate_Japanese_Ln.8 JLPT JLPT_N4,O?8pX)Ooz*
+踊る,おどる,to dance,Genki Genki_Ln.9 JLPT JLPT_N4,LnHUFv$!`;
+細かい,こまかい,"small; fine, minute",JLPT JLPT_N4,PrWma5VeE[
+塗る,ぬる,"to paint, to plaster",JLPT JLPT_N4,gb*{+)EK`F
+ご主人,ごしゅじん,"(your, her) husband",Genki Genki_Ln.14 JLPT JLPT_N4,"Gb,y/-3SAS"
+珍しい,めずらしい,"unusual, rare",Intermediate_Japanese_Ln.4 JLPT JLPT_N4,LG3n^a@XAC
+用,よう,"errand, task, business (to take care of)",Intermediate_Japanese_Ln.9 JLPT JLPT_N4,CvxvGX`|/>
+公務員,こうむいん,"government worker, public servant",JLPT JLPT_N4,p;42%b%y:T
+お嬢さん,おじょうさん,(someone's) daughter (polite),Genki Genki_Ln.22 JLPT JLPT_N4,Ee+d{e?WRj
+用意,ようい,preparation,JLPT JLPT_N4,"PJ%Q,E{$_L"
+探す,さがす,"to search, to seek, to look for",Genki Genki_Ln.15 Intermediate_Japanese_Ln.8 JLPT JLPT_N4,h4(YO`o85t
+形,かたち,shape,JLPT JLPT_N4,f7_i%J0-/Y
+運転,うんてんする,driving,JLPT JLPT_N4,r!zv#R0ur*
+すっかり,すっかり,"all, completely",JLPT JLPT_N4,nV=]]BK.9=
+アナウンサー,アナウンサー,announcer,JLPT JLPT_N4,oG?shn0:uO
+お土産,おみやげ,souvenir,Genki Genki_Ln.4 JLPT JLPT_N4,IKS:}hgF8q
+消しゴム,けしゴム,eraser,JLPT JLPT_N4,"gW^biR[nM,"
+旅館,りょかん,a Japanese inn,Genki Genki_Ln.15 Intermediate_Japanese_Ln.6 JLPT JLPT_N4,Ke`aN1|5T#
+海岸,かいがん,"coast, seashore",JLPT JLPT_N4,O1]Ne=Q0*.
+寂しい,さびしい,"lonely, lonesome",Genki Genki_Ln.9 JLPT JLPT_N4,pi{)YOFX|t
+火,ひ,fire,JLPT JLPT_N4,gjC}:7>!AJ
+育てる,そだてる,to raise (v.t.); to bring up,Genki Genki_Ln.22 JLPT JLPT_N4,r6b~+z#uh_
+味噌,みそ,"miso, bean paste",JLPT JLPT_N4,FzA7odIzvp
+お祝い,おいわい,"congratulation, celebration",Intermediate_Japanese_Ln.7 JLPT JLPT_N4,sQaWTq!hP`
+乗り物,のりもの,vehicle,JLPT JLPT_N4,i9[ZI9WM}X
+案内,あんないする,"information, guidance",JLPT JLPT_N4,DO_nJ<yYaJ
+通う,かよう,to go back and forth; to commute,JLPT JLPT_N4,D<g$_r(YBs
+連れる,つれる,"to lead, to take (a person)",JLPT JLPT_N4,J&sg+H>0p_
+技術,ぎじゅつ,"technique, technology, skill",JLPT JLPT_N4,PCC!&zGiCY
+小鳥,ことり,small bird,JLPT JLPT_N4,G|$muceS&O
+下宿,げしゅく,"lodging, boarding house",JLPT JLPT_N4,"bmjB!,8T=p"
+ジャム,ジャム,jam,JLPT JLPT_N4,D@h7*f7p?d
+招待,しょうたいする,invitation,JLPT JLPT_N4,c$Y~;QF){;
+鏡,かがみ,mirror,JLPT JLPT_N4,v%J5x[E:;(
+はず,はず,it should be so,JLPT JLPT_N4,Jg5{R&fxyH
+法律,ほうりつ,law,JLPT JLPT_N4,O9|FD5Fq3.
+進む,すすむ,"to advance, to proceed",JLPT JLPT_N4,b6Re}g0};8
+楽む,たのしむ,to enjoy,JLPT JLPT_N4,iCe:{Xn-6L
+貿易,ぼうえき,trade,JLPT JLPT_N4,bc9Yp10YbE
+反対,はんたい,"oppose, opposition, resistance",JLPT JLPT_N4,KY]P)[osSM
+おる,おる,-- extra-modest expression for いる --,Genki Genki_Ln.20 JLPT JLPT_N4,Adc_Jds{te
+申す,もうす,-- extra-modest (humble) expression for 言う (いう) --,Genki Genki_Ln.20 JLPT JLPT_N4,e<WJ-6`NVb
+試験,しけん,an exam,Genki Genki_Ln.9 JLPT JLPT_N4,bUCd_5rR^-
+真面目,まじめ,"diligent, serious",JLPT JLPT_N4,xK*F{fx?.z
+ごらんになる,,-- honorific expression for みる --,Genki Genki_Ln.19 JLPT JLPT_N4,k(j]!OR1gM
+店員,てんいん,clerk; shop-employee,Intermediate_Japanese_Ln.6 JLPT JLPT_N4,GeFU%up;F{
+泊まる,とまる,to stay (over night) (v.i.),JLPT JLPT_N4,IbHq#Ubd>&
+よろしい,よろしい,"(hon.) good, OK, all right",JLPT JLPT_N4,Ah<}g#ysAC
+今夜,こんや,"this evening, tonight",JLPT JLPT_N4,qWO]e*;%U}
+おつり,おつり,change; balance of money returned to the purchaser,JLPT JLPT_N4,wx#vXTnj!Z
+チェックする,チェックする,check,JLPT JLPT_N4,o%*Ndg~YHB
+会話,かいわ,conversation,JLPT JLPT_N4,dD;CvmzQ9b
+空気,くうき,"air, atmosphere",Genki Genki_Ln.8 JLPT JLPT_N4,C)1Z!^eB^|
+交通,こうつう,"traffic, transportation",JLPT JLPT_N4,AyJ>}k*DyK
+ワープロ,ワープロ,word processor,JLPT JLPT_N4,!Qc[fI`%{
+喜ぶ,よろこぶ,"to rejoice, to be delighted, to be glad",JLPT JLPT_N4,DF7Py?yTD[
+急行,きゅうこう,express train or bus,Intermediate_Japanese_Ln.7 JLPT JLPT_N4,t]K/5%].:3
+皆,みな,everyone,JLPT JLPT_N4,r56e/uzKVH
+味,あじ,"flavor, taste",JLPT JLPT_N4,B]?q9zUNzO
+空港,くうこう,airport,Genki Genki_Ln.20 JLPT JLPT_N4,Qgx/]mMiIj
+手袋,てぶくろ,glove(s),Genki Genki_Ln.10 JLPT JLPT_N4,LM6P1@!I~2
+校長,こうちょう,"principal, headmaster",JLPT JLPT_N4,eI/Ghjq;7/
+ごちそう,ごちそう,"feast, treating (someone)",JLPT JLPT_N4,D/ibPniDYT
+踊り,おどり,dance,JLPT JLPT_N4,J=*Z|>n+QR
+興味,きょうみ,interest (in something),JLPT JLPT_N4,DIyl0xA#)2
+引っ越す,ひっこす,to move to a new place of residence,JLPT JLPT_N4,EGeSfwOFZ.
+冷房,れいぼう,"cooling, air conditioning",JLPT JLPT_N4,stZHJs{qvP
+都合,つごう,"circumstances, convenience",JLPT JLPT_N4,b;szYJp1~0
+遠慮,えんりょする,"restraint, reserve, hesitate",JLPT JLPT_N4,uqPUmCD*1n
+亡くなる,なくなる,to pass away,JLPT JLPT_N4,Iq_q:mI=}n
+科学,かがく,science,Genki Genki_Ln.1 JLPT JLPT_N4,gWOi-(wW;M
+はっきり,はっきり,"clearly, distinctly",JLPT JLPT_N4,soMm6B)m]t
+差し上げる,さしあげる,-- humble expression for あげる --,Genki Genki_Ln.20 JLPT JLPT_N4,zkSrvJWm{I
+気持ち,きもち,"feeling, sensation, mood",JLPT JLPT_N4,P!ajdoiyb.
+祖父,そふ,grandfather,JLPT JLPT_N4,ytyAfRG*6x
+港,みなと,"harbor, port",JLPT JLPT_N4,sHl5)cnUcM
+予約,よやく,reservation,Genki Genki_Ln.10 JLPT JLPT_N4,rSce1JPbkI
+凄い,すごい,"terrific, great",JLPT JLPT_N4,P~)7jIfH{m
+入学,にゅうがくする,entry to school or university,JLPT JLPT_N4,"jo:/>1,9uU"
+片付ける,かたづける,"to (clean) tidy up (v.t.), to put away",JLPT JLPT_N4,Ef_Twp5ERS
+写す,うつす,to copy (v.t.); to photograph,JLPT JLPT_N4,x|L%TU)*iv
+パソコン,パソコン,(personal) computer,JLPT JLPT_N4,tQ#JE!pNrV
+部長,ぶちょう,department (division) manager,Genki Genki_Ln.19 Intermediate_Japanese_Ln.15 JLPT JLPT_N4,O:v<m}n3*n
+火事,かじ,fire,JLPT JLPT_N4,Kll.Pvc/gB
+足す,たす,to add (numbers),JLPT JLPT_N4,M:pOTP>t7-
+教会,きょうかい,church,Intermediate_Japanese_Ln.9 JLPT JLPT_N4,oA&[8r+GKm
+彼ら,かれら,they (usually male),JLPT JLPT_N4,k?K1].&L.0
+一杯,いっぱい,"full, to the utmost",JLPT JLPT_N4,w&/o{@M=$:
+アメリカ,アメリカ,"America, U.S.A.",Genki Genki_Ln.1 Genki_Ln.2 JLPT JLPT_N4,IVipO?aKE#
+男性,だんせい,man; male,JLPT JLPT_N4,r6Y+#Vxx9S
+理由,りゆう,reason,JLPT JLPT_N4,P7}t{e2du#
+生産,せいさんする,production; to produce,JLPT JLPT_N4,pm+O;C4U:>
+着物,きもの,kimono; Japanese traditional dress,Genki Genki_Ln.13 JLPT JLPT_N4,"A(ZdyF5k,T"
+おもちゃ,おもちゃ,a toy,Genki Genki_Ln.11 JLPT JLPT_N4,Cf`[JaXL7u
+暮れる,くれる,"to get dark, to come to an end",JLPT JLPT_N4,i-JL+Sl!mg
+釣る,つる,to fish,JLPT JLPT_N4,"GWJ%g`TG,o"
+～ちゃん,～ちゃん,suffix for familiar (female) person,JLPT JLPT_N4,r2m3z~%1s]
+打つ,うつ,"to hit, to strike",JLPT JLPT_N4,pBs^gx/@>a
+あんな,あんな,"such, like that",JLPT JLPT_N4,K%g**4JE#C
+謝る,あやまる,to apologize,JLPT JLPT_N4,C%+Y^2-4l[
+昼間,ひるま,"daytime, during the day",JLPT JLPT_N4,p3^ge-^eJl
+教育,きょういく,education,JLPT JLPT_N4,HW9*4`esHu
+女性,じょせい,woman,JLPT JLPT_N4,E9gO2XIg*K
+米,こめ,uncooked rice,JLPT JLPT_N4,"t,HSQDh#2"
+邪魔,じゃま,"hindrance, intrusion",JLPT JLPT_N4,c]>yivA`ny
+国際,こくさい,international,JLPT JLPT_N4,f~g3tMo97^
+隅,すみ,corner,JLPT JLPT_N4,eeOvjZ5zl.
+伺う,うかがう,"humble form of 行く (いく), 聞く (きく) and 来る (くる)",JLPT JLPT_N4,Lmfy{2F]$A
+再来週,さらいしゅう,the week after next,JLPT JLPT_N4,kKHM?VM`7o
+夢,ゆめ,a dream,Genki Genki_Ln.11 JLPT JLPT_N4,lZn7[}J9+0
+喉,のど,throat,JLPT JLPT_N4,c+C3t7I~.8
+最近,さいきん,"recently, nowadays, in recent years, most recent, latest",Genki Genki_Ln.15 Intermediate_Japanese_Ln.9 JLPT JLPT_N4,e2RD]Myt9A
+周り,まわり,surroundings,JLPT JLPT_N4,fhT%f*K[Vx
+歴史,れきし,history,Genki Genki_Ln.1 Genki_Ln.2 Intermediate_Japanese_Ln.3 JLPT JLPT_N4,lQ}Sxv&`A!
+不便,ふべん,inconvenience,JLPT JLPT_N4,C!<M[IO(?_
+血,ち,blood,JLPT JLPT_N4,0ihaC]*Q^
+～続ける,～つづける,to continue doing ~,JLPT JLPT_N4,JHO_m/Gf)j
+毛,け,"hair, fur",JLPT JLPT_N4,gsy(C|!IEU
+ひどい,ひどい,"terrible, awful, unfair, cruel",Genki Genki_Ln.21 Intermediate_Japanese_Ln.4 JLPT JLPT_N4,M6<?LBefmj
+例えば,たとえば,"for example, e.g.",Genki Genki_Ln.17 Intermediate_Japanese_Ln.2 JLPT JLPT_N4,n/o*9@bFx6
+中々,なかなか,"very, considerably, quite",JLPT JLPT_N4,@YWCVJq=)
+随分,ずいぶん,extremely,JLPT JLPT_N4,NMl:D%#1zF
+～やすい,～やすい,easy to do ~,JLPT JLPT_N4,exjp1w(~N7
+押し入れ,おしいれ,closet,JLPT JLPT_N4,Al&#S)GWr$
+電灯,でんとう,electric light,JLPT JLPT_N4,jodPP9K~W{
+叱る,しかる,to scold,JLPT JLPT_N4,LMzmk?%TI!
+サンダル,サンダル,sandal,JLPT JLPT_N4,nKx7m0Vnj8
+びっくりする,びっくりする,to be surprised,Genki Genki_Ln.21 JLPT JLPT_N4,Cr@7!m+n{m
+うまい,うまい,delicious; skillful; fortunate,JLPT JLPT_N4,"C`4~Q!,KRn"
+変える,かえる,"to change, to alter, to vary",JLPT JLPT_N4,x+80xLQg^-
+講堂,こうどう,auditorium,JLPT JLPT_N4,ktg9A%:iyA
+子,こ,child,JLPT JLPT_N4,u.wVLBCC7[
+沸かす,わかす,to boil,JLPT JLPT_N4,"d,.x::f0>g"
+レジ,レジ,register,JLPT JLPT_N4,m?VOxpy?_K
+しばらく,しばらく,little while,JLPT JLPT_N4,w1JlkP{0C8
+特に,とくに,particularly,Intermediate_Japanese_Ln.3 JLPT JLPT_N4,Qf=L0@hP&F
+空く,あく,"to open, to become empty (vacant)",JLPT JLPT_N4,Cg0$u|Ogik
+計画,けいかくする,"plan, project, schedule",JLPT JLPT_N4,s2fE.u9}xk
+通り,とおり,"~ Street, ~ Avenue",JLPT JLPT_N4,QBI<)8t#SN
+下着,したぎ,underwear,JLPT JLPT_N4,tFl(JKOvJ3
+経済,けいざい,"economics, finance, economy",JLPT JLPT_N4,rJHgD<t_i_
+こう,こう,"like this, this way",JLPT JLPT_N4,Q%+*%s6}J9
+是非,ぜひ,"certainly, by all means; without fail",Genki Genki_Ln.9 Intermediate_Japanese_Ln.15 Intermediate_Japanese_Ln.8 JLPT JLPT_N4,kray(3KD^X
+裏,うら,"reverse side, back",JLPT JLPT_N4,pQ2heE~587
+為,ため,"good, advantage, in order to",JLPT JLPT_N4,Fly+C7B(R*
+おいでになる,おいでになる,(hon.) to be,JLPT JLPT_N4,ok-j:Fq]#X
+変わる,かわる,"to change (v.i.), to be transformed, to vary",Intermediate_Japanese_Ln.4 JLPT JLPT_N4,N?)pR_`l)L
+以外,いがい,"other than, with the exception of, excepting",Intermediate_Japanese_Ln.3 JLPT JLPT_N4,io5npAJ^ZJ
+済む,すむ,"to finish, to end",JLPT JLPT_N4,eQV4%/qxB)
+ハンバーグ,ハンバーグ,hamburger steak,JLPT JLPT_N4,zs3r)kO4N*
+市,し,city,JLPT JLPT_N4,rXed<x$qC(
+引き出し,ひきだし,drawer,JLPT JLPT_N4,tGG+yHdqmL
+遊び,あそび,play,JLPT JLPT_N4,"O8zue,3OP7"
+支度,したくする,preparation,JLPT JLPT_N4,QsqU&|{INc
+～始める,～はじめる,to start doing ~,JLPT JLPT_N4,BA.Jz]NK1.
+見える,みえる,to be visible; -- polite verb meaning 来る (くる) --,Genki Genki_Ln.15 JLPT JLPT_N4,cEonZn&vE$
+十分,じゅうぶん,enough,JLPT JLPT_N4,vgB;={Nvrv
+音,おと,"sound, note",Genki Genki_Ln.20 JLPT JLPT_N4,y~nFfa-~?d
+きっと,きっと,"surely, definitely, undoubtedly, certainly",Intermediate_Japanese_Ln.7 JLPT JLPT_N4,>[X6H]9HU
+まず,まず,"first (of all), to start with",Genki Genki_Ln.18 JLPT JLPT_N4,b.U+m9N1DV
+遠く,とおく,"far away, distant",JLPT JLPT_N4,P.EKUt5=[B
+大体,だいたい,approximately; in most cases; in general; to begin with (same as もともと),Intermediate_Japanese_Ln.15 Intermediate_Japanese_Ln.3 JLPT JLPT_N4,PoQwq(:pGi
+折れる,おれる,"to break, to be folded, to give in; to turn (a corner)",JLPT JLPT_N4,"C>N,+q5aTm"
+正しい,ただしい,correct,JLPT JLPT_N4,ynVxN8fR|I
+輸入,ゆにゅう,import,JLPT JLPT_N4,c#?sbZfFpt
+返事,へんじ,"reply, answer",JLPT JLPT_N4,KqUGjMWU_#
+都,と,metropolitan,JLPT JLPT_N4,OcM{?!kX-7
+産業,さんぎょう,industry,JLPT JLPT_N4,r<I`MSX5aQ
+伝える,つたえる,"to convey (a message); to tell, to report",Genki Genki_Ln.20 Intermediate_Japanese_Ln.15 JLPT JLPT_N4,"z>dT,I0S3h"
+お金持ち,かねもち; おかねもち,rich person,JLPT JLPT_N4,H?Z`hWb&65
+説明,せつめい,explanation,JLPT JLPT_N4,jzx*<D-6cG
+島,しま,island,Intermediate_Japanese_Ln.5 JLPT JLPT_N4,AOZjwUDN5g
+道具,どうぐ,tool,JLPT JLPT_N4,Me$$/AnEcv
+滑る,すべる,"to slide, to slip",JLPT JLPT_N4,nobw)6B/(-
+それほど,それほど,to that degree; extent,JLPT JLPT_N4,tq|Owona;B
+以上,いじょう,more than; this is all,JLPT JLPT_N4,kbfzlR:5u>
+～まま,～まま,as it is,JLPT JLPT_N4,j#zKPMXsT3
+特急,とっきゅう,limited express (train faster than an express),JLPT JLPT_N4,sOgOxrQFHN
+プレゼント,プレゼント,"present, gift",Genki Genki_Ln.12 JLPT JLPT_N4,FrsjD-2$(X
+～(に) よると,～(に) よると,according to ~,JLPT JLPT_N4,erz+S2{yL|
+妻,つま,wife (humble),JLPT JLPT_N4,pfL{;:Bm<O
+帰り,かえり,"return, coming back",JLPT JLPT_N4,A1{^9x(Ly$
+具合,ぐあい,"condition, state, health",JLPT JLPT_N4,Ha+Fpz*nIy
+堅; 硬; 固い,かたい,"solid, hard, firm",JLPT JLPT_N4,Qr]]OTGag7
+駐車場,ちゅうしゃじょう,parking lot,JLPT JLPT_N4,Q9!i44Gj}q
+スーツ,スーツ,suit,JLPT JLPT_N4,"M~,%txA#EO"
+危険,きけん,"danger, risk, hazard",Intermediate_Japanese_Ln.15 JLPT JLPT_N4,f#x=KD-)bk
+髪,かみ,hair,Genki Genki_Ln.7 JLPT JLPT_N4,roFwJrlfKR
+天気予報,てんきよほう,weather forecast,Genki Genki_Ln.8 JLPT JLPT_N4,rN#1gCRiI^
+彼女,かのじょ,girlfriend; she,Genki Genki_Ln.12 JLPT JLPT_N4,xL3J@WlS{%
+間,あいだ,"space, interval",JLPT JLPT_N4,MXEynMn6*x
+卒業,そつぎょう,graduation,JLPT JLPT_N4,yOSz]L8FJS
+それで,それで,"and (conj.), thereupon, because of that",JLPT JLPT_N4,rZ[:sRogcN
+枝,えだ,"branch, twig",JLPT JLPT_N4,FAl}KCf:~8
+専門,せんもん,major; speciality,Genki Genki_Ln.1 JLPT JLPT_N4,k;2({qLOGz
+そろそろ,そろそろ,"gradually, soon",JLPT JLPT_N4,Q|>K44^N++
+送る,おくる,"to send, to dispatch",Genki Genki_Ln.14 Intermediate_Japanese_Ln.3 JLPT JLPT_N4,e1#_xMS<)@
+あげる,あげる,to give,JLPT JLPT_N4,w6NP$s|k?>
+騒ぐ,さわぐ,"to make noise, to clamor",JLPT JLPT_N4,E-jyAQ+?xZ
+尋ねる,たずねる,to inquire (same as 質問する),JLPT JLPT_N4,B;}vj%?W%Z
+放送,ほうそうする,broadcasting,JLPT JLPT_N4,HT(fAub[.Z
+政治,せいじ,politics,Genki Genki_Ln.1 Genki_Ln.12 Intermediate_Japanese_Ln.3 JLPT JLPT_N4,LbbPDli%;(
+市民,しみん,citizen,JLPT JLPT_N4,KnKdz8[G7<
+ファックス,ファックス,fax,JLPT JLPT_N4,sG]9/N[j*>
+負ける,まける,"to lose (a game) (v.i.), to be defeated",Intermediate_Japanese_Ln.7 JLPT JLPT_N4,t-t/Tk%(SS
+指輪,ゆびわ,(finger) ring,Genki Genki_Ln.14 JLPT JLPT_N4,By9Xq1v4J{
+田舎,いなか,"rural, countryside",JLPT JLPT_N4,qO;XWK^*$*
+見つける,みつける,"to discover, to find (v.t.)",Genki Genki_Ln.21 JLPT JLPT_N4,JSBDi~:Uul
+高校生,こうこうせい,high school student,Genki Genki_Ln.1 JLPT JLPT_N4,s|lGtGG1fi
+講義,こうぎ,a lecture,Intermediate_Japanese_Ln.5 JLPT JLPT_N4,q(32?ls(B3
+そんなに,そんなに,"so much, like that",JLPT JLPT_N4,pG^h}ycj3(
+昼休み,ひるやすみ,"lunch break, noon recess",JLPT JLPT_N4,lFVXC$-X%0
+忘れ物,わすれもの,"lost article, something forgotten",JLPT JLPT_N4,c>u.i{BBMW
+下りる,おりる,"to get down, to go; come down",JLPT JLPT_N4,"d9,VKd=RU="
+腕,うで,arm (in reference to body),Intermediate_Japanese_Ln.7 JLPT JLPT_N4,AiW}:.4@ze
+訳,わけ,reason; explanation,JLPT JLPT_N4,usS4^zwn[>
+承知,しょうちする,"consent, acceptance",JLPT JLPT_N4,H:BcaGHLGe
+日記,にっき,"diary, journal",Genki Genki_Ln.18 JLPT JLPT_N4,"BMMWqQZ#[,"
+高校; 高等学校,こうこう; こうとうがっこう,high school; senior high school,JLPT JLPT_N4,KKBE9#o7:F
+似る,にる,"to resemble, to be similar",JLPT JLPT_N4,i`_a~no4G!
+～おわる,～おわる,to finish doing ~,JLPT JLPT_N4,qwf(Try}@4
+暖房,だんぼう,heating,JLPT JLPT_N4,dvn`p4e0P6
+留守,るす,absence; not at home,Genki Genki_Ln.21 JLPT JLPT_N4,BK(gHI]ze3
+割合,わりあい,"rate, ratio, percentage",JLPT JLPT_N4,vGMwhqQc%{
+寺,てら,Buddhist temple,JLPT JLPT_N4,Hiagec7p~[
+慣れる,なれる,to grow accustomed to,JLPT JLPT_N4,m30?cbGY7<
+普通,ふつう,common; usual,Intermediate_Japanese_Ln.2 Intermediate_Japanese_Ln.3 JLPT JLPT_N4,s:f#izD=u2
+手伝う,てつだう,to help,JLPT JLPT_N4,s_Pi8jG!6%
+なるほど,なるほど,I see; I now understand,Intermediate_Japanese_Ln.6 JLPT JLPT_N4,b:e%Ujd8JZ
+くださる,くださる,"(hon.) to give, to confer",JLPT JLPT_N4,sPmqOCO=cT
+息子,むすこ,(humble) son,JLPT JLPT_N4,xE%1d@q~=0
+お子さん,おこさん,(someone else's) child (polite),Genki Genki_Ln.19 JLPT JLPT_N4,JfH~5*U.a_
+会場,かいじょう,"venue, meeting place",JLPT JLPT_N4,rYhMPU9-hG
+笑う,わらう,"to laugh, to smile",JLPT JLPT_N4,y~ow$kbx8M
+運ぶ,はこぶ,"to transport, to carry",Genki Genki_Ln.22 Intermediate_Japanese_Ln.6 JLPT JLPT_N4,v9DX2R5H-S
+文学,ぶんがく,literature,Genki Genki_Ln.1 Intermediate_Japanese_Ln.3 JLPT JLPT_N4,"lUX,?(3;D]"
+光,ひかり,light,JLPT JLPT_N4,qZgkVt9uh<
+お見舞い,おみまい,"calling on someone who is ill, visit",JLPT JLPT_N4,vi}b>#%^FD
+席,せき,a seat,Intermediate_Japanese_Ln.7 JLPT JLPT_N4,frRhF)UU}W
+～様,～さま,"Mr., Mrs., Ms.",JLPT JLPT_N4,JidByAlQoq
+ご存じ,ごぞんじ,"knowing, acquaintance",JLPT JLPT_N4,k8%o+}YbEd
+下る,さがる,"to descend, to drop, to fall",JLPT JLPT_N4,oX|5UGkIW2
+字,じ,letter; character,Genki Genki_Ln.20 JLPT JLPT_N4,paD_A<.{(!
+アジア,アジア,Asia,JLPT JLPT_N4,"Q{IM`lB,o7"
+褒める,ほめる,to praise; to say nice things,Genki Genki_Ln.21 JLPT JLPT_N4,!.H?[6|B.
+空く,すく,"to be empty (in reference to people), to be less crowded",JLPT JLPT_N4,fg<?z[S^C:
+あ,あ,Ah,JLPT JLPT_N4,qc]3W&Jc<m
+最も,もっとも,most,JLPT JLPT_N4,TJ2Lm-F`{
+合う,あう,"to fit, to match",JLPT JLPT_N4,OAIc&<q]o$
+～代,～だい,~ age; period,JLPT JLPT_N4,y4r%$Sls[D
+最後,さいご,"last, end",JLPT JLPT_N4,P^V7$JoB=L
+値段,ねだん,price,JLPT JLPT_N4,E3[j8aN}XJ
+退院,たいいんする,leaving hospital,JLPT JLPT_N4,E-^*b8-xhX
+展覧会,てんらんかい,exhibition,JLPT JLPT_N4,PN~#oqMNRx
+久しぶり,ひさしぶり,it has been a long time; for the first time in a long time,Genki Genki_Ln.11 Intermediate_Japanese_Ln.4 JLPT JLPT_N4,"J`#Y!H,,<%"
+カーテン,カーテン,curtain,Genki Genki_Ln.18 JLPT JLPT_N4,NFW!?qkYyo
+汽車,きしゃ,train (steam),JLPT JLPT_N4,KH0a_3!CiN
+遅れる,おくれる,to (be) become late,Genki Genki_Ln.19 Intermediate_Japanese_Ln.2 JLPT JLPT_N4,rDxLnq^]Ph
+見つかる,みつかる,"to be found (v.i.), to be discovered",JLPT JLPT_N4,b>m8LlfHOm
+召し上がる,めしあがる,-- honorific form of 食べる (たべる) and 飲む (のむ) --,Genki Genki_Ln.19 Intermediate_Japanese_Ln.6 JLPT JLPT_N4,Fa=r1a7`zE
+太る,ふとる,to gain weight,Genki Genki_Ln.7 JLPT JLPT_N4,BN&?E=z3*H
+注射,ちゅうしゃ,injection,JLPT JLPT_N4,lG`+>+=?Os
+様,よう,"way, manner, kind",JLPT JLPT_N4,t[MNQO-W6
+～おき,～おき,after every ~,JLPT JLPT_N4,ISv;l<*PQR
+最初,さいしょ,"beginning, first",JLPT JLPT_N4,uJfgbAk&PM
+御～,ご～,honorable ~,JLPT JLPT_N4,b?YXE$9w]A
+安心,あんしん,"peace of mind, relief",JLPT JLPT_N4,C^vt]hY6vW
+直る,なおる,to be fixed,JLPT JLPT_N4,wOi%P<vl?O
+集める,あつめる,"to collect, to gather (v.t.), to assemble",Genki Genki_Ln.16 Intermediate_Japanese_Ln.7 JLPT JLPT_N4,OW4zN$vq<h
+直す,なおす,to correct (v.t.); to fix,Genki Genki_Ln.16 JLPT JLPT_N4,g9g}aXNY+w
+続く,つづく,to be continued,JLPT JLPT_N4,"I,82^s2,ha"
+先輩,せんぱい,senior members of a group,Genki Genki_Ln.22 JLPT JLPT_N4,iQ7T^oqMw-
+約束,やくそく,"arrangement, appointment, promise",Genki Genki_Ln.13 JLPT JLPT_N4,gG#1gGEk5+
+世話,せわする,looking after; to look after,JLPT JLPT_N4,u{y[j%Z9W2
+近所,きんじょ,neighborhood,JLPT JLPT_N4,hCRlD3m.g(
+将来,しょうらい,(in the) future; prospects,Genki Genki_Ln.11 Intermediate_Japanese_Ln.5 JLPT JLPT_N4,y@QKAOSu|U
+億,おく,hundred million,JLPT JLPT_N4,iX-FN@Kj?p
+数学,すうがく,mathematics,JLPT JLPT_N4,EO5o6*tgn9
+文化,ぶんか,culture,Genki Genki_Ln.19 JLPT JLPT_N4,z%ky|Q={QQ
+払う,はらう,to pay,Genki Genki_Ln.10 Intermediate_Japanese_Ln.3 JLPT JLPT_N4,i~kIT)jn~k
+習慣,しゅうかん,custom (in reference to culture),JLPT JLPT_N4,v)1shr#hf=
+焼ける,やける,"to burn, to be roasted",JLPT JLPT_N4,ws>!BOMOtu
+君,きみ,you (informal for men),JLPT JLPT_N4,P|5<lpF.:2
+冷える,ひえる,"to grow cold, to cool down",JLPT JLPT_N4,np-S*rxEi@
+点く,つく,"to be started, to be switched on",JLPT JLPT_N4,s+|BHBlyTh
+この間,このあいだ,"the other day, recently",Genki Genki_Ln.16 JLPT JLPT_N4,c(L)|Hc$oD
+格好,かっこう,"appearance, manner, shape, form, posture",JLPT JLPT_N4,j4zgBW-)uI
+かまう,,"to mind, to care about, to be concerned about",JLPT JLPT_N4,l%US3Ov|)s
+続ける,つづける,"to continue, to keep up",Genki Genki_Ln.21 JLPT JLPT_N4,Dmf=K4sY#J
+落す,おとす,"to drop, to lose",JLPT JLPT_N4,p0#ZhzpH-}
+明日,あす,tomorrow,JLPT JLPT_N4,ITR}TzQQ.H
+出発,しゅっぱつする,departure,JLPT JLPT_N4,hH4(GI}wN&
+拝見,はいけんする,"(humble) (polite) seeing, look at",JLPT JLPT_N4,udBE2Kt)`=
+割れる,われる,to break,JLPT JLPT_N4,G?t1hbgS`?
+背中,せなか,back (of body),JLPT JLPT_N4,hg%3^*8ICS
+新聞社,しんぶんしゃ,newspaper company,JLPT JLPT_N4,m^QI_$65r>
+いじめる,いじめる,"to bully, to torment",Genki Genki_Ln.21 JLPT JLPT_N4,gd&LFipme&
+回る、回す,まわる、まわす,"to go around, to revolve",JLPT JLPT_N4,OXe]%sDun3
+～君,～くん,"Mr. (junior) ~, master ~",JLPT JLPT_N4,yqGP#fHaRj
+おっしゃる,おっしゃる,-- honorific expression for いう --,Genki Genki_Ln.19 JLPT JLPT_N4,Bv6:t/{x_6
+眠い,ねむい,"sleepy, drowsy",Genki Genki_Ln.10 JLPT JLPT_N4,g1)0|I<ucL
+濡れる,ぬれる,to get wet,JLPT JLPT_N4,"n,@-PdsLi~"
+倒れる,たおれる,"to collapse, to break down",JLPT JLPT_N4,k|Od:&*w$$
+スーパー (マーケット),スーパー (マーケット),supermarket,JLPT JLPT_N4,DH3_3RD/FB
+アクセサリー,アクセサリー,accessory,JLPT JLPT_N4,qvO-&Z#/h
+考える,かんがえる,to think (about); to consider,Genki Genki_Ln.18 JLPT JLPT_N4,"M,WdgwY$__"
+向かう,むかう,"to face, to go towards",JLPT JLPT_N4,sLFa<Dk5BC
+自由,じゆう,freedom,Genki Genki_Ln.22 JLPT JLPT_N4,lFnDZou.7G
+仕方,しかた,way (of doing something),JLPT JLPT_N4,AM]yYl5eIO
+首,くび,neck,JLPT JLPT_N4,JPecz-JR}]
+程,ほど,"degree, extent",JLPT JLPT_N4,p%bF6rAi^7
+代わり,かわり,"substitute, replacement",JLPT JLPT_N4,rZ#&qP#LLe
+失敗,しっぱい,"failure, mistake",JLPT JLPT_N4,KT@^}h^l+<
+工業,こうぎょう,(manufacturing) industry,JLPT JLPT_N4,kLOeCV|5Ly
+移る,うつる,to move (from a house); to transfer (from a department); to shift,JLPT JLPT_N4,EwBssfbpE#
+スーツケース,スーツケース,suitcase,JLPT JLPT_N4,z<X.?7YIM*
+ひげ,ひげ,beard,Genki Genki_Ln.17 JLPT JLPT_N4,OC&/lk8Sbt
+研究室,けんきゅうしつ,the professor's office; laboratory,Intermediate_Japanese_Ln.3 JLPT JLPT_N4,C=g-AqnF6#
+工場,こうじょう,factory,Genki Genki_Ln.21 Intermediate_Japanese_Ln.15 JLPT JLPT_N4,zB*.:-`=4j
+紹介,しょうかい,an introduction,JLPT JLPT_N4,dT=BbRaUvW
+けれど; けれども,けれど; けれども,"but, although",JLPT JLPT_N4,mDzGR2QZWc
+舟,ふね,"ship, boat",JLPT JLPT_N4,"B,m2(2B05a"
+動く,うごく,to move,JLPT JLPT_N4,F~}14d`>!6
+～(に) ついて,～(に) ついて,"about, concerning",JLPT JLPT_N4,"s~K|,g+o=("
+コンサート,コンサート,concert,Genki Genki_Ln.9 JLPT JLPT_N4,c-Fil]C?m3
+虫,むし,insect,JLPT JLPT_N4,gn!@amuoHx
+優しい,やさしい,"kind (person), gentle (person), easy (problem)",Genki Genki_Ln.5 JLPT JLPT_N4,gfbdYDbw~Y
+コンピュータ; コンピューター,コンピュータ; コンピューター,computer,JLPT JLPT_N4,i=KlAInS10
+植える,うえる,to plant,JLPT JLPT_N4,M>_C}7!LEs
+両方,りょうほう,"both sides, both parties",JLPT JLPT_N4,w+8nx7:F3*
+汚れる,よごれる,to become dirty,JLPT JLPT_N4,yxTJ>uc(`r
+水泳,すいえい,swimming,JLPT JLPT_N4,p8o.J&l.y:
+経験,けいけんする,experience,JLPT JLPT_N4,f+zL`Y7buD
+勝つ,かつ,to win,JLPT JLPT_N4,vi?&`a{.eH
+砂,すな,sand,JLPT JLPT_N4,"v^,Hr#Vg!e"
+警察,けいさつ,police; police station,Genki Genki_Ln.21 JLPT JLPT_N4,Cqbq5lE;g6
+取り替える,とりかえる,"to exchange, to replace",JLPT JLPT_N4,fAPL%{p!|p
+急ぐ,いそぐ,"to hurry, to be in a hurry, to rush",Genki Genki_Ln.6 Intermediate_Japanese_Ln.2 JLPT JLPT_N4,C+o)~b82kd
+簡単,かんたん,simple,JLPT JLPT_N4,oG^L}3iGdF
+参る,まいる,humble expression for 行く and 来る,Genki Genki_Ln.20 Intermediate_Japanese_Ln.6 JLPT JLPT_N4,dY_fG(MyTI
+全然,ぜんぜん,"not at all; wholly, entirely",JLPT JLPT_N4,iJGs=<smMr
+特別,とくべつ,special,JLPT JLPT_N4,w*:rZ|MXHf
+復習,ふくしゅう,"review (of lessons), revision",JLPT JLPT_N4,O40vK?08(g
+間に合う,まにあう,to be in time for,JLPT JLPT_N4,l3xWb^IMb
+役に立つ,やくにたつ,"to be helpful, to be useful",Intermediate_Japanese_Ln.4 JLPT JLPT_N4,Bodoj{2=?#
+もうすぐ,もうすぐ,very soon; in a few moments; days,Genki Genki_Ln.12 JLPT JLPT_N4,cr{2h{c->
+真中,まんなか,"middle, center",JLPT JLPT_N4,R5Bu:`G<@
+戻る,もどる,to return (v.i.); to come back,Genki Genki_Ln.20 Intermediate_Japanese_Ln.8 JLPT JLPT_N4,g9-rOAl2<k
+研究,けんきゅう,"study, research, investigation",JLPT JLPT_N4,"r,JjBHrK!8"
+ケーキ,ケーキ,cake,Genki Genki_Ln.13 JLPT JLPT_N4,iADgmRoi>q
+草,くさ,grass,JLPT JLPT_N4,CRSs:E15FF
+込む,こむ,to be crowded,JLPT JLPT_N4,C3zU]</XPv
+この頃,このごろ,"these days, nowadays",Genki Genki_Ln.10 JLPT JLPT_N4,F2eeT8$KYX
+訪ねる,たずねる,to visit,JLPT JLPT_N4,l{^{>8a$f>
+下げる,さげる,to lower (v.t.); to hang,Intermediate_Japanese_Ln.2 JLPT JLPT_N4,mC:cy`3AnB
+花見,はなみ,cherry-blossom viewing,JLPT JLPT_N4,ulvW_e[_zQ
+途中,とちゅう,"on the way, midway",JLPT JLPT_N4,"qP[3T,bvTy"
+入院,にゅういんする,hospitalization,JLPT JLPT_N4,iB?^g:!ksb
+乗り換える,のりかえる,"to transfer (trains), to change (bus, train, etc.)",JLPT JLPT_N4,Fu#~2.ajY<
+別れる,わかれる,"to part from, to separate",JLPT JLPT_N4,ova[fXA&]m
+～町,～ちょう,the town of ~,JLPT JLPT_N4,"mf84}],`T,"
+安全,あんぜん,"safety, security",JLPT JLPT_N4,x>KuTt~>`B
+看護婦,かんごふ,(female) nurse,JLPT JLPT_N4,Mvt??7-[{v
+見物,けんぶつ,sightseeing,JLPT JLPT_N4,z/6V9+.-]v
+相談,そうだんする,consultation,JLPT JLPT_N4,"h,~$1#Tmi]"
+ガソリンスタンド,ガソリンスタンド,"gas station, service station",JLPT JLPT_N4,NoACr|m()D
+テニス,テニス,tennis,Genki Genki_Ln.3 JLPT JLPT_N4,Bm|4X!fT~f
+眠る,ねむる,to sleep,JLPT JLPT_N4,H2kKiMD`}M
+上がる,あがる,"to rise, to go up",JLPT JLPT_N4,cvVez@U$xD
+翻訳,ほんやく,translation,Intermediate_Japanese_Ln.8 JLPT JLPT_N4,q5u{4?O6M1
+食事,しょくじする,meal,JLPT JLPT_N4,K<!4=Wx(&)
+お陰,おかげ,thanks or owing to,JLPT JLPT_N4,y:GH2MLVp!
+娘,むすめ,daughter (humble),JLPT JLPT_N4,D>Uc.0t(Pv
+湯,ゆ,hot water,JLPT JLPT_N4,qZk(zY%Dgg
+競争,きょうそう,"competition, contest",JLPT JLPT_N4,G%KC6%zs?X
+会議,かいぎ,business meeting; conference,Genki Genki_Ln.21 JLPT JLPT_N4,O^:<Y%-[JT
+湖,みずうみ,lake,Genki Genki_Ln.11 Intermediate_Japanese_Ln.4 JLPT JLPT_N4,pP3.DL~IX-
+集まる,あつまる,"to gather (v.i.), to collect",Intermediate_Japanese_Ln.7 JLPT JLPT_N4,dj|VykRm7g
+～にくい,～にくい,difficult to do ~,JLPT JLPT_N4,m7`CbDBUYU
+生活,せいかつする,"living, life; to live",JLPT JLPT_N4,w`Fz_<nW/g
+糸,いと,thread,JLPT JLPT_N4,IpR-(E.>}{
+関係,かんけい,"relation(ship), connection",JLPT JLPT_N4,A95yiv24#q
+ピアノ,ピアノ,piano,Genki Genki_Ln.9 JLPT JLPT_N4,l~WqV~#3P+
+～目,～め,"number ~ sequence, ~nd; ~th",JLPT JLPT_N4,E~pd/+U#PU
+番組,ばんぐみ,broadcast program,Genki Genki_Ln.15 JLPT JLPT_N4,A~P5;`m>{J
+急,きゅう,"urgent, sudden; steep",JLPT JLPT_N4,tI;p#VWdsZ
+棚,たな,"shelves, rack",JLPT JLPT_N4,u[EB{0+w?@
+木綿,もめん,cotton,JLPT JLPT_N4,C1;C=MJBjh
+輸出,ゆしゅつする,export,JLPT JLPT_N4,tgSB[Csamk
+タイプ,タイプ,"type, style",JLPT JLPT_N4,GKLj7~1p[w
+すり,すり,pickpocket,JLPT JLPT_N4,"LZR2]zL[V,"
+嬉しい,うれしい,to be happy; to be glad,Genki Genki_Ln.13 JLPT JLPT_N4,"d;<k5,X?rJ"
+アルコール,アルコール,alcohol,JLPT JLPT_N4,g3}Or~C[qU
+ソフト,ソフト,soft; soft hat; software,JLPT JLPT_N4,D1{]Y{P=2b
+神社,じんじゃ,Shinto shrine,JLPT JLPT_N4,"p-k,[(f(jy"
+大分,だいぶ,"fairly well, to a large extent, considerably, pretty much",Intermediate_Japanese_Ln.4 JLPT JLPT_N4,F=YkB>ku|#
+楽しみ,たのしみ,"pleasure, joy",JLPT JLPT_N4,bsnv=TM#%{
+趣味,しゅみ,hobby; pastime,Genki Genki_Ln.20 JLPT JLPT_N4,NkyAEs05(h
+電報,でんぽう,telegram,JLPT JLPT_N4,d~+A[2;3vQ
+家内,かない,(one's own) wife,Intermediate_Japanese_Ln.7 JLPT JLPT_N4,JMHIMXzaOu
+指,ゆび,finger,JLPT JLPT_N4,mOnb%$R^21
+これから,これから,"from now on, after this",JLPT JLPT_N4,xyC3_bE-{d
+たまに,たまに,occasionally,JLPT JLPT_N4,Op~e1|~DMP
+社会,しゃかい,society,JLPT JLPT_N4,br3q(Z|Zbk

--- a/src/n5.csv
+++ b/src/n5.csv
@@ -1,719 +1,719 @@
-expression,reading,meaning,tags
-ああ,ああ,"Ah!, Oh!",JLPT JLPT_4 JLPT_5 JLPT_N5
-会う,あう,"to meet, to see",JLPT JLPT_3 JLPT_5 JLPT_N5
-青,あお,blue,JLPT JLPT_5 JLPT_N5
-青い,あおい,blue,Genki Genki_Ln.9 JLPT JLPT_5 JLPT_N5
-赤,あか,red,JLPT JLPT_5 JLPT_N5
-赤い,あかい,red,Genki Genki_Ln.9 Intermediate_Japanese Intermediate_Japanese_Ln.12 JLPT JLPT_5 JLPT_N5
-明るい,あかるい,bright (in reference to personality or weather); cheerful,Genki Genki_Ln.18 Intermediate_Japanese Intermediate_Japanese_Ln.11 JLPT JLPT_5 JLPT_N5
-秋,あき,fall (season),Genki Genki_Ln.10 Intermediate_Japanese Intermediate_Japanese_Ln.4 JLPT JLPT_3 JLPT_5 JLPT_N5
-開く,あく,"to open, to become open",JLPT JLPT_3 JLPT_5 JLPT_N5
-開ける,あける,to open (v.t.),Intermediate_Japanese Intermediate_Japanese_Ln.12 JLPT JLPT_3 JLPT_5 JLPT_N5
-上げる,あげる,"to raise, to lift",JLPT JLPT_3 JLPT_5 JLPT_N5
-朝,あさ,morning,Genki Genki_Ln.3 Intermediate_Japanese Intermediate_Japanese_Ln.2 JLPT JLPT_5 JLPT_N5
-朝御飯,あさごはん,breakfast,Genki Genki_Ln.3 JLPT JLPT_5 JLPT_N5
-明後日,あさって,day after tomorrow,JLPT JLPT_5 JLPT_N5
-足; 脚,あし,foot; leg,JLPT JLPT_5 JLPT_N5
-明日,あした,tomorrow,Genki Genki_Ln.3 Intermediate_Japanese Intermediate_Japanese_Ln.7 JLPT JLPT_3 JLPT_5 JLPT_N5
-あそこ,あそこ,"there, over there, that place",Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5
-遊ぶ,あそぶ,to play; to spend time pleasantly; to hang out,Genki Genki_Ln.6 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5
-暖かい,あたたかい,warm,JLPT_N5
-頭,あたま,head,Intermediate_Japanese Intermediate_Japanese_Ln.2 JLPT JLPT_5 JLPT_N5
-新しい,あたらしい,new,Genki Genki_Ln.5 JLPT JLPT_5 JLPT_N5
-あちら,あちら,this way (polite),Genki Genki_Ln.20 JLPT JLPT_5 JLPT_N5
-暑い,あつい,"hot (in reference to weather), warm",Genki Genki_Ln.5 Intermediate_Japanese Intermediate_Japanese_Ln.4 JLPT JLPT_5 JLPT_N5
-熱い,あつい,hot (objects),Genki Genki_Ln.5 JLPT JLPT_5 JLPT_N5
-厚い,あつい,"kind, warm(hearted), thick, deep",JLPT JLPT_5 JLPT_N5
-あっち,あっち,over there,JLPT JLPT_5 JLPT_N5
-後,あと,afterwards (later); in the future; the rest; since then,Genki Genki_Ln.18 JLPT JLPT_2 JLPT_3 JLPT_5 JLPT_N5
-あなた,あなた,you,Genki Genki_Ln.4 JLPT JLPT_5 JLPT_N5
-兄,あに,(my) older brother (humble),Genki Genki_Ln.14 JLPT JLPT_5 JLPT_N5
-姉,あね,(my) older sister (humble),Genki Genki_Ln.7 JLPT JLPT_5 JLPT_N5
-アパート,アパート,apartment (abbr.),Genki Genki_Ln.7 JLPT JLPT_5 JLPT_N5
-あの,あの,"that over there; like that, that way; um...",JLPT JLPT_4 JLPT_5 JLPT_N5
-浴びる,あびる,"to bathe, to shower",JLPT JLPT_3 JLPT_5 JLPT_N5
-危ない,あぶない,"dangerous, critical",Intermediate_Japanese Intermediate_Japanese_Ln.15 JLPT JLPT_5 JLPT_N5
-甘い,あまい,"generous, sweet",Genki Genki_Ln.12 JLPT JLPT_5 JLPT_N5
-余り,あまり,not very; surplus,JLPT JLPT_3 JLPT_5 JLPT_N5
-雨,あめ,rain,Genki Genki_Ln.8 JLPT JLPT_5 JLPT_N5
-飴,あめ,(hard) candy,JLPT JLPT_5 JLPT_N5
-洗う,あらう,to wash,Genki Genki_Ln.8 Intermediate_Japanese Intermediate_Japanese_Ln.10 JLPT JLPT_5 JLPT_N5
-在る,ある,"to be, to have",JLPT JLPT_3 JLPT_5 JLPT_N5
-有る,ある,"to be, to have",JLPT JLPT_3 JLPT_5 JLPT_N5
-歩く,あるく,to walk,Genki Genki_Ln.20 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5
-あれ,あれ,that one (over there),Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5
-いい; よい,いい; よい,good,JLPT JLPT_5 JLPT_N5
-いいえ,いいえ,"no, not at all",JLPT JLPT_5 JLPT_N5
-言う,いう,to say,Genki Genki_Ln.8 JLPT JLPT_5 JLPT_N5
-家,いえ,"house, home",Genki Genki_Ln.3 JLPT JLPT_2 JLPT_3 JLPT_5 JLPT_N5
-いかが,いかが,"how, in what way",JLPT JLPT_5 JLPT_N5
-行く,いく; ゆく,to go,JLPT JLPT_5 JLPT_N5
-いくつ,いくつ,"how many, how old",JLPT JLPT_3 JLPT_5 JLPT_N5
-いくら,いくら,"how much, how many",Genki Genki_Ln.2 JLPT JLPT_3 JLPT_5 JLPT_N5
-池,いけ,pond,JLPT JLPT_5 JLPT_N5
-医者,いしゃ,doctor; physician,Genki Genki_Ln.1 Genki_Ln.10 Intermediate_Japanese Intermediate_Japanese_Ln.12 JLPT JLPT_5 JLPT_N5
-椅子,いす,chair,JLPT JLPT_3 JLPT_5 JLPT_N5
-忙しい,いそがしい,"busy (people, days)",Genki Genki_Ln.5 JLPT JLPT_5 JLPT_N5
-痛い,いたい,hurt; painful; sore,Genki Genki_Ln.12 Intermediate_Japanese Intermediate_Japanese_Ln.5 JLPT JLPT_5 JLPT_N5
-一,いち,one,JLPT JLPT_3 JLPT_5 JLPT_N5
-一日,いちにち,one day (duration),Genki Genki_Ln.13 JLPT JLPT_5 JLPT_N5
-一番,いちばん,"best (most), first, number one",Genki Genki_Ln.10 Intermediate_Japanese Intermediate_Japanese_Ln.3 JLPT JLPT_3 JLPT_5 JLPT_N5
-いつ,いつ,when,Genki Genki_Ln.3 JLPT JLPT_2 JLPT_5 JLPT_N5
-五日,いつか,five days; fifth day of the month,Genki Genki_Ln.13 JLPT JLPT_3 JLPT_5 JLPT_N5
-一緒,いっしょ,together,Intermediate_Japanese Intermediate_Japanese_Ln.7 JLPT JLPT_5 JLPT_N5
-五つ,いつつ,five things,Genki Genki_Ln.9 JLPT JLPT_5 JLPT_N5
-いつも,いつも,"always, usually, every time, never (with neg. verb)",Genki Genki_Ln.12 JLPT JLPT_3 JLPT_5 JLPT_N5
-犬,いぬ,dog,Genki Genki_Ln.4 JLPT JLPT_5 JLPT_N5
-今,いま,now,Genki Genki_Ln.1 JLPT JLPT_3 JLPT_5 JLPT_N5
-意味,いみ,"meaning, significance",Genki Genki_Ln.12 Intermediate_Japanese Intermediate_Japanese_Ln.2 JLPT JLPT_5 JLPT_N5
-妹,いもうと,younger sister (humble),Genki Genki_Ln.1 Genki_Ln.7 JLPT JLPT_5 JLPT_N5
-嫌,いや,"disagreeable, detestable, unpleasant",JLPT JLPT_3 JLPT_5 JLPT_N5
-入口,いりぐち,entrance,JLPT JLPT_5 JLPT_N5
-居る,いる,"(humble) to be (animate), to exist",JLPT JLPT_5 JLPT_N5
-要る,いる,to need,JLPT JLPT_5 JLPT_N5
-入れる,いれる,to put in,JLPT JLPT_5 JLPT_N5
-色,いろ,color,Genki Genki_Ln.9 Intermediate_Japanese Intermediate_Japanese_Ln.9 JLPT JLPT_5 JLPT_N5
-色々,いろいろ,various,JLPT JLPT_5 JLPT_N5
-上,うえ,"above (up, top, etc.), over, on top of",JLPT JLPT_2 JLPT_5 JLPT_N5
-後ろ,うしろ,"back, behind, rear",JLPT JLPT_3 JLPT_5 JLPT_N5
-薄い,うすい,"thin, weak",JLPT JLPT_3 JLPT_5 JLPT_N5
-歌,うた,a song,Genki Genki_Ln.7 JLPT JLPT_5 JLPT_N5
-歌う,うたう,to sing,Genki Genki_Ln.7 Intermediate_Japanese Intermediate_Japanese_Ln.7 JLPT JLPT_5 JLPT_N5
-うち,うち,home; house; my place,Genki Genki_Ln.3 JLPT JLPT_3 JLPT_5 JLPT_N5
-生まれる,うまれる,to be born,JLPT JLPT_3 JLPT_5 JLPT_N5
-海,うみ,"sea, beach",Genki Genki_Ln.5 JLPT JLPT_5 JLPT_N5
-売る,うる,to sell (v.t.),Genki Genki_Ln.15 Intermediate_Japanese Intermediate_Japanese_Ln.6 JLPT JLPT_3 JLPT_5 JLPT_N5
-うるさい,うるさい,noisy; annoying,Genki Genki_Ln.22 JLPT JLPT_3 JLPT_5 JLPT_N5
-上着,うわぎ,"coat, jacket",JLPT JLPT_5 JLPT_N5
-絵,え,a painting; a picture; a drawing,Genki Genki_Ln.15 JLPT JLPT_3 JLPT_5 JLPT_N5
-映画,えいが,"movie, film",Genki Genki_Ln.3 Intermediate_Japanese Intermediate_Japanese_Ln.7 JLPT JLPT_5 JLPT_N5
-映画館,えいがかん,"movie theater, cinema",Genki Genki_Ln.15 JLPT JLPT_5 JLPT_N5
-英語,えいご,English (language),Genki Genki_Ln.1 JLPT JLPT_5 JLPT_N5
-ええ,ええ,yes,Genki Genki_Ln.1 JLPT JLPT_5 JLPT_N5
-駅,えき,station,Genki Genki_Ln.10 JLPT JLPT_5 JLPT_N5
-エレベーター,エレベーター,elevator,JLPT JLPT_2 JLPT_5 JLPT_N5
-～円,～えん,Yen,JLPT JLPT_5 JLPT_N5
-鉛筆,えんぴつ,pencil,Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5
-お～,お～,honorable ~ (honorific),JLPT JLPT_5 JLPT_N5
-美味しい,おいしい,"delicious, tasty",JLPT JLPT_5 JLPT_N5
-多い,おおい,many; there are a lot,Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5
-大きい,おおきい,"big, large",Genki Genki_Ln.5 JLPT JLPT_5 JLPT_N5
-大きな,おおきな,big,JLPT JLPT_5 JLPT_N5
-大勢,おおぜい,great number of people,JLPT JLPT_5 JLPT_N5
-お母さん,おかあさん,mother (formal),Genki Genki_Ln.1 Genki_Ln.2 JLPT JLPT_5 JLPT_N5
-お菓子,おかし,"confections, sweets, snack",Genki Genki_Ln.11 JLPT JLPT_5 JLPT_N5
-お金,おかね,money,Genki Genki_Ln.6 JLPT JLPT_5 JLPT_N5
-起きる,おきる,"to get up (e.g., from sleeping); to happen",Genki Genki_Ln.3 Intermediate_Japanese Intermediate_Japanese_Ln.12 JLPT JLPT_3 JLPT_5 JLPT_N5
-置く,おく,to put; to lay; to place,Genki Genki_Ln.21 JLPT JLPT_3 JLPT_5 JLPT_N5
-奥さん,おくさん,(someone else's) wife (hon.),Genki Genki_Ln.14 Intermediate_Japanese Intermediate_Japanese_Ln.9 JLPT JLPT_5 JLPT_N5
-お酒,おさけ,sake; alcohol,Genki Genki_Ln.3 JLPT JLPT_5 JLPT_N5
-お皿,おさら,"plate, dish",JLPT JLPT_5 JLPT_N5
-伯父; 叔父さん,おじさん,"uncle, middle-aged man",JLPT JLPT_5 JLPT_N5
-おじいさん,おじいさん,"grandfather, male senior citizen",Genki Genki_Ln.13 JLPT JLPT_3 JLPT_5 JLPT_N5
-教える,おしえる,"to teach, to inform, to instruct",Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5
-押す,おす,"to push, to press, to stamp (e.g., a passport)",Genki Genki_Ln.18 JLPT JLPT_5 JLPT_N5
-遅い,おそい,slow; (to be) late,Genki Genki_Ln.10 Intermediate_Japanese Intermediate_Japanese_Ln.11 JLPT JLPT_5 JLPT_N5
-お茶,おちゃ,(green) tea,Genki Genki_Ln.3 Intermediate_Japanese Intermediate_Japanese_Ln.6 JLPT JLPT_5 JLPT_N5
-お手洗い,おてあらい,"toilet, restroom, bathroom (lit., a place to wash one's hands)",Genki Genki_Ln.2 Intermediate_Japanese Intermediate_Japanese_Ln.13 JLPT JLPT_5 JLPT_N5
-お父さん,おとうさん,father (formal),Genki Genki_Ln.1 Genki_Ln.2 JLPT JLPT_5 JLPT_N5
-弟,おとうと,younger brother,Genki Genki_Ln.1 Genki_Ln.7 JLPT JLPT_5 JLPT_N5
-男,おとこ,"man, male",Genki Genki_Ln.17 JLPT JLPT_5 JLPT_N5
-男の子,おとこのこ,boy,Genki Genki_Ln.11 JLPT JLPT_5 JLPT_N5
-一昨日,おととい,the day before yesterday,Genki Genki_Ln.19 JLPT JLPT_5 JLPT_N5
-おととし,おととし,year before last,JLPT JLPT_5 JLPT_N5
-大人,おとな,adult,Genki Genki_Ln.13 JLPT JLPT_5 JLPT_N5
-お腹,おなか,stomach,JLPT JLPT_3 JLPT_5 JLPT_N5
-同じ,おなじ,"same, identical",Genki Genki_Ln.14 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5
-お兄さん,おにいさん,(someone else's) older brother (formal),Genki Genki_Ln.1 Genki_Ln.7 Intermediate_Japanese Intermediate_Japanese_Ln.4 JLPT JLPT_5 JLPT_N5
-お姉さん,おねえさん,older sister (formal),Genki Genki_Ln.1 Genki_Ln.7 JLPT JLPT_5 JLPT_N5
-伯母さん; 叔母さん,おばさん,aunt,JLPT JLPT_5 JLPT_N5
-おばあさん,おばあさん,"grandmother, female senior-citizen",Genki Genki_Ln.6 JLPT JLPT_5 JLPT_N5
-お風呂,おふろ,a bath,JLPT_N5
-お弁当,おべんとう,a boxed lunch,Genki Genki_Ln.9 JLPT JLPT_5 JLPT_N5
-覚える,おぼえる,"to learn, to commit to memory, to remember, to memorize",Intermediate_Japanese Intermediate_Japanese_Ln.2 JLPT JLPT_5 JLPT_N5
-おまわりさん,おまわりさん,policeman (friendly term),JLPT JLPT_5 JLPT_N5
-重い,おもい,heavy; serious,Genki Genki_Ln.20 JLPT JLPT_3 JLPT_5 JLPT_N5
-面白い,おもしろい,"interesting, amusing",Genki Genki_Ln.5 Intermediate_Japanese Intermediate_Japanese_Ln.4 JLPT JLPT_5 JLPT_N5
-泳ぐ,およぐ,to swim,Genki Genki_Ln.5 JLPT JLPT_5 JLPT_N5
-降りる,おりる,to get off,JLPT JLPT_3 JLPT_5 JLPT_N5
-終る,おわる,"to finish, to close",JLPT JLPT_5 JLPT_N5
-音楽,おんがく,Music,Genki Genki_Ln.3 Intermediate_Japanese Intermediate_Japanese_Ln.3 JLPT JLPT_5 JLPT_N5
-女,おんな,"woman, female",Genki Genki_Ln.17 JLPT JLPT_5 JLPT_N5
-女の子,おんなのこ,girl,Genki Genki_Ln.11 JLPT JLPT_5 JLPT_N5
-～回,～かい,counter for occurrences (~ times),JLPT JLPT_1 JLPT_5 JLPT_N5
-～階,～かい,counter for stories (floors) of a building,JLPT JLPT_4 JLPT_5 JLPT_N5
-外国,がいこく,foreign country; abroad,Genki Genki_Ln.11 Intermediate_Japanese Intermediate_Japanese_Ln.6 JLPT JLPT_5 JLPT_N5
-外国人,がいこくじん,foreigner,Genki Genki_Ln.15 JLPT JLPT_5 JLPT_N5
-会社,かいしゃ,"company, corporation",Genki Genki_Ln.7 JLPT JLPT_5 JLPT_N5
-階段,かいだん,stairs,JLPT JLPT_5 JLPT_N5
-買い物,かいもの,shopping,Genki Genki_Ln.4 JLPT JLPT_5 JLPT_N5
-買う,かう,to buy,JLPT JLPT_3 JLPT_5 JLPT_N5
-返す,かえす,to return something,JLPT JLPT_3 JLPT_5 JLPT_N5
-帰る,かえる,"to go back, to go home, to return",Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_3 JLPT_5 JLPT_N5
-顔,かお,face (body part),Genki Genki_Ln.10 Intermediate_Japanese Intermediate_Japanese_Ln.2 JLPT JLPT_3 JLPT_5 JLPT_N5
-かかる,かかる,"it takes (amount of time, money) (v.i.)",Genki Genki_Ln.10 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_3 JLPT_5 JLPT_N5
-鍵,かぎ,a lock; a key,Genki Genki_Ln.17 JLPT JLPT_3 JLPT_5 JLPT_N5
-書く,かく,to write,JLPT JLPT_3 JLPT_5 JLPT_N5
-学生,がくせい,student,Genki Genki_Ln.1 JLPT JLPT_5 JLPT_N5
-～か月,～かげつ,(number of) months,JLPT JLPT_5 JLPT_N5
-掛ける,かける,"to put on (e.g., glasses); to hang (e.g., on a wall)",JLPT JLPT_3 JLPT_4 JLPT_5 JLPT_N5
-かける,かける,"to dial/call (e.g., phone); to sit down",Genki Genki_Ln.19 JLPT JLPT_3 JLPT_4 JLPT_5 JLPT_N5
-傘,かさ,"umbrella, parasol",Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5
-貸す,かす,to lend,Intermediate_Japanese Intermediate_Japanese_Ln.3 JLPT JLPT_5 JLPT_N5
-風,かぜ,"wind, breeze",Genki Genki_Ln.22 JLPT JLPT_5 JLPT_N5
-風邪,かぜ,"cold, flu",Genki Genki_Ln.12 JLPT JLPT_5 JLPT_N5
-方,かた,-- honorific form for 人 (ひと) --; way of doing,Intermediate_Japanese Intermediate_Japanese_Ln.4 JLPT JLPT_3 JLPT_4 JLPT_5 JLPT_N5
-家族,かぞく,"family, members of a family",Genki Genki_Ln.7 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5
-片仮名,かたかな,katakana,JLPT JLPT_5 JLPT_N5
-～月,～がつ,month of year,JLPT JLPT_5 JLPT_N5
-学校,がっこう,a school,Genki Genki_Ln.3 JLPT JLPT_5 JLPT_N5
-カップ,カップ,cup,JLPT JLPT_1 JLPT_5 JLPT_N5
-家庭,かてい,home; family,Intermediate_Japanese Intermediate_Japanese_Ln.3 JLPT JLPT_3 JLPT_5 JLPT_N5
-角,かど,"corner (e.g., desk, pavement)",Genki Genki_Ln.20 JLPT JLPT_5 JLPT_N5
-かばん,かばん,"bag, basket",Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5
-花瓶,かびん,(flower) vase,JLPT JLPT_5 JLPT_N5
-かぶる,かぶる,"to wear, to put on (e.g., a hat on the head)",Genki Genki_Ln.7 JLPT JLPT_3 JLPT_5 JLPT_N5
-紙,かみ,paper,Genki Genki_Ln.17 JLPT JLPT_3 JLPT_5 JLPT_N5
-カメラ,カメラ,camera,Genki Genki_Ln.8 JLPT JLPT_5 JLPT_N5
-火曜日,かようび,Tuesday,Genki Genki_Ln.4 JLPT JLPT_5 JLPT_N5
-辛い,からい,hot and spicy; salty,Genki Genki_Ln.13 JLPT JLPT_5 JLPT_N5
-体,からだ,body; health,Genki Genki_Ln.23 Intermediate_Japanese Intermediate_Japanese_Ln.4 JLPT JLPT_5 JLPT_N5
-借りる,かりる,"to borrow, to owe",JLPT JLPT_5 JLPT_N5
-～がる,～がる,feel,JLPT JLPT_5 JLPT_N5
-軽い,かるい,"light, non-serious, minor",JLPT JLPT_5 JLPT_N5
-カレー,カレー,curry (abbr. for curry and rice),Genki Genki_Ln.13 JLPT JLPT_1 JLPT_5 JLPT_N5
-カレンダー,カレンダー,calendar,JLPT JLPT_5 JLPT_N5
-川; 河,かわ,river,JLPT JLPT_3 JLPT_5 JLPT_N5
-～側,～がわ,~ side,JLPT_N5
-可愛い,かわいい,"cute, adorable",JLPT JLPT_5 JLPT_N5
-漢字,かんじ,kanji; Chinese character,Genki Genki_Ln.6 Intermediate_Japanese Intermediate_Japanese_Ln.4 JLPT JLPT_3 JLPT_5 JLPT_N5
-木,き,"tree, wood, timber",Genki Genki_Ln.22 JLPT JLPT_5 JLPT_N5
-黄色,きいろ,yellow,JLPT JLPT_5 JLPT_N5
-黄色い,きいろい,yellow,JLPT JLPT_5 JLPT_N5
-消える,きえる,"to vanish, to disappear",Genki Genki_Ln.18 JLPT JLPT_5 JLPT_N5
-聞く,きく,"to hear, to listen, to ask",JLPT JLPT_3 JLPT_5 JLPT_N5
-北,きた,north,Intermediate_Japanese Intermediate_Japanese_Ln.10 JLPT JLPT_5 JLPT_N5
-ギター,ギター,guitar,Genki Genki_Ln.9 JLPT JLPT_5 JLPT_N5
-汚い,きたない,"dirty, unclean, filthy",Genki Genki_Ln.16 JLPT JLPT_5 JLPT_N5
-喫茶店,きっさてん,café,Genki Genki_Ln.2 Intermediate_Japanese Intermediate_Japanese_Ln.11 JLPT JLPT_5 JLPT_N5
-切手,きって,postal (postage) stamps,Genki Genki_Ln.5 Intermediate_Japanese Intermediate_Japanese_Ln.3 JLPT JLPT_5 JLPT_N5
-切符,きっぷ,a ticket,Genki Genki_Ln.5 Intermediate_Japanese Intermediate_Japanese_Ln.10 JLPT JLPT_5 JLPT_N5
-昨日,きのう,yesterday,Genki Genki_Ln.4 JLPT JLPT_3 JLPT_5 JLPT_N5
-九,きゅう,nine,JLPT JLPT_3 JLPT_5 JLPT_N5
-牛肉,ぎゅうにく,beef,JLPT JLPT_5 JLPT_N5
-牛乳,ぎゅうにゅう,milk,Genki Genki_Ln.18 JLPT JLPT_5 JLPT_N5
-今日,きょう,"today, this day",Genki Genki_Ln.3 JLPT JLPT_5 JLPT_N5
-教室,きょうしつ,classroom,Intermediate_Japanese Intermediate_Japanese_Ln.3 JLPT JLPT_5 JLPT_N5
-兄弟,きょうだい,"siblings (humble), brothers and sisters",Genki Genki_Ln.7 JLPT JLPT_5 JLPT_N5
-去年,きょねん,last year,Genki Genki_Ln.14 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5
-嫌い,きらい,dislike,JLPT JLPT_5 JLPT_N5
-切る,きる,to cut; to hang up (a phone),Genki Genki_Ln.8 Intermediate_Japanese Intermediate_Japanese_Ln.12 JLPT JLPT_5 JLPT_N5
-着る,きる,to put on (clothes above your waist); to wear,Genki Genki_Ln.7 Intermediate_Japanese Intermediate_Japanese_Ln.9 JLPT JLPT_5 JLPT_N5
-綺麗,きれい,"pretty, clean, tidy",JLPT JLPT_5 JLPT_N5
-キロ; キログラム,キロ; キログラム,(abbr.) kilo (kilogram),JLPT JLPT_3 JLPT_5 JLPT_N5
-キロ; キロメートル,キロ; キロメートル,(abbr.) kilo (kilometer),JLPT JLPT_3 JLPT_5 JLPT_N5
-銀行,ぎんこう,bank,Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5
-金曜日,きんようび,Friday,Genki Genki_Ln.4 JLPT JLPT_3 JLPT_5 JLPT_N5
-九,く,nine,JLPT JLPT_3 JLPT_5 JLPT_N5
-薬,くすり,medicine,Genki Genki_Ln.9 Intermediate_Japanese Intermediate_Japanese_Ln.12 JLPT JLPT_5 JLPT_N5
-下さい,ください,(with te-form verb) please do for me,JLPT JLPT_5 JLPT_N5
-果物,くだもの,fruit,Intermediate_Japanese Intermediate_Japanese_Ln.9 JLPT JLPT_5 JLPT_N5
-口,くち,job opening; mouth,Intermediate_Japanese Intermediate_Japanese_Ln.11 Intermediate_Japanese_Ln.8 JLPT JLPT_5 JLPT_N5
-靴,くつ,"shoes, footwear",Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5
-靴下,くつした,socks,Genki Genki_Ln.23 JLPT JLPT_5 JLPT_N5
-国,くに,country; place of origin,Genki Genki_Ln.7 JLPT JLPT_5 JLPT_N5
-曇り,くもり,"cloudiness, cloudy weather",Genki Genki_Ln.12 JLPT JLPT_3 JLPT_5 JLPT_N5
-曇る,くもる,"to become cloudy, to become dim",JLPT JLPT_5 JLPT_N5
-暗い,くらい,"dark, gloomy",JLPT JLPT_3 JLPT_5 JLPT_N5
-～くらい; ぐらい,～くらい; ぐらい,approximate (quantity),JLPT JLPT_5 JLPT_N5
-クラス,クラス,a class,Genki Genki_Ln.4 JLPT JLPT_5 JLPT_N5
-グラム,グラム,gram,JLPT JLPT_5 JLPT_N5
-来る,くる,to come,JLPT JLPT_5 JLPT_N5
-車,くるま,"car, vehicle",Genki Genki_Ln.7 JLPT JLPT_5 JLPT_N5
-黒,くろ,black,JLPT JLPT_5 JLPT_N5
-黒い,くろい,black; dark,Genki Genki_Ln.9 JLPT JLPT_5 JLPT_N5
-警官,けいかん,police officer,JLPT JLPT_5 JLPT_N5
-今朝,けさ,this morning,Genki Genki_Ln.8 Intermediate_Japanese Intermediate_Japanese_Ln.2 JLPT JLPT_5 JLPT_N5
-消す,けす,"to erase, to delete, to turn off power",JLPT JLPT_5 JLPT_N5
-結構,けっこう,"splendid; enough, tolerably",JLPT JLPT_3 JLPT_5 JLPT_N5
-結婚,けっこん (する),marriage (get married),JLPT JLPT_5 JLPT_N5
-月曜日,げつようび,Monday,Genki Genki_Ln.4 JLPT JLPT_3 JLPT_5 JLPT_N5
-玄関,げんかん,entrance (to a house or a building),Intermediate_Japanese Intermediate_Japanese_Ln.5 JLPT JLPT_4 JLPT_5 JLPT_N5
-元気,げんき,"health(y), energetic",JLPT JLPT_5 JLPT_N5
-～個,～こ,"counter for small items (e.g., fruits, cups)",JLPT JLPT_2 JLPT_5 JLPT_N5
-五,ご,five,JLPT JLPT_3 JLPT_5 JLPT_N5
-～語,～ご,"word, language",JLPT JLPT_5 JLPT_N5
-公園,こうえん,a park,Genki Genki_Ln.4 JLPT JLPT_3 JLPT_5 JLPT_N5
-交差点,こうさてん,intersection,JLPT JLPT_5 JLPT_N5
-紅茶,こうちゃ,black tea,Genki Genki_Ln.13 JLPT JLPT_5 JLPT_N5
-交番,こうばん,police box,JLPT JLPT_5 JLPT_N5
-声,こえ,voice,Intermediate_Japanese Intermediate_Japanese_Ln.2 JLPT JLPT_5 JLPT_N5
-コート,コート,"coat; court (e.g., tennis)",JLPT JLPT_5 JLPT_N5
-コーヒー,コーヒー,coffee,Genki Genki_Ln.3 JLPT JLPT_5 JLPT_N5
-ここ,ここ,"here, this place",Genki Genki_Ln.4 JLPT JLPT_3 JLPT_5 JLPT_N5
-午後,ごご,"afternoon, P.M.",Genki Genki_Ln.1 JLPT JLPT_5 JLPT_N5
-九日,ここのか,nine days; ninth day of the month,Genki Genki_Ln.13 JLPT JLPT_5 JLPT_N5
-九つ,ここのつ,nine things,Genki Genki_Ln.9 JLPT JLPT_5 JLPT_N5
-午前,ごぜん,"morning, A.M.",Genki Genki_Ln.1 JLPT JLPT_5 JLPT_N5
-答える,こたえる,"to answer, to reply",JLPT JLPT_5 JLPT_N5
-こちら,こちら,this person (polite); this way (polite),Genki Genki_Ln.11 Genki_Ln.19 JLPT JLPT_5 JLPT_N5
-こっち,こっち,this person; this direction; this side,JLPT JLPT_4 JLPT_5 JLPT_N5
-コップ,コップ,a tumbler; a glass,Genki Genki_Ln.14 JLPT JLPT_5 JLPT_N5
-今年,ことし,this year,Genki Genki_Ln.10 JLPT JLPT_5 JLPT_N5
-言葉,ことば,language; word(s); expression(s),Genki Genki_Ln.13 Intermediate_Japanese Intermediate_Japanese_Ln.2 JLPT JLPT_5 JLPT_N5
-子供,こども,child(ren),Genki Genki_Ln.4 Intermediate_Japanese Intermediate_Japanese_Ln.2 JLPT JLPT_5 JLPT_N5
-この,この,this,JLPT JLPT_3 JLPT_5 JLPT_N5
-御飯,ごはん,rice (cooked); meal,Genki Genki_Ln.4 JLPT JLPT_5 JLPT_N5
-コピーする,コピーする,to copy,JLPT JLPT_3 JLPT_5 JLPT_N5
-困る,こまる,"to be bothered, to have difficulty",Genki Genki_Ln.16 JLPT JLPT_5 JLPT_N5
-これ,これ,this one,Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5
-～ころ; ～ごろ,～ころ; ～ごろ,"about, toward, approximately (time)",JLPT JLPT_5 JLPT_N5
-今月,こんげつ,this month,Genki Genki_Ln.8 JLPT JLPT_5 JLPT_N5
-今週,こんしゅう,this week,Genki Genki_Ln.6 JLPT JLPT_5 JLPT_N5
-こんな,こんな,"such, like this",JLPT JLPT_5 JLPT_N5
-今晩,こんばん,"tonight, this evening",Genki Genki_Ln.3 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5
-さあ,さあ,"come now, well",JLPT JLPT_5 JLPT_N5
-～歳,～さい,~ years old,JLPT JLPT_2 JLPT_5 JLPT_N5
-財布,さいふ,wallet,Genki Genki_Ln.2 Intermediate_Japanese Intermediate_Japanese_Ln.4 JLPT JLPT_5 JLPT_N5
-魚,さかな,fish,Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5
-先,さき,"future; recent, previous",JLPT JLPT_5 JLPT_N5
-咲く,さく,to bloom,Genki Genki_Ln.18 JLPT JLPT_3 JLPT_5 JLPT_N5
-作文,さくぶん,essay; composition,Genki Genki_Ln.9 JLPT JLPT_5 JLPT_N5
-差す,さす,"to raise (stretch out) hands, to raise (e.g., umbrella)",JLPT JLPT_3 JLPT_5 JLPT_N5
-～冊,～さつ,counter for books,JLPT JLPT_5 JLPT_N5
-雑誌,ざっし,"magazine, journal",Genki Genki_Ln.3 Intermediate_Japanese Intermediate_Japanese_Ln.8 JLPT JLPT_5 JLPT_N5
-砂糖,さとう,sugar,Genki Genki_Ln.16 JLPT JLPT_5 JLPT_N5
-寒い,さむい,cold (in reference to weather),Genki Genki_Ln.5 Intermediate_Japanese Intermediate_Japanese_Ln.2 JLPT JLPT_5 JLPT_N5
-さ来年,さらいねん,year after next,JLPT JLPT_5 JLPT_N5
-～さん,～さん,"Mr. ~, Ms. ~",JLPT JLPT_2 JLPT_5 JLPT_N5
-三,さん,three,JLPT JLPT_5 JLPT_N5
-散歩,さんぽ (する),"walk, stroll",JLPT JLPT_3 JLPT_5 JLPT_N5
-四,し,four,JLPT JLPT_3 JLPT_5 JLPT_N5
-～時,～じ,~ o'clock (time),JLPT JLPT_1 JLPT_5 JLPT_N5
-塩,しお,salt,JLPT JLPT_5 JLPT_N5
-しかし,しかし,however; but,Intermediate_Japanese Intermediate_Japanese_Ln.3 JLPT JLPT_5 JLPT_N5
-時間,じかん,time,Genki Genki_Ln.14 JLPT JLPT_2 JLPT_5 JLPT_N5
-～時間,～じかん,~ hours,JLPT JLPT_5 JLPT_N5
-仕事,しごと,"work, job, occupation, employment",Genki Genki_Ln.1 Genki_Ln.8 JLPT JLPT_5 JLPT_N5
-辞書,じしょ,dictionary,Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5
-静か,しずか,"quiet, calm",JLPT JLPT_5 JLPT_N5
-下,した,"under, below, beneath",JLPT JLPT_3 JLPT_5 JLPT_N5
-七,しち,seven,JLPT JLPT_3 JLPT_5 JLPT_N5
-質問,しつもん,"question, inquiry",Intermediate_Japanese Intermediate_Japanese_Ln.2 JLPT JLPT_5 JLPT_N5
-自転車,じてんしゃ,bicycle,Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5
-自動車,じどうしゃ,automobile,JLPT JLPT_5 JLPT_N5
-死ぬ,しぬ,to die,Genki Genki_Ln.6 JLPT JLPT_5 JLPT_N5
-字引,じびき,dictionary,JLPT JLPT_5 JLPT_N5
-自分,じぶん,"myself, oneself",Genki Genki_Ln.17 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5
-閉まる,しまる,"to close, to be closed",JLPT JLPT_5 JLPT_N5
-閉める,しめる,"to close, to shut",JLPT JLPT_3 JLPT_5 JLPT_N5
-締める,しめる,"to tie, to fasten, to tighten",JLPT JLPT_3 JLPT_5 JLPT_N5
-じゃ; じゃあ,じゃ; じゃあ,"well, well then",JLPT JLPT_3 JLPT_5 JLPT_N5
-写真,しゃしん,a picture; a photograph,Genki Genki_Ln.4 Intermediate_Japanese Intermediate_Japanese_Ln.4 JLPT JLPT_5 JLPT_N5
-シャツ,シャツ,shirt,Genki Genki_Ln.10 JLPT JLPT_5 JLPT_N5
-シャワー,シャワー,shower,JLPT JLPT_5 JLPT_N5
-十,じゅう,ten,JLPT JLPT_3 JLPT_5 JLPT_N5
-～中,～じゅう,"during, while",JLPT JLPT_2 JLPT_5 JLPT_N5
-～週間,～しゅうかん,~ weeks,JLPT JLPT_5 JLPT_N5
-授業,じゅぎょう,a class (of school),Genki Genki_Ln.11 Intermediate_Japanese Intermediate_Japanese_Ln.3 JLPT JLPT_2 JLPT_5 JLPT_N5
-宿題,しゅくだい,homework,Genki Genki_Ln.5 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5
-上手,じょうず,"be good at, skillful",JLPT JLPT_5 JLPT_N5
-丈夫,じょうぶ,"strong, solid, durable",JLPT JLPT_5 JLPT_N5
-醤油,しょうゆ,soy sauce,Genki Genki_Ln.18 JLPT JLPT_5 JLPT_N5
-食堂,しょくどう,"cafeteria, dining hall",Genki Genki_Ln.7 JLPT JLPT_5 JLPT_N5
-知る,しる,"to know, to understand",Genki Genki_Ln.7 JLPT JLPT_5 JLPT_N5
-白,しろ,white,JLPT JLPT_3 JLPT_5 JLPT_N5
-白い,しろい,white,Genki Genki_Ln.9 JLPT JLPT_5 JLPT_N5
-～人,～じん,counter for people,JLPT JLPT_5 JLPT_N5
-新聞,しんぶん,newspaper,Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5
-水曜日,すいようび,Wednesday,Genki Genki_Ln.4 JLPT JLPT_5 JLPT_N5
-吸う,すう,"to breathe in, to suck",JLPT JLPT_3 JLPT_5 JLPT_N5
-スカート,スカート,skirt,Genki Genki_Ln.18 JLPT JLPT_5 JLPT_N5
-好き,すき,"liking, fondness, love",JLPT JLPT_5 JLPT_N5
-～すぎ,～すぎ,"past; to exceed, ~ too much",JLPT JLPT_5 JLPT_N5
-少ない,すくない,a little; a few,Genki Genki_Ln.17 JLPT JLPT_5 JLPT_N5
-すぐに,すぐに,"immediately, soon",JLPT JLPT_5 JLPT_N5
-少し,すこし,"little, few",Genki Genki_Ln.21 JLPT JLPT_5 JLPT_N5
-涼しい,すずしい,"cool, refreshing (in reference to weather)",Genki Genki_Ln.10 JLPT JLPT_5 JLPT_N5
-～ずつ,～ずつ,at a time,JLPT JLPT_5 JLPT_N5
-ストーブ,ストーブ,heater (lit: stove),Genki Genki_Ln.17 JLPT JLPT_5 JLPT_N5
-スプーン,スプーン,spoon,JLPT JLPT_5 JLPT_N5
-スポーツ,スポーツ,sport(s),Genki Genki_Ln.3 JLPT JLPT_5 JLPT_N5
-ズボン,ズボン,trousers,JLPT JLPT_5 JLPT_N5
-住む,すむ,"to reside, to live in",JLPT JLPT_3 JLPT_5 JLPT_N5
-する,する,"to do, to try; to wear small items (e.g., necktie, watch, etc.)",Genki Genki_Ln.17 JLPT JLPT_3 JLPT_5 JLPT_N5
-座る,すわる,to sit,JLPT JLPT_5 JLPT_N5
-背,せい,"(one's) height, stature",Intermediate_Japanese Intermediate_Japanese_Ln.4 JLPT JLPT_3 JLPT_5 JLPT_N5
-生徒,せいと,student; pupil,Intermediate_Japanese Intermediate_Japanese_Ln.5 JLPT JLPT_5 JLPT_N5
-セーター,セーター,sweater,Genki Genki_Ln.13 JLPT JLPT_5 JLPT_N5
-石鹸,せっけん,soap,JLPT JLPT_5 JLPT_N5
-背広,せびろ,men's suit,Intermediate_Japanese Intermediate_Japanese_Ln.9 JLPT JLPT_5 JLPT_N5
-狭い,せまい,narrow; not spacious,Genki Genki_Ln.12 Intermediate_Japanese Intermediate_Japanese_Ln.15 JLPT JLPT_5 JLPT_N5
-ゼロ,ゼロ,zero,JLPT JLPT_5 JLPT_N5
-千,せん,thousand,JLPT JLPT_5 JLPT_N5
-先月,せんげつ,last month,Genki Genki_Ln.9 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5
-先週,せんしゅう,last week,Genki Genki_Ln.4 JLPT JLPT_5 JLPT_N5
-先生,せんせい,"teacher, professor; master; doctor",Genki Genki_Ln.1 JLPT JLPT_5 JLPT_N5
-洗濯,せんたく,"washing, laundry",Intermediate_Japanese Intermediate_Japanese_Ln.11 JLPT JLPT_3 JLPT_5 JLPT_N5
-全部,ぜんぶ,"all, entire, whole",Genki Genki_Ln.13 Intermediate_Japanese Intermediate_Japanese_Ln.3 JLPT JLPT_5 JLPT_N5
-そう; そうです,そう; そうです,"yes; appears, to be the case",JLPT JLPT_5 JLPT_N5
-掃除,そうじ (する),"cleaning, sweeping",JLPT JLPT_3 JLPT_5 JLPT_N5
-そうして; そして,そうして; そして,"and, like that",JLPT JLPT_5 JLPT_N5
-そこ,そこ,"that place, there; bottom, sole",Genki Genki_Ln.4 JLPT JLPT_2 JLPT_3 JLPT_5 JLPT_N5
-そちら,そちら,over there,JLPT JLPT_5 JLPT_N5
-そっち,そっち,over there,JLPT JLPT_5 JLPT_N5
-外,そと,"outside, exterior",Genki Genki_Ln.18 Intermediate_Japanese Intermediate_Japanese_Ln.2 JLPT JLPT_5 JLPT_N5
-その,その,that,JLPT JLPT_3 JLPT_5 JLPT_N5
-そば,そば,"near, close, beside; Japanese traditional buckwheat noodle",Genki Genki_Ln.15 JLPT JLPT_3 JLPT_5 JLPT_N5
-空,そら,sky,JLPT JLPT_5 JLPT_N5
-それ,それ,that one,Genki Genki_Ln.2 JLPT JLPT_3 JLPT_5 JLPT_N5
-それから,それから,"and then, after that",Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5
-それでは,それでは,"in that situation, well then...",JLPT JLPT_5 JLPT_N5
-～台,～だい,counter for vehicles; machines,JLPT JLPT_5 JLPT_N5
-大学,だいがく,college; university,Genki Genki_Ln.1 JLPT JLPT_5 JLPT_N5
-大使館,たいしかん,embassy,JLPT JLPT_5 JLPT_N5
-大丈夫,だいじょうぶ,It's ok (all right); No need to worry; Everything is under control,Genki Genki_Ln.5 Intermediate_Japanese Intermediate_Japanese_Ln.3 JLPT JLPT_5 JLPT_N5
-大好き,だいすき,"very like-able, like very much",JLPT JLPT_5 JLPT_N5
-大切,たいせつ,important,JLPT JLPT_5 JLPT_N5
-台所,だいどころ,kitchen,JLPT JLPT_5 JLPT_N5
-大変,たいへん,"very; difficult, hard",JLPT JLPT_3 JLPT_5 JLPT_N5
-高い,たかい,"tall, high; expensive",Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5
-～だけ,～だけ,"only ~, just ~, as ~",JLPT JLPT_1 JLPT_5 JLPT_N5
-沢山,たくさん,"many, much",JLPT JLPT_5 JLPT_N5
-タクシー,タクシー,taxi,JLPT JLPT_5 JLPT_N5
-出す,だす,to take (something) out; to hand in (something),Genki Genki_Ln.16 JLPT JLPT_5 JLPT_N5
-～たち,～たち,plural suffix,JLPT JLPT_5 JLPT_N5
-立つ,たつ,to stand up,Genki Genki_Ln.6 JLPT JLPT_3 JLPT_5 JLPT_N5
-たて,たて,"length, height",JLPT JLPT_3 JLPT_5 JLPT_N5
-建物,たてもの,building,Intermediate_Japanese Intermediate_Japanese_Ln.5 JLPT JLPT_5 JLPT_N5
-楽しい,たのしい,"enjoyable, fun",Genki Genki_Ln.5 JLPT JLPT_5 JLPT_N5
-頼む,たのむ,"to request, to ask (a favor)",Genki Genki_Ln.18 Intermediate_Japanese Intermediate_Japanese_Ln.3 JLPT JLPT_5 JLPT_N5
-たばこ,たばこ,"tobacco, cigarettes",JLPT JLPT_5 JLPT_N5
-多分,たぶん,"perhaps, probably, maybe",Genki Genki_Ln.12 Intermediate_Japanese Intermediate_Japanese_Ln.2 JLPT JLPT_3 JLPT_5 JLPT_N5
-食べ物,たべもの,food,Genki Genki_Ln.5 JLPT JLPT_5 JLPT_N5
-食べる,たべる,to eat,JLPT JLPT_5 JLPT_N5
-卵,たまご,egg,Intermediate_Japanese Intermediate_Japanese_Ln.6 JLPT JLPT_5 JLPT_N5
-誰,だれ,who,Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5
-誰か,だれか,someone,JLPT JLPT_3 JLPT_5 JLPT_N5
-誕生日,たんじょうび,birthday,Genki Genki_Ln.5 JLPT JLPT_5 JLPT_N5
-段々,だんだん,"gradually, by degrees",JLPT JLPT_5 JLPT_N5
-小さい,ちいさい,"small, little",Genki Genki_Ln.5 JLPT JLPT_5 JLPT_N5
-小さな,ちいさな,"small, little",JLPT JLPT_5 JLPT_N5
-近い,ちかい,"near, close by, short",Genki Genki_Ln.13 JLPT JLPT_5 JLPT_N5
-違う,ちがう,to be different; to differ; wrong,Genki Genki_Ln.23 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5
-近く,ちかく,nearby; in the neighborhood,Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5
-地下鉄,ちかてつ,"underground train, subway",Genki Genki_Ln.10 JLPT JLPT_5 JLPT_N5
-地図,ちず,a map,Genki Genki_Ln.15 Intermediate_Japanese Intermediate_Japanese_Ln.12 JLPT JLPT_5 JLPT_N5
-父,ちち,(my) father,Genki Genki_Ln.7 JLPT JLPT_5 JLPT_N5
-茶色,ちゃいろ,brown,JLPT JLPT_5 JLPT_N5
-茶碗,ちゃわん,rice bowl,JLPT JLPT_5 JLPT_N5
-～中,～ちゅう,"during, while ~ing",JLPT JLPT_5 JLPT_N5
-丁度,ちょうど,"just, right, exactly",JLPT JLPT_5 JLPT_N5
-ちょっと,ちょっと,"a little, somewhat; just a little, somewhat",Genki Genki_Ln.3 JLPT JLPT_2 JLPT_5 JLPT_N5
-一日,ついたち,one day; first day of the month,JLPT JLPT_5 JLPT_N5
-使う,つかう,to use,JLPT JLPT_5 JLPT_N5
-疲れる,つかれる,to get (become) tired; to become fatigued,Genki Genki_Ln.11 Intermediate_Japanese Intermediate_Japanese_Ln.10 JLPT JLPT_5 JLPT_N5
-次,つぎ,next,Genki Genki_Ln.6 JLPT JLPT_5 JLPT_N5
-着く,つく,"to arrive at, to reach",JLPT JLPT_3 JLPT_5 JLPT_N5
-机,つくえ,desk,Genki Genki_Ln.4 Intermediate_Japanese Intermediate_Japanese_Ln.10 JLPT JLPT_5 JLPT_N5
-作る,つくる,"to make, to create",Genki Genki_Ln.8 JLPT JLPT_5 JLPT_N5
-つける,つける,"to turn on (e.g., a light); to take",JLPT JLPT_3 JLPT_4 JLPT_5 JLPT_N5
-勤める,つとめる,to work (for),JLPT JLPT_5 JLPT_N5
-つまらない,つまらない,"boring, dull; insignificant",Genki Genki_Ln.5 JLPT JLPT_5 JLPT_N5
-冷たい,つめたい,"cold (things, people)",Genki Genki_Ln.10 JLPT JLPT_5 JLPT_N5
-強い,つよい,"strong, powerful",Genki Genki_Ln.17 Intermediate_Japanese Intermediate_Japanese_Ln.13 JLPT JLPT_5 JLPT_N5
-手,て,hand,JLPT JLPT_5 JLPT_N5
-テープ,テープ,tape,Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5
-テープレコーダー,テープレコーダー,tape recorder,JLPT JLPT_5 JLPT_N5
-テーブル,テーブル,table,JLPT JLPT_5 JLPT_N5
-出かける,でかける,to go out; to depart,Genki Genki_Ln.5 JLPT JLPT_5 JLPT_N5
-手紙,てがみ,letter,Genki Genki_Ln.4 JLPT JLPT_5 JLPT_N5
-できる,できる,to be able to (to accomplish),JLPT JLPT_3 JLPT_4 JLPT_5 JLPT_N5
-出口,でぐち,an exit,Intermediate_Japanese Intermediate_Japanese_Ln.7 JLPT JLPT_5 JLPT_N5
-テスト,テスト,test,Genki Genki_Ln.5 JLPT JLPT_5 JLPT_N5
-では,では,"then, well, so",JLPT JLPT_3 JLPT_5 JLPT_N5
-デパート,デパート,(abbr.) department store,Genki Genki_Ln.4 JLPT JLPT_5 JLPT_N5
-でも,でも,"but, however",JLPT JLPT_3 JLPT_5 JLPT_N5
-出る,でる,"to appear, to leave",JLPT JLPT_5 JLPT_N5
-テレビ,テレビ,"television, TV",Genki Genki_Ln.3 JLPT JLPT_5 JLPT_N5
-天気,てんき,weather,Genki Genki_Ln.5 JLPT JLPT_5 JLPT_N5
-電気,でんき,"electricity, (electric) light",Genki Genki_Ln.6 JLPT JLPT_5 JLPT_N5
-電車,でんしゃ,electric train,Genki Genki_Ln.6 JLPT JLPT_5 JLPT_N5
-電話,でんわ,a telephone,Genki Genki_Ln.1 JLPT JLPT_5 JLPT_N5
-戸,と,door (Japanese style),JLPT JLPT_5 JLPT_N5
-～度,～ど,counter for occurrences; ~ degree; ~ point,JLPT JLPT_1 JLPT_5 JLPT_N5
-ドア,ドア,door (Western style),JLPT JLPT_5 JLPT_N5
-トイレ,トイレ,bathroom; toilet,Intermediate_Japanese Intermediate_Japanese_Ln.10 JLPT JLPT_5 JLPT_N5
-どう,どう,"how, in what way",JLPT JLPT_5 JLPT_N5
-どうして,どうして,"why, for what reason",Genki Genki_Ln.4 JLPT JLPT_5 JLPT_N5
-どうぞ,どうぞ,"please, kindly, by all means",JLPT JLPT_5 JLPT_N5
-動物,どうぶつ,animal,Intermediate_Japanese Intermediate_Japanese_Ln.10 JLPT JLPT_5 JLPT_N5
-どうも,どうも,Thank you; somehow; no matter how hard one may try,Genki Genki_Ln.2 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5
-十,(〜を) とお,ten (~),Genki Genki_Ln.9 JLPT JLPT_3 JLPT_5 JLPT_N5
-遠い,とおい,"far (away), distant",Genki Genki_Ln.21 JLPT JLPT_5 JLPT_N5
-十日,とおか,ten days; tenth day of the month,Genki Genki_Ln.13 JLPT JLPT_5 JLPT_N5
-～時,～とき,at the time of ~,JLPT JLPT_3 JLPT_5 JLPT_N5
-時々,ときどき,sometimes,Genki Genki_Ln.3 JLPT JLPT_5 JLPT_N5
-時計,とけい,a watch; a clock,Genki Genki_Ln.2 Intermediate_Japanese Intermediate_Japanese_Ln.2 JLPT JLPT_5 JLPT_N5
-どこ,どこ,"where, what place",Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5
-所,ところ,place,Genki Genki_Ln.8 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5
-年,とし,"year, age",JLPT JLPT_3 JLPT_5 JLPT_N5
-図書館,としょかん,library,Genki Genki_Ln.2 Intermediate_Japanese Intermediate_Japanese_Ln.5 JLPT JLPT_5 JLPT_N5
-どちら,どちら,which (one) (way); where (polite),Genki Genki_Ln.10 Genki_Ln.19 JLPT JLPT_5 JLPT_N5
-どっち,どっち,"which one, which way",Genki Genki_Ln.10 JLPT JLPT_5 JLPT_N5
-とても,とても,"very (much), greatly, exceedingly",Genki Genki_Ln.5 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_3 JLPT_5 JLPT_N5
-どなた,どなた,who,JLPT JLPT_5 JLPT_N5
-隣,となり,"next to, next door to",Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5
-どの,どの,which,JLPT JLPT_5 JLPT_N5
-飛ぶ,とぶ,"to fly, to hop",JLPT JLPT_5 JLPT_N5
-止まる,とまる,to come to a halt,JLPT JLPT_5 JLPT_N5
-友達,ともだち,friend,Genki Genki_Ln.1 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5
-土曜日,どようび,Saturday,Genki Genki_Ln.3 JLPT JLPT_3 JLPT_5 JLPT_N5
-鳥,とり,"chicken (lit., bird)",Intermediate_Japanese Intermediate_Japanese_Ln.6 JLPT JLPT_5 JLPT_N5
-鶏肉,とりにく,chicken meat,JLPT JLPT_5 JLPT_N5
-取る,とる,to take (a class); to get (a grade),Genki Genki_Ln.11 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5
-撮る,とる,"to take (a photo), to make (a film)",JLPT JLPT_5 JLPT_N5
-どれ,どれ,which one,Genki Genki_Ln.2 JLPT JLPT_3 JLPT_5 JLPT_N5
-どんな,どんな,"what, what kind of",JLPT JLPT_3 JLPT_5 JLPT_N5
-ない,ない,"there isn't, doesn't have",JLPT JLPT_5 JLPT_N5
-ナイフ,ナイフ,knife,JLPT JLPT_5 JLPT_N5
-中,なか,"inside, middle, among",JLPT JLPT_3 JLPT_5 JLPT_N5
-長い,ながい,"long, lengthy",Genki Genki_Ln.7 Intermediate_Japanese Intermediate_Japanese_Ln.4 JLPT JLPT_2 JLPT_5 JLPT_N5
-鳴く,なく,to make sound (animal),JLPT JLPT_5 JLPT_N5
-無くす,なくす,to lose something,JLPT JLPT_3 JLPT_5 JLPT_N5
-なぜ,なぜ,why (same as どうして),Genki Genki_Ln.19 JLPT JLPT_5 JLPT_N5
-夏,なつ,summer,Genki Genki_Ln.8 Intermediate_Japanese Intermediate_Japanese_Ln.4 JLPT JLPT_5 JLPT_N5
-夏休み,なつやすみ,summer vacation,JLPT JLPT_5 JLPT_N5
-～など,～など,et cetera,JLPT JLPT_3 JLPT_5 JLPT_N5
-七つ,ななつ,seven things,Genki Genki_Ln.9 JLPT JLPT_3 JLPT_5 JLPT_N5
-何,なん; なに,what,Genki Genki_Ln.1 JLPT JLPT_3 JLPT_5 JLPT_N5
-七日,なのか,seven days; seventh day (of the month),Genki Genki_Ln.13 JLPT JLPT_5 JLPT_N5
-名前,なまえ,name,Genki Genki_Ln.1 JLPT JLPT_5 JLPT_N5
-習う,ならう,to learn,Genki Genki_Ln.11 JLPT JLPT_5 JLPT_N5
-並ぶ,ならぶ,"to line up, to stand in a line (v.i.)",Intermediate_Japanese Intermediate_Japanese_Ln.7 JLPT JLPT_5 JLPT_N5
-並べる,ならべる,to put (things) side by side; to line up,Intermediate_Japanese Intermediate_Japanese_Ln.15 JLPT JLPT_5 JLPT_N5
-なる,なる,to become,Genki Genki_Ln.10 JLPT JLPT_3 JLPT_5 JLPT_N5
-何～,なん～,what sort of ~,JLPT JLPT_5 JLPT_N5
-二,に,two,JLPT JLPT_5 JLPT_N5
-にぎやか,にぎやか,"bustling, busy",JLPT JLPT_5 JLPT_N5
-肉,にく,meat,Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5
-西,にし,west,JLPT JLPT_5 JLPT_N5
-～日,～にち,"~ day of the month, for ~ days",JLPT JLPT_5 JLPT_N5
-日曜日,にちようび,Sunday,Genki Genki_Ln.3 JLPT JLPT_3 JLPT_5 JLPT_N5
-荷物,にもつ,luggage; baggage,Genki Genki_Ln.6 Intermediate_Japanese Intermediate_Japanese_Ln.6 JLPT JLPT_5 JLPT_N5
-ニュース,ニュース,news,Genki Genki_Ln.17 JLPT JLPT_5 JLPT_N5
-庭,にわ,garden,Genki Genki_Ln.15 JLPT JLPT_5 JLPT_N5
-～人,～にん,counter for people,JLPT JLPT_5 JLPT_N5
-脱ぐ,ぬぐ,to take off (clothes),Genki Genki_Ln.17 JLPT JLPT_5 JLPT_N5
-温い,ぬるい,lukewarm,JLPT JLPT_3 JLPT_5 JLPT_N5
-ネクタイ,ネクタイ,"tie, necktie",Genki Genki_Ln.14 JLPT JLPT_5 JLPT_N5
-猫,ねこ,cat,Genki Genki_Ln.4 JLPT JLPT_5 JLPT_N5
-寝る,ねる,to sleep; to go to sleep; to go to bed,Genki Genki_Ln.3 Intermediate_Japanese Intermediate_Japanese_Ln.2 JLPT JLPT_5 JLPT_N5
-～年,～ねん,~ years,JLPT JLPT_5 JLPT_N5
-ノート,ノート,notebook,Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5
-登る,のぼる,to climb,JLPT JLPT_3 JLPT_5 JLPT_N5
-飲み物,のみもの,"drink, beverage",Genki Genki_Ln.5 JLPT JLPT_5 JLPT_N5
-飲む,のむ,to drink,JLPT JLPT_5 JLPT_N5
-乗る,のる,"to get on, to ride in, to board",JLPT JLPT_3 JLPT_5 JLPT_N5
-歯,は,tooth,Genki Genki_Ln.12 Intermediate_Japanese Intermediate_Japanese_Ln.12 JLPT JLPT_5 JLPT_N5
-パーティー,パーティー,a party,Genki Genki_Ln.8 JLPT JLPT_5 JLPT_N5
-はい,はい,yes,Genki Genki_Ln.1 JLPT JLPT_3 JLPT_5 JLPT_N5
-～杯,～はい,counter for cupfuls,JLPT JLPT_5 JLPT_N5
-灰皿,はいざら,ashtray,JLPT JLPT_5 JLPT_N5
-入る,はいる,"to enter, to contain, to hold",JLPT JLPT_5 JLPT_N5
-葉書,はがき,postcard,Genki Genki_Ln.5 JLPT JLPT_5 JLPT_N5
-はく,はく,to put on (items below your waist),Genki Genki_Ln.7 JLPT JLPT_3 JLPT_5 JLPT_N5
-箱,はこ,box,JLPT JLPT_5 JLPT_N5
-橋,はし,bridge,JLPT JLPT_3 JLPT_5 JLPT_N5
-箸,はし,chopsticks,Genki Genki_Ln.8 JLPT JLPT_3 JLPT_5 JLPT_N5
-始まる,はじまる,(something) begins,Genki Genki_Ln.9 JLPT JLPT_5 JLPT_N5
-初め; 始め,はじめ,"beginning, start",JLPT JLPT_3 JLPT_5 JLPT_N5
-初めて,はじめて,for the first time,Genki Genki_Ln.12 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5
-走る,はしる,to run,Genki Genki_Ln.22 Intermediate_Japanese Intermediate_Japanese_Ln.10 JLPT JLPT_5 JLPT_N5
-バス,バス,bus; bath; bass,Genki Genki_Ln.5 Intermediate_Japanese Intermediate_Japanese_Ln.10 JLPT JLPT_1 JLPT_5 JLPT_N5
-バター,バター,butter,JLPT JLPT_5 JLPT_N5
-二十歳,はたち,20 years old,JLPT JLPT_3 JLPT_5 JLPT_N5
-働く,はたらく,to work,Genki Genki_Ln.11 Intermediate_Japanese Intermediate_Japanese_Ln.9 JLPT JLPT_5 JLPT_N5
-八,はち,eight,JLPT JLPT_5 JLPT_N5
-二十日,はつか,"twenty days, twentieth (day of the month)",JLPT JLPT_5 JLPT_N5
-花,はな,flower,JLPT JLPT_5 JLPT_N5
-鼻,はな,nose,JLPT JLPT_5 JLPT_N5
-話,はなし,"talk (chat), story",Genki Genki_Ln.19 JLPT JLPT_5 JLPT_N5
-話す,はなす,to speak,JLPT JLPT_3 JLPT_5 JLPT_N5
-母,はは,(my) mother,Genki Genki_Ln.14 JLPT JLPT_5 JLPT_N5
-早い,はやい,early,Genki Genki_Ln.3 JLPT JLPT_5 JLPT_N5
-速い,はやい,"fast, quick",Genki Genki_Ln.7 Intermediate_Japanese Intermediate_Japanese_Ln.4 JLPT JLPT_5 JLPT_N5
-春,はる,spring,Genki Genki_Ln.10 Intermediate_Japanese Intermediate_Japanese_Ln.4 JLPT JLPT_3 JLPT_5 JLPT_N5
-貼る,はる,to post; to paste; to attach,Genki Genki_Ln.21 Intermediate_Japanese Intermediate_Japanese_Ln.3 JLPT JLPT_3 JLPT_5 JLPT_N5
-晴れ,はれ,clear (sunny) weather,Genki Genki_Ln.12 JLPT JLPT_5 JLPT_N5
-晴れる,はれる,to be sunny,Genki Genki_Ln.19 JLPT JLPT_5 JLPT_N5
-半,はん,"half (e.g., にじはん | half-past two)",Genki Genki_Ln.1 JLPT JLPT_3 JLPT_5 JLPT_N5
-晩,ばん,evening,JLPT JLPT_3 JLPT_5 JLPT_N5
-～番,～ばん,~st; ~th best,JLPT JLPT_5 JLPT_N5
-パン,パン,bread,Genki Genki_Ln.4 JLPT JLPT_5 JLPT_N5
-ハンカチ,ハンカチ,handkerchief,JLPT JLPT_5 JLPT_N5
-番号,ばんごう,"number, series of digits",Genki Genki_Ln.1 JLPT JLPT_5 JLPT_N5
-晩御飯,ばんごはん,"dinner, evening meal",Genki Genki_Ln.3 JLPT JLPT_5 JLPT_N5
-半分,はんぶん,half,JLPT JLPT_5 JLPT_N5
-東,ひがし,east,JLPT JLPT_5 JLPT_N5
-～匹,～ひき,counter for small animals,JLPT JLPT_5 JLPT_N5
-引く,ひく,"to pull, to draw; subtract",JLPT JLPT_2 JLPT_3 JLPT_5 JLPT_N5
-弾く,ひく,to play (a string instrument or piano),Genki Genki_Ln.9 JLPT JLPT_3 JLPT_5 JLPT_N5
-低い,ひくい,"short, low",JLPT JLPT_5 JLPT_N5
-飛行機,ひこうき,airplane,Genki Genki_Ln.5 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5
-左,ひだり,left hand side,JLPT JLPT_5 JLPT_N5
-人,ひと,"man, person",Genki Genki_Ln.4 JLPT JLPT_5 JLPT_N5
-一つ,ひとつ,one thing,Genki Genki_Ln.9 JLPT JLPT_5 JLPT_N5
-一月,ひとつき,one month,JLPT JLPT_5 JLPT_N5
-一人,ひとり,one person,Genki Genki_Ln.7 JLPT JLPT_3 JLPT_5 JLPT_N5
-暇,ひま,"free time, leisure",JLPT JLPT_5 JLPT_N5
-百,ひゃく,hundred,JLPT JLPT_5 JLPT_N5
-病院,びょういん,hospital,Genki Genki_Ln.4 JLPT JLPT_5 JLPT_N5
-病気,びょうき,illness; sickness,Genki Genki_Ln.9 Intermediate_Japanese Intermediate_Japanese_Ln.2 JLPT JLPT_5 JLPT_N5
-平仮名,ひらがな,hiragana,JLPT JLPT_5 JLPT_N5
-昼,ひる,"noon, daytime",JLPT JLPT_5 JLPT_N5
-昼御飯,ひるごはん,"lunch, midday meal",Genki Genki_Ln.3 JLPT JLPT_5 JLPT_N5
-広い,ひろい,spacious; wide; broad,Genki Genki_Ln.15 Intermediate_Japanese Intermediate_Japanese_Ln.15 JLPT JLPT_5 JLPT_N5
-フィルム,フィルム,film (roll of),JLPT JLPT_5 JLPT_N5
-封筒,ふうとう,envelope,Intermediate_Japanese Intermediate_Japanese_Ln.3 JLPT JLPT_5 JLPT_N5
-プール,プール,swimming pool,Genki Genki_Ln.15 JLPT JLPT_5 JLPT_N5
-フォーク,フォーク,fork,JLPT JLPT_5 JLPT_N5
-吹く,ふく,"to blow (wind, etc.)",Genki Genki_Ln.22 JLPT JLPT_3 JLPT_5 JLPT_N5
-服,ふく,clothes,Genki Genki_Ln.12 JLPT JLPT_3 JLPT_5 JLPT_N5
-二つ,ふたつ,two things,Genki Genki_Ln.9 JLPT JLPT_5 JLPT_N5
-豚肉,ぶたにく,pork,JLPT JLPT_5 JLPT_N5
-二人,ふたり,two people,Genki Genki_Ln.7 JLPT JLPT_5 JLPT_N5
-二日,ふつか,two days; second day of the month,Genki Genki_Ln.13 JLPT JLPT_5 JLPT_N5
-太い,ふとい,"fat, thick",JLPT JLPT_5 JLPT_N5
-冬,ふゆ,winter,Genki Genki_Ln.8 Intermediate_Japanese Intermediate_Japanese_Ln.4 JLPT JLPT_5 JLPT_N5
-降る,ふる,"to precipitate, to fall (e.g., rain, snow, etc.)",Intermediate_Japanese Intermediate_Japanese_Ln.2 JLPT JLPT_3 JLPT_5 JLPT_N5
-古い,ふるい,"old (in reference to objects, not people), aged, ancient",Genki Genki_Ln.5 JLPT JLPT_5 JLPT_N5
-～分,～ふん,~ minutes,JLPT JLPT_5 JLPT_N5
-文章,ぶんしょう,"sentence, text",JLPT JLPT_5 JLPT_N5
-ページ,ページ,a page,Genki Genki_Ln.6 JLPT JLPT_5 JLPT_N5
-下手,へた,"unskillful, poor",JLPT JLPT_5 JLPT_N5
-ベッド,ベッド,bed,JLPT JLPT_5 JLPT_N5
-ペット,ペット,pet,Genki Genki_Ln.15 JLPT JLPT_3 JLPT_5 JLPT_N5
-部屋,へや,a room,Genki Genki_Ln.5 Intermediate_Japanese Intermediate_Japanese_Ln.2 JLPT JLPT_5 JLPT_N5
-辺,へん,"area, vicinity",JLPT JLPT_5 JLPT_N5
-ペン,ペン,pen,Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5
-勉強,べんきょう (する),study,JLPT JLPT_3 JLPT_5 JLPT_N5
-便利,べんり,"convenient, handy",JLPT JLPT_5 JLPT_N5
-帽子,ぼうし,hat; cap,Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5
-ボールペン,ボールペン,ball-point pen,JLPT JLPT_5 JLPT_N5
-外,ほか,"other, the rest",JLPT JLPT_3 JLPT_5 JLPT_N5
-ポケット,ポケット,pocket,JLPT JLPT_5 JLPT_N5
-欲しい,ほしい,"to want, in need of",JLPT JLPT_5 JLPT_N5
-ポスト,ポスト,"mailbox; post, position",JLPT JLPT_5 JLPT_N5
-細い,ほそい,"thin, slender, fine",JLPT JLPT_5 JLPT_N5
-ボタン,ボタン,button,JLPT JLPT_5 JLPT_N5
-ホテル,ホテル,hotel,Genki Genki_Ln.4 JLPT JLPT_5 JLPT_N5
-本,ほん,book,Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5
-～本,～ほん,counter for long cylindrical things,JLPT JLPT_2 JLPT_5 JLPT_N5
-本棚,ほんだな,bookshelf,JLPT JLPT_5 JLPT_N5
-本当,ほんとう,"real, true",JLPT JLPT_3 JLPT_5 JLPT_N5
-～枚,～まい,counter for flat things,JLPT JLPT_5 JLPT_N5
-毎朝,まいあさ,every morning,Genki Genki_Ln.19 JLPT JLPT_5 JLPT_N5
-毎月,まいげつ; まいつき,"every month, monthly",JLPT JLPT_5 JLPT_N5
-毎週,まいしゅう,every week,Genki Genki_Ln.8 JLPT JLPT_5 JLPT_N5
-毎日,まいにち,every day,Genki Genki_Ln.3 JLPT JLPT_5 JLPT_N5
-毎年,まいねん; まいとし,"every year, yearly, annually",JLPT JLPT_5 JLPT_N5
-毎晩,まいばん,every night,Genki Genki_Ln.3 JLPT JLPT_5 JLPT_N5
-前,まえ,"before, in front",Genki Genki_Ln.17 JLPT JLPT_5 JLPT_N5
-～前,～まえ,in front of ~,JLPT JLPT_5 JLPT_N5
-曲る,まがる,"to turn, to bend",JLPT JLPT_3 JLPT_5 JLPT_N5
-まずい,まずい,"terrible (in reference to food), unappetizing, unpleasant (taste)",Genki Genki_Ln.23 JLPT JLPT_5 JLPT_N5
-また,また,and; furthermore,Genki Genki_Ln.20 Intermediate_Japanese Intermediate_Japanese_Ln.5 JLPT JLPT_3 JLPT_5 JLPT_N5
-まだ,まだ,"yet, still, besides",Genki Genki_Ln.19 JLPT JLPT_3 JLPT_5 JLPT_N5
-町,まち,town; city,Genki Genki_Ln.4 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_3 JLPT_5 JLPT_N5
-待つ,まつ,to wait,JLPT JLPT_3 JLPT_5 JLPT_N5
-まっすぐ,まっすぐ,"straight (ahead), direct",JLPT JLPT_3 JLPT_5 JLPT_N5
-マッチ,マッチ,match,JLPT JLPT_5 JLPT_N5
-窓,まど,window,Genki Genki_Ln.6 JLPT JLPT_5 JLPT_N5
-丸い; 円い,まるい,"round, circular",JLPT JLPT_3 JLPT_5 JLPT_N5
-万,まん,ten thousand,JLPT JLPT_5 JLPT_N5
-万年筆,まんねんひつ,fountain pen,JLPT JLPT_5 JLPT_N5
-磨く,みがく,to brush (teeth); to polish,Genki Genki_Ln.13 JLPT JLPT_5 JLPT_N5
-右,みぎ,right hand side,JLPT JLPT_5 JLPT_N5
-短い,みじかい,short (length),Genki Genki_Ln.7 Intermediate_Japanese Intermediate_Japanese_Ln.11 JLPT JLPT_5 JLPT_N5
-水,みず,water,Genki Genki_Ln.3 JLPT JLPT_5 JLPT_N5
-店,みせ,"store, shop",Genki Genki_Ln.13 Intermediate_Japanese Intermediate_Japanese_Ln.6 JLPT JLPT_5 JLPT_N5
-見せる,みせる,"to show, to display",Genki Genki_Ln.16 JLPT JLPT_5 JLPT_N5
-道,みち,"road, street; way, directions",Genki Genki_Ln.16 JLPT JLPT_5 JLPT_N5
-三日,みっか,"three days, third day of the month",Genki Genki_Ln.13 JLPT JLPT_5 JLPT_N5
-三つ,みっつ,three things,Genki Genki_Ln.9 JLPT JLPT_5 JLPT_N5
-緑,みどり,green,JLPT JLPT_5 JLPT_N5
-皆さん,みなさん,"all of you, everyone",Intermediate_Japanese Intermediate_Japanese_Ln.4 JLPT JLPT_5 JLPT_N5
-南,みなみ,South,Intermediate_Japanese Intermediate_Japanese_Ln.10 JLPT JLPT_5 JLPT_N5
-耳,みみ,ear,Intermediate_Japanese Intermediate_Japanese_Ln.5 JLPT JLPT_5 JLPT_N5
-見る,みる,"to see, to look",JLPT JLPT_3 JLPT_5 JLPT_N5
-みんな,みんな,"all, everyone, everybody",Genki Genki_Ln.9 JLPT JLPT_3 JLPT_5 JLPT_N5
-六日,むいか,six days; sixth day of month,Genki Genki_Ln.13 JLPT JLPT_5 JLPT_N5
-向こう,むこう,"beyond, over there",JLPT JLPT_5 JLPT_N5
-難しい,むずかしい,difficult,Genki Genki_Ln.5 Intermediate_Japanese Intermediate_Japanese_Ln.2 JLPT JLPT_5 JLPT_N5
-六つ,むっつ,six things,Genki Genki_Ln.9 JLPT JLPT_5 JLPT_N5
-村,むら,village,Intermediate_Japanese Intermediate_Japanese_Ln.10 JLPT JLPT_5 JLPT_N5
-目,め,eye(s),Genki Genki_Ln.7 JLPT JLPT_3 JLPT_5 JLPT_N5
-メートル,メートル,meter,JLPT JLPT_5 JLPT_N5
-眼鏡,めがね,eye glasses,Genki Genki_Ln.7 JLPT JLPT_5 JLPT_N5
-もう,もう,already; again; more,Genki Genki_Ln.9 JLPT JLPT_2 JLPT_5 JLPT_N5
-木曜日,もくようび,Thursday,Genki Genki_Ln.4 JLPT JLPT_3 JLPT_5 JLPT_N5
-もしもし,もしもし,Hello? (used on the phone),Genki Genki_Ln.4 JLPT JLPT_5 JLPT_N5
-持つ,もつ,"to hold, to carry; to possess",JLPT JLPT_5 JLPT_N5
-もっと,もっと,more,Genki Genki_Ln.11 JLPT JLPT_3 JLPT_5 JLPT_N5
-物,もの,thing (concrete object),Genki Genki_Ln.12 JLPT JLPT_3 JLPT_5 JLPT_N5
-門,もん,gate,JLPT JLPT_5 JLPT_N5
-問題,もんだい,a problem,Intermediate_Japanese Intermediate_Japanese_Ln.11 JLPT JLPT_5 JLPT_N5
-～屋,～や,~ shop,JLPT_N5
-八百屋,やおや,greengrocer,JLPT JLPT_5 JLPT_N5
-野菜,やさい,vegetable,Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5
-易しい,やさしい,"easy, plain, simple",JLPT JLPT_5 JLPT_N5
-安い,やすい,inexpensive; cheap (things),Genki Genki_Ln.5 JLPT JLPT_5 JLPT_N5
-休み,やすみ,holiday; day off; absence,Genki Genki_Ln.5 JLPT JLPT_5 JLPT_N5
-休む,やすむ,"to rest, to have a break, to get time off",JLPT JLPT_5 JLPT_N5
-八つ,やっつ,eight things,Genki Genki_Ln.9 JLPT JLPT_5 JLPT_N5
-山,やま,mountain,Genki Genki_Ln.11 JLPT JLPT_5 JLPT_N5
-やる,やる,"to do; to give (to pets, parents, siblings, etc.)",Genki Genki_Ln.21 JLPT JLPT_4 JLPT_5 JLPT_N5
-夕方,ゆうがた,"late afternoon (typically just before dinner time), evening",Genki Genki_Ln.18 Intermediate_Japanese Intermediate_Japanese_Ln.10 JLPT JLPT_5 JLPT_N5
-夕飯,ゆうはん,"dinner, supper, evening meal",JLPT JLPT_4 JLPT_5 JLPT_N5
-郵便局,ゆうびんきょく,post office,Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5
-昨夜,ゆうべ,last night,JLPT JLPT_3 JLPT_5 JLPT_N5
-有名,ゆうめい,famous,JLPT JLPT_5 JLPT_N5
-雪,ゆき,snow,Genki Genki_Ln.12 JLPT JLPT_3 JLPT_5 JLPT_N5
-ゆっくりと,ゆっくりと,"slowly, at ease",JLPT JLPT_5 JLPT_N5
-八日,ようか,eight days; eighth day of the month,Genki Genki_Ln.13 JLPT JLPT_5 JLPT_N5
-洋服,ようふく,Western-style clothes,JLPT JLPT_5 JLPT_N5
-よく,よく,"frequently, often (much); well, skillfully",Genki Genki_Ln.14 Genki_Ln.3 JLPT JLPT_5 JLPT_N5
-横,よこ,beside; side; width,Intermediate_Japanese Intermediate_Japanese_Ln.11 JLPT JLPT_5 JLPT_N5
-四日,よっか,four days; fourth day of the month,Genki Genki_Ln.13 JLPT JLPT_5 JLPT_N5
-四つ,よっつ,four things,Genki Genki_Ln.9 JLPT JLPT_2 JLPT_5 JLPT_N5
-呼ぶ,よぶ,to call (one's name); to invite,Genki Genki_Ln.19 JLPT JLPT_3 JLPT_5 JLPT_N5
-読む,よむ,to read,JLPT JLPT_5 JLPT_N5
-夜,よる,"evening, night",Genki Genki_Ln.6 JLPT JLPT_3 JLPT_5 JLPT_N5
-弱い,よわい,weak,JLPT JLPT_5 JLPT_N5
-来月,らいげつ,next month,Genki Genki_Ln.8 JLPT JLPT_5 JLPT_N5
-来週,らいしゅう,next week,Genki Genki_Ln.6 JLPT JLPT_5 JLPT_N5
-来年,らいねん,next year,Genki Genki_Ln.6 JLPT JLPT_5 JLPT_N5
-ラジオ,ラジオ,radio,Genki Genki_Ln.14 JLPT JLPT_5 JLPT_N5
-ラジオカセ,ラジオカセ,radio cassette player,JLPT JLPT_5 JLPT_N5
-りっぱ,りっぱ,"splendid, fine",JLPT JLPT_3 JLPT_5 JLPT_N5
-留学生,りゅうがくせい,international student,Genki Genki_Ln.1 JLPT JLPT_5 JLPT_N5
-両親,りょうしん,"parents (lit., both parents)",Genki Genki_Ln.14 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5
-料理,りょうり,cooking; cuisine,Intermediate_Japanese Intermediate_Japanese_Ln.4 JLPT JLPT_5 JLPT_N5
-旅行,りょこう,"travel, trip",Genki Genki_Ln.5 JLPT JLPT_5 JLPT_N5
-零,れい,"zero, nought",JLPT JLPT_3 JLPT_5 JLPT_N5
-冷蔵庫,れいぞうこ,refrigerator,Genki Genki_Ln.18 JLPT JLPT_5 JLPT_N5
-レコード,レコード,record,JLPT JLPT_5 JLPT_N5
-レストラン,レストラン,restaurant,Genki Genki_Ln.4 JLPT JLPT_5 JLPT_N5
-練習,れんしゅう (する),(to) practice,JLPT JLPT_5 JLPT_N5
-廊下,ろうか,corridor,JLPT JLPT_5 JLPT_N5
-六,ろく,six,JLPT JLPT_5 JLPT_N5
-ワイシャツ,ワイシャツ,"shirt (lit: white shirt), business shirt",JLPT JLPT_5 JLPT_N5
-若い,わかい,young,Genki Genki_Ln.9 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5
-分かる,わかる,to understand,JLPT JLPT_5 JLPT_N5
-忘れる,わすれる,to forget,Intermediate_Japanese Intermediate_Japanese_Ln.3 JLPT JLPT_5 JLPT_N5
-私,わたし,"I, myself",Genki Genki_Ln.1 JLPT JLPT_5 JLPT_N5
-私,わたくし,"I (formal), myself, private affairs",Genki Genki_Ln.13 JLPT JLPT_2 JLPT_5 JLPT_N5
-渡す,わたす,to hand (something) over (v.t.); to get across,Intermediate_Japanese Intermediate_Japanese_Ln.6 JLPT JLPT_5 JLPT_N5
-渡る,わたる,"to cross over, to go across",JLPT JLPT_5 JLPT_N5
-悪い,わるい,"bad, sinful; inferior",Genki Genki_Ln.12 Intermediate_Japanese Intermediate_Japanese_Ln.3 JLPT JLPT_5 JLPT_N5
+expression,reading,meaning,tags,guid
+ああ,ああ,"Ah!, Oh!",JLPT JLPT_4 JLPT_5 JLPT_N5,HI-.Ij?HS~
+会う,あう,"to meet, to see",JLPT JLPT_3 JLPT_5 JLPT_N5,kupB!kWE}<
+青,あお,blue,JLPT JLPT_5 JLPT_N5,HB)I{+$j.i
+青い,あおい,blue,Genki Genki_Ln.9 JLPT JLPT_5 JLPT_N5,q(A)lc.Kr8
+赤,あか,red,JLPT JLPT_5 JLPT_N5,y!Fn9IOz@J
+赤い,あかい,red,Genki Genki_Ln.9 Intermediate_Japanese Intermediate_Japanese_Ln.12 JLPT JLPT_5 JLPT_N5,D`aKGX2j!#
+明るい,あかるい,bright (in reference to personality or weather); cheerful,Genki Genki_Ln.18 Intermediate_Japanese Intermediate_Japanese_Ln.11 JLPT JLPT_5 JLPT_N5,m>)z8|k.>J
+秋,あき,fall (season),Genki Genki_Ln.10 Intermediate_Japanese Intermediate_Japanese_Ln.4 JLPT JLPT_3 JLPT_5 JLPT_N5,H~$iS3{X?*
+開く,あく,"to open, to become open",JLPT JLPT_3 JLPT_5 JLPT_N5,m[4![DH*c~
+開ける,あける,to open (v.t.),Intermediate_Japanese Intermediate_Japanese_Ln.12 JLPT JLPT_3 JLPT_5 JLPT_N5,y.#AVx@-k>
+上げる,あげる,"to raise, to lift",JLPT JLPT_3 JLPT_5 JLPT_N5,Hp0]9?Ae.w
+朝,あさ,morning,Genki Genki_Ln.3 Intermediate_Japanese Intermediate_Japanese_Ln.2 JLPT JLPT_5 JLPT_N5,g|Q>VbnCii
+朝御飯,あさごはん,breakfast,Genki Genki_Ln.3 JLPT JLPT_5 JLPT_N5,wWUR=G6*(U
+明後日,あさって,day after tomorrow,JLPT JLPT_5 JLPT_N5,mF[0Aq7|V7
+足; 脚,あし,foot; leg,JLPT JLPT_5 JLPT_N5,m.INsC.wC2
+明日,あした,tomorrow,Genki Genki_Ln.3 Intermediate_Japanese Intermediate_Japanese_Ln.7 JLPT JLPT_3 JLPT_5 JLPT_N5,xZI7N3AauN
+あそこ,あそこ,"there, over there, that place",Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5,P>AI.lx+Jq
+遊ぶ,あそぶ,to play; to spend time pleasantly; to hang out,Genki Genki_Ln.6 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5,e<h|f2`;&
+暖かい,あたたかい,warm,JLPT_N5,tk[pUMy0{i
+頭,あたま,head,Intermediate_Japanese Intermediate_Japanese_Ln.2 JLPT JLPT_5 JLPT_N5,DaKiPvzaex
+新しい,あたらしい,new,Genki Genki_Ln.5 JLPT JLPT_5 JLPT_N5,h)6JB@Q5Rj
+あちら,あちら,this way (polite),Genki Genki_Ln.20 JLPT JLPT_5 JLPT_N5,h{rLO32/d4
+暑い,あつい,"hot (in reference to weather), warm",Genki Genki_Ln.5 Intermediate_Japanese Intermediate_Japanese_Ln.4 JLPT JLPT_5 JLPT_N5,"gSl8i,<}^I"
+熱い,あつい,hot (objects),Genki Genki_Ln.5 JLPT JLPT_5 JLPT_N5,Gy7fB=0YXx
+厚い,あつい,"kind, warm(hearted), thick, deep",JLPT JLPT_5 JLPT_N5,v[2GvOysf?
+あっち,あっち,over there,JLPT JLPT_5 JLPT_N5,Pv=fA$Z6K5
+後,あと,afterwards (later); in the future; the rest; since then,Genki Genki_Ln.18 JLPT JLPT_2 JLPT_3 JLPT_5 JLPT_N5,"r-[yF55!,-"
+あなた,あなた,you,Genki Genki_Ln.4 JLPT JLPT_5 JLPT_N5,"dwd.i?n%,!"
+兄,あに,(my) older brother (humble),Genki Genki_Ln.14 JLPT JLPT_5 JLPT_N5,L}%Kue=51s
+姉,あね,(my) older sister (humble),Genki Genki_Ln.7 JLPT JLPT_5 JLPT_N5,IX6p9}CO.e
+アパート,アパート,apartment (abbr.),Genki Genki_Ln.7 JLPT JLPT_5 JLPT_N5,wZ/2ki)d+f
+あの,あの,"that over there; like that, that way; um...",JLPT JLPT_4 JLPT_5 JLPT_N5,B2LX%goFyX
+浴びる,あびる,"to bathe, to shower",JLPT JLPT_3 JLPT_5 JLPT_N5,b2.2F3UI=#
+危ない,あぶない,"dangerous, critical",Intermediate_Japanese Intermediate_Japanese_Ln.15 JLPT JLPT_5 JLPT_N5,kjgRC;INvI
+甘い,あまい,"generous, sweet",Genki Genki_Ln.12 JLPT JLPT_5 JLPT_N5,jcM!HlCL`<
+余り,あまり,not very; surplus,JLPT JLPT_3 JLPT_5 JLPT_N5,"l$B(J(k,y1"
+雨,あめ,rain,Genki Genki_Ln.8 JLPT JLPT_5 JLPT_N5,PaXlv})<8_
+飴,あめ,(hard) candy,JLPT JLPT_5 JLPT_N5,v}dp1l^X:W
+洗う,あらう,to wash,Genki Genki_Ln.8 Intermediate_Japanese Intermediate_Japanese_Ln.10 JLPT JLPT_5 JLPT_N5,H=[cc$xhzR
+在る,ある,"to be, to have",JLPT JLPT_3 JLPT_5 JLPT_N5,w$Yz{uB@-`
+有る,ある,"to be, to have",JLPT JLPT_3 JLPT_5 JLPT_N5,v`6i&kQMJj
+歩く,あるく,to walk,Genki Genki_Ln.20 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5,"Kkagn,fSTU"
+あれ,あれ,that one (over there),Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5,Co(PaI(^/_
+いい; よい,いい; よい,good,JLPT JLPT_5 JLPT_N5,O(#?WJE%7H
+いいえ,いいえ,"no, not at all",JLPT JLPT_5 JLPT_N5,"iO`r],Af`o"
+言う,いう,to say,Genki Genki_Ln.8 JLPT JLPT_5 JLPT_N5,iurNhMLEpv
+家,いえ,"house, home",Genki Genki_Ln.3 JLPT JLPT_2 JLPT_3 JLPT_5 JLPT_N5,QGc`#y1e97
+いかが,いかが,"how, in what way",JLPT JLPT_5 JLPT_N5,r5L~xW!JP9
+行く,いく; ゆく,to go,JLPT JLPT_5 JLPT_N5,kJnXhXxW0)
+いくつ,いくつ,"how many, how old",JLPT JLPT_3 JLPT_5 JLPT_N5,mxf9)ZwbLi
+いくら,いくら,"how much, how many",Genki Genki_Ln.2 JLPT JLPT_3 JLPT_5 JLPT_N5,G7]VF2LkZL
+池,いけ,pond,JLPT JLPT_5 JLPT_N5,"u8]?l[G,7&"
+医者,いしゃ,doctor; physician,Genki Genki_Ln.1 Genki_Ln.10 Intermediate_Japanese Intermediate_Japanese_Ln.12 JLPT JLPT_5 JLPT_N5,"f&|8.,xzY9"
+椅子,いす,chair,JLPT JLPT_3 JLPT_5 JLPT_N5,Nxw^e{dZp(
+忙しい,いそがしい,"busy (people, days)",Genki Genki_Ln.5 JLPT JLPT_5 JLPT_N5,pTORshR]m|
+痛い,いたい,hurt; painful; sore,Genki Genki_Ln.12 Intermediate_Japanese Intermediate_Japanese_Ln.5 JLPT JLPT_5 JLPT_N5,O@@jk^&oQ8
+一,いち,one,JLPT JLPT_3 JLPT_5 JLPT_N5,C57gy_Lcmo
+一日,いちにち,one day (duration),Genki Genki_Ln.13 JLPT JLPT_5 JLPT_N5,Q/Fb^F]yhk
+一番,いちばん,"best (most), first, number one",Genki Genki_Ln.10 Intermediate_Japanese Intermediate_Japanese_Ln.3 JLPT JLPT_3 JLPT_5 JLPT_N5,y&ds7j((mb
+いつ,いつ,when,Genki Genki_Ln.3 JLPT JLPT_2 JLPT_5 JLPT_N5,oGX1~x%YQo
+五日,いつか,five days; fifth day of the month,Genki Genki_Ln.13 JLPT JLPT_3 JLPT_5 JLPT_N5,iii]i;bYjg
+一緒,いっしょ,together,Intermediate_Japanese Intermediate_Japanese_Ln.7 JLPT JLPT_5 JLPT_N5,D>uK5dFJy^
+五つ,いつつ,five things,Genki Genki_Ln.9 JLPT JLPT_5 JLPT_N5,Q!*H:Q_rHO
+いつも,いつも,"always, usually, every time, never (with neg. verb)",Genki Genki_Ln.12 JLPT JLPT_3 JLPT_5 JLPT_N5,BM|Xrf53.p
+犬,いぬ,dog,Genki Genki_Ln.4 JLPT JLPT_5 JLPT_N5,"ktH(<>,fX+"
+今,いま,now,Genki Genki_Ln.1 JLPT JLPT_3 JLPT_5 JLPT_N5,N{Ld-iFO]H
+意味,いみ,"meaning, significance",Genki Genki_Ln.12 Intermediate_Japanese Intermediate_Japanese_Ln.2 JLPT JLPT_5 JLPT_N5,xQ(-U#d9Tp
+妹,いもうと,younger sister (humble),Genki Genki_Ln.1 Genki_Ln.7 JLPT JLPT_5 JLPT_N5,BL_XI^txw+
+嫌,いや,"disagreeable, detestable, unpleasant",JLPT JLPT_3 JLPT_5 JLPT_N5,pj6@51cCNZ
+入口,いりぐち,entrance,JLPT JLPT_5 JLPT_N5,"E5~,8$6,oj"
+居る,いる,"(humble) to be (animate), to exist",JLPT JLPT_5 JLPT_N5,wfzvV]4NOO
+要る,いる,to need,JLPT JLPT_5 JLPT_N5,j|TF$iBC;9
+入れる,いれる,to put in,JLPT JLPT_5 JLPT_N5,swmy/(v]Eb
+色,いろ,color,Genki Genki_Ln.9 Intermediate_Japanese Intermediate_Japanese_Ln.9 JLPT JLPT_5 JLPT_N5,"Epa;v6=%P,"
+色々,いろいろ,various,JLPT JLPT_5 JLPT_N5,jV7cB[WgxE
+上,うえ,"above (up, top, etc.), over, on top of",JLPT JLPT_2 JLPT_5 JLPT_N5,"j3j@,T!uH>"
+後ろ,うしろ,"back, behind, rear",JLPT JLPT_3 JLPT_5 JLPT_N5,s:DnwS1iNM
+薄い,うすい,"thin, weak",JLPT JLPT_3 JLPT_5 JLPT_N5,pRrb<$bzH|
+歌,うた,a song,Genki Genki_Ln.7 JLPT JLPT_5 JLPT_N5,JJN9**Hn8A
+歌う,うたう,to sing,Genki Genki_Ln.7 Intermediate_Japanese Intermediate_Japanese_Ln.7 JLPT JLPT_5 JLPT_N5,AN4yH;7MHR
+うち,うち,home; house; my place,Genki Genki_Ln.3 JLPT JLPT_3 JLPT_5 JLPT_N5,u5l2?%hKEd
+生まれる,うまれる,to be born,JLPT JLPT_3 JLPT_5 JLPT_N5,i{d6CiQ#iK
+海,うみ,"sea, beach",Genki Genki_Ln.5 JLPT JLPT_5 JLPT_N5,Cla&e~|Y6P
+売る,うる,to sell (v.t.),Genki Genki_Ln.15 Intermediate_Japanese Intermediate_Japanese_Ln.6 JLPT JLPT_3 JLPT_5 JLPT_N5,nqk=gYOr|$
+うるさい,うるさい,noisy; annoying,Genki Genki_Ln.22 JLPT JLPT_3 JLPT_5 JLPT_N5,fsH/V)BWD4
+上着,うわぎ,"coat, jacket",JLPT JLPT_5 JLPT_N5,nv?u]<OhhN
+絵,え,a painting; a picture; a drawing,Genki Genki_Ln.15 JLPT JLPT_3 JLPT_5 JLPT_N5,E6H3mWmPF1
+映画,えいが,"movie, film",Genki Genki_Ln.3 Intermediate_Japanese Intermediate_Japanese_Ln.7 JLPT JLPT_5 JLPT_N5,Q842_8x`<%
+映画館,えいがかん,"movie theater, cinema",Genki Genki_Ln.15 JLPT JLPT_5 JLPT_N5,tKa%gU>tYk
+英語,えいご,English (language),Genki Genki_Ln.1 JLPT JLPT_5 JLPT_N5,l~kTfp|Na~
+ええ,ええ,yes,Genki Genki_Ln.1 JLPT JLPT_5 JLPT_N5,K4f;DsCIdC
+駅,えき,station,Genki Genki_Ln.10 JLPT JLPT_5 JLPT_N5,EP[wTa2Y![
+エレベーター,エレベーター,elevator,JLPT JLPT_2 JLPT_5 JLPT_N5,GomZ-xrho6
+～円,～えん,Yen,JLPT JLPT_5 JLPT_N5,"rY,[_6)@&p"
+鉛筆,えんぴつ,pencil,Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5,ArKUTnLoi2
+お～,お～,honorable ~ (honorific),JLPT JLPT_5 JLPT_N5,Q1z/@I6[X=
+美味しい,おいしい,"delicious, tasty",JLPT JLPT_5 JLPT_N5,f%Oz)hC{aH
+多い,おおい,many; there are a lot,Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5,CS_ZJ+i5[)
+大きい,おおきい,"big, large",Genki Genki_Ln.5 JLPT JLPT_5 JLPT_N5,N*s[nF-<Om
+大きな,おおきな,big,JLPT JLPT_5 JLPT_N5,"C@,$F5(H&S"
+大勢,おおぜい,great number of people,JLPT JLPT_5 JLPT_N5,d_f[=H{F{<
+お母さん,おかあさん,mother (formal),Genki Genki_Ln.1 Genki_Ln.2 JLPT JLPT_5 JLPT_N5,JmU7?0Aw7)
+お菓子,おかし,"confections, sweets, snack",Genki Genki_Ln.11 JLPT JLPT_5 JLPT_N5,iY2$$8!fW<
+お金,おかね,money,Genki Genki_Ln.6 JLPT JLPT_5 JLPT_N5,uh%`nh}D?M
+起きる,おきる,"to get up (e.g., from sleeping); to happen",Genki Genki_Ln.3 Intermediate_Japanese Intermediate_Japanese_Ln.12 JLPT JLPT_3 JLPT_5 JLPT_N5,i~#f<a525w
+置く,おく,to put; to lay; to place,Genki Genki_Ln.21 JLPT JLPT_3 JLPT_5 JLPT_N5,"KTJ,/<Sfw7"
+奥さん,おくさん,(someone else's) wife (hon.),Genki Genki_Ln.14 Intermediate_Japanese Intermediate_Japanese_Ln.9 JLPT JLPT_5 JLPT_N5,raj<Z6u7R]
+お酒,おさけ,sake; alcohol,Genki Genki_Ln.3 JLPT JLPT_5 JLPT_N5,BPnYG]G`g3
+お皿,おさら,"plate, dish",JLPT JLPT_5 JLPT_N5,"lNBs!SV,D!"
+伯父; 叔父さん,おじさん,"uncle, middle-aged man",JLPT JLPT_5 JLPT_N5,s$4&3o9W|{
+おじいさん,おじいさん,"grandfather, male senior citizen",Genki Genki_Ln.13 JLPT JLPT_3 JLPT_5 JLPT_N5,OnBGSorIYO
+教える,おしえる,"to teach, to inform, to instruct",Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5,&(rx8HabP
+押す,おす,"to push, to press, to stamp (e.g., a passport)",Genki Genki_Ln.18 JLPT JLPT_5 JLPT_N5,O7S.k1^4+9
+遅い,おそい,slow; (to be) late,Genki Genki_Ln.10 Intermediate_Japanese Intermediate_Japanese_Ln.11 JLPT JLPT_5 JLPT_N5,e`TVG4aTiS
+お茶,おちゃ,(green) tea,Genki Genki_Ln.3 Intermediate_Japanese Intermediate_Japanese_Ln.6 JLPT JLPT_5 JLPT_N5,"o|6tDcd,cL"
+お手洗い,おてあらい,"toilet, restroom, bathroom (lit., a place to wash one's hands)",Genki Genki_Ln.2 Intermediate_Japanese Intermediate_Japanese_Ln.13 JLPT JLPT_5 JLPT_N5,jX+//z~!X8
+お父さん,おとうさん,father (formal),Genki Genki_Ln.1 Genki_Ln.2 JLPT JLPT_5 JLPT_N5,Kh?V(6)C|2
+弟,おとうと,younger brother,Genki Genki_Ln.1 Genki_Ln.7 JLPT JLPT_5 JLPT_N5,"ht,o]F,GkV"
+男,おとこ,"man, male",Genki Genki_Ln.17 JLPT JLPT_5 JLPT_N5,QC9-<k]D|G
+男の子,おとこのこ,boy,Genki Genki_Ln.11 JLPT JLPT_5 JLPT_N5,mDCUq=3c&Y
+一昨日,おととい,the day before yesterday,Genki Genki_Ln.19 JLPT JLPT_5 JLPT_N5,n^WNNS^t5D
+おととし,おととし,year before last,JLPT JLPT_5 JLPT_N5,"i$lVvl^Y,~"
+大人,おとな,adult,Genki Genki_Ln.13 JLPT JLPT_5 JLPT_N5,F~j9Wag0^x
+お腹,おなか,stomach,JLPT JLPT_3 JLPT_5 JLPT_N5,GVf+XC=Lx4
+同じ,おなじ,"same, identical",Genki Genki_Ln.14 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5,FT1U+`d~$u
+お兄さん,おにいさん,(someone else's) older brother (formal),Genki Genki_Ln.1 Genki_Ln.7 Intermediate_Japanese Intermediate_Japanese_Ln.4 JLPT JLPT_5 JLPT_N5,c-e]c9shpL
+お姉さん,おねえさん,older sister (formal),Genki Genki_Ln.1 Genki_Ln.7 JLPT JLPT_5 JLPT_N5,"Q,2s6~F,9F"
+伯母さん; 叔母さん,おばさん,aunt,JLPT JLPT_5 JLPT_N5,fk]_fvvw.h
+おばあさん,おばあさん,"grandmother, female senior-citizen",Genki Genki_Ln.6 JLPT JLPT_5 JLPT_N5,K7L64Zdx7D
+お風呂,おふろ,a bath,JLPT_N5,btJ^oH!>Ob
+お弁当,おべんとう,a boxed lunch,Genki Genki_Ln.9 JLPT JLPT_5 JLPT_N5,ou=Mxez95b
+覚える,おぼえる,"to learn, to commit to memory, to remember, to memorize",Intermediate_Japanese Intermediate_Japanese_Ln.2 JLPT JLPT_5 JLPT_N5,k*NiP6Je8n
+おまわりさん,おまわりさん,policeman (friendly term),JLPT JLPT_5 JLPT_N5,kI/erxg?st
+重い,おもい,heavy; serious,Genki Genki_Ln.20 JLPT JLPT_3 JLPT_5 JLPT_N5,n(}tZ@Uv29
+面白い,おもしろい,"interesting, amusing",Genki Genki_Ln.5 Intermediate_Japanese Intermediate_Japanese_Ln.4 JLPT JLPT_5 JLPT_N5,"J&$%9x,#?>"
+泳ぐ,およぐ,to swim,Genki Genki_Ln.5 JLPT JLPT_5 JLPT_N5,bxmTHH/R3s
+降りる,おりる,to get off,JLPT JLPT_3 JLPT_5 JLPT_N5,hM4FhZWg_/
+終る,おわる,"to finish, to close",JLPT JLPT_5 JLPT_N5,D_J6!H@vf*
+音楽,おんがく,Music,Genki Genki_Ln.3 Intermediate_Japanese Intermediate_Japanese_Ln.3 JLPT JLPT_5 JLPT_N5,fcOO[?V993
+女,おんな,"woman, female",Genki Genki_Ln.17 JLPT JLPT_5 JLPT_N5,d3!7^Z7+&i
+女の子,おんなのこ,girl,Genki Genki_Ln.11 JLPT JLPT_5 JLPT_N5,n^ma[3kYmi
+～回,～かい,counter for occurrences (~ times),JLPT JLPT_1 JLPT_5 JLPT_N5,dwW`SX||PF
+～階,～かい,counter for stories (floors) of a building,JLPT JLPT_4 JLPT_5 JLPT_N5,x]4mRhDP?0
+外国,がいこく,foreign country; abroad,Genki Genki_Ln.11 Intermediate_Japanese Intermediate_Japanese_Ln.6 JLPT JLPT_5 JLPT_N5,K:<1s^}$O$
+外国人,がいこくじん,foreigner,Genki Genki_Ln.15 JLPT JLPT_5 JLPT_N5,mxObbkK7.-
+会社,かいしゃ,"company, corporation",Genki Genki_Ln.7 JLPT JLPT_5 JLPT_N5,owc{ezB4?4
+階段,かいだん,stairs,JLPT JLPT_5 JLPT_N5,"ui<=#{,<U^"
+買い物,かいもの,shopping,Genki Genki_Ln.4 JLPT JLPT_5 JLPT_N5,uV:`-T%Eq~
+買う,かう,to buy,JLPT JLPT_3 JLPT_5 JLPT_N5,Q.3jlQZyvW
+返す,かえす,to return something,JLPT JLPT_3 JLPT_5 JLPT_N5,b+[+YOY+dv
+帰る,かえる,"to go back, to go home, to return",Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_3 JLPT_5 JLPT_N5,HBCAN.he?j
+顔,かお,face (body part),Genki Genki_Ln.10 Intermediate_Japanese Intermediate_Japanese_Ln.2 JLPT JLPT_3 JLPT_5 JLPT_N5,MGLL{4`mK@
+かかる,かかる,"it takes (amount of time, money) (v.i.)",Genki Genki_Ln.10 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_3 JLPT_5 JLPT_N5,yajlZ<1W@=
+鍵,かぎ,a lock; a key,Genki Genki_Ln.17 JLPT JLPT_3 JLPT_5 JLPT_N5,CBifo1C?=d
+書く,かく,to write,JLPT JLPT_3 JLPT_5 JLPT_N5,ytOa}oy+zO
+学生,がくせい,student,Genki Genki_Ln.1 JLPT JLPT_5 JLPT_N5,"JC,(K4dD=="
+～か月,～かげつ,(number of) months,JLPT JLPT_5 JLPT_N5,p^^qFJHF)[
+掛ける,かける,"to put on (e.g., glasses); to hang (e.g., on a wall)",JLPT JLPT_3 JLPT_4 JLPT_5 JLPT_N5,J@I.fZoEvE
+かける,かける,"to dial/call (e.g., phone); to sit down",Genki Genki_Ln.19 JLPT JLPT_3 JLPT_4 JLPT_5 JLPT_N5,j[@hZ&;%2u
+傘,かさ,"umbrella, parasol",Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5,p_LV=Cf?pc
+貸す,かす,to lend,Intermediate_Japanese Intermediate_Japanese_Ln.3 JLPT JLPT_5 JLPT_N5,yag&XA]F86
+風,かぜ,"wind, breeze",Genki Genki_Ln.22 JLPT JLPT_5 JLPT_N5,wPz(SGuAqF
+風邪,かぜ,"cold, flu",Genki Genki_Ln.12 JLPT JLPT_5 JLPT_N5,"G#zadB[Bd,"
+方,かた,-- honorific form for 人 (ひと) --; way of doing,Intermediate_Japanese Intermediate_Japanese_Ln.4 JLPT JLPT_3 JLPT_4 JLPT_5 JLPT_N5,GtdTiap.Os
+家族,かぞく,"family, members of a family",Genki Genki_Ln.7 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5,jwBW:Yf?[N
+片仮名,かたかな,katakana,JLPT JLPT_5 JLPT_N5,y%B]18.T{|
+～月,～がつ,month of year,JLPT JLPT_5 JLPT_N5,x[qBqm:mer
+学校,がっこう,a school,Genki Genki_Ln.3 JLPT JLPT_5 JLPT_N5,jMUlk]n4bL
+カップ,カップ,cup,JLPT JLPT_1 JLPT_5 JLPT_N5,N>J.3DDIIf
+家庭,かてい,home; family,Intermediate_Japanese Intermediate_Japanese_Ln.3 JLPT JLPT_3 JLPT_5 JLPT_N5,K=/LkA^bE5
+角,かど,"corner (e.g., desk, pavement)",Genki Genki_Ln.20 JLPT JLPT_5 JLPT_N5,NblB:vgsi`
+かばん,かばん,"bag, basket",Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5,M4T~@ehWYB
+花瓶,かびん,(flower) vase,JLPT JLPT_5 JLPT_N5,m<:4xC~U|%
+かぶる,かぶる,"to wear, to put on (e.g., a hat on the head)",Genki Genki_Ln.7 JLPT JLPT_3 JLPT_5 JLPT_N5,"v~,/++9.ks"
+紙,かみ,paper,Genki Genki_Ln.17 JLPT JLPT_3 JLPT_5 JLPT_N5,BZj5w]P?W@
+カメラ,カメラ,camera,Genki Genki_Ln.8 JLPT JLPT_5 JLPT_N5,m@gkXGnk1!
+火曜日,かようび,Tuesday,Genki Genki_Ln.4 JLPT JLPT_5 JLPT_N5,rx9;D%FE+1
+辛い,からい,hot and spicy; salty,Genki Genki_Ln.13 JLPT JLPT_5 JLPT_N5,EjaGe<]5<&
+体,からだ,body; health,Genki Genki_Ln.23 Intermediate_Japanese Intermediate_Japanese_Ln.4 JLPT JLPT_5 JLPT_N5,x=d[R_7msH
+借りる,かりる,"to borrow, to owe",JLPT JLPT_5 JLPT_N5,EV_.CiOUqY
+～がる,～がる,feel,JLPT JLPT_5 JLPT_N5,e--3P:#0au
+軽い,かるい,"light, non-serious, minor",JLPT JLPT_5 JLPT_N5,"Q?,F=N/]i*"
+カレー,カレー,curry (abbr. for curry and rice),Genki Genki_Ln.13 JLPT JLPT_1 JLPT_5 JLPT_N5,l)iLA}_6t!
+カレンダー,カレンダー,calendar,JLPT JLPT_5 JLPT_N5,"H,vNs@Ml~$"
+川; 河,かわ,river,JLPT JLPT_3 JLPT_5 JLPT_N5,QzV_(D2VAO
+～側,～がわ,~ side,JLPT_N5,ks2wGx4U0-
+可愛い,かわいい,"cute, adorable",JLPT JLPT_5 JLPT_N5,"cM$xbG,Do&"
+漢字,かんじ,kanji; Chinese character,Genki Genki_Ln.6 Intermediate_Japanese Intermediate_Japanese_Ln.4 JLPT JLPT_3 JLPT_5 JLPT_N5,"yx;[,(ZC<M"
+木,き,"tree, wood, timber",Genki Genki_Ln.22 JLPT JLPT_5 JLPT_N5,"Pt,~h2%O9J"
+黄色,きいろ,yellow,JLPT JLPT_5 JLPT_N5,c$:@4*e3c*
+黄色い,きいろい,yellow,JLPT JLPT_5 JLPT_N5,yw~rIwG)7I
+消える,きえる,"to vanish, to disappear",Genki Genki_Ln.18 JLPT JLPT_5 JLPT_N5,Hl(tY84I}b
+聞く,きく,"to hear, to listen, to ask",JLPT JLPT_3 JLPT_5 JLPT_N5,CbCe+?lSS(
+北,きた,north,Intermediate_Japanese Intermediate_Japanese_Ln.10 JLPT JLPT_5 JLPT_N5,c_4*(T~qY|
+ギター,ギター,guitar,Genki Genki_Ln.9 JLPT JLPT_5 JLPT_N5,gl.RMMgxvn
+汚い,きたない,"dirty, unclean, filthy",Genki Genki_Ln.16 JLPT JLPT_5 JLPT_N5,gA&c1.)X%=
+喫茶店,きっさてん,café,Genki Genki_Ln.2 Intermediate_Japanese Intermediate_Japanese_Ln.11 JLPT JLPT_5 JLPT_N5,b3?(}lhy[4
+切手,きって,postal (postage) stamps,Genki Genki_Ln.5 Intermediate_Japanese Intermediate_Japanese_Ln.3 JLPT JLPT_5 JLPT_N5,GZ2eU+7^)f
+切符,きっぷ,a ticket,Genki Genki_Ln.5 Intermediate_Japanese Intermediate_Japanese_Ln.10 JLPT JLPT_5 JLPT_N5,i@ntG+Gt0l
+昨日,きのう,yesterday,Genki Genki_Ln.4 JLPT JLPT_3 JLPT_5 JLPT_N5,"mMKJxv#,<s"
+九,きゅう,nine,JLPT JLPT_3 JLPT_5 JLPT_N5,PCz+i!/c^t
+牛肉,ぎゅうにく,beef,JLPT JLPT_5 JLPT_N5,"HN>QIS,sa)"
+牛乳,ぎゅうにゅう,milk,Genki Genki_Ln.18 JLPT JLPT_5 JLPT_N5,fkn+n(t~hl
+今日,きょう,"today, this day",Genki Genki_Ln.3 JLPT JLPT_5 JLPT_N5,bCP{!%CS>.
+教室,きょうしつ,classroom,Intermediate_Japanese Intermediate_Japanese_Ln.3 JLPT JLPT_5 JLPT_N5,jd>*%:rgPV
+兄弟,きょうだい,"siblings (humble), brothers and sisters",Genki Genki_Ln.7 JLPT JLPT_5 JLPT_N5,tg~Kr0A/Mn
+去年,きょねん,last year,Genki Genki_Ln.14 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5,zrXmT>AI2s
+嫌い,きらい,dislike,JLPT JLPT_5 JLPT_N5,"qw1}y,Um4C"
+切る,きる,to cut; to hang up (a phone),Genki Genki_Ln.8 Intermediate_Japanese Intermediate_Japanese_Ln.12 JLPT JLPT_5 JLPT_N5,A;e]B2v]77
+着る,きる,to put on (clothes above your waist); to wear,Genki Genki_Ln.7 Intermediate_Japanese Intermediate_Japanese_Ln.9 JLPT JLPT_5 JLPT_N5,g$-Eqb.V#N
+綺麗,きれい,"pretty, clean, tidy",JLPT JLPT_5 JLPT_N5,y:f/R>36c4
+キロ; キログラム,キロ; キログラム,(abbr.) kilo (kilogram),JLPT JLPT_3 JLPT_5 JLPT_N5,"v,MI,fa=Pd"
+キロ; キロメートル,キロ; キロメートル,(abbr.) kilo (kilometer),JLPT JLPT_3 JLPT_5 JLPT_N5,I+%u|o<M9)
+銀行,ぎんこう,bank,Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5,dJzM6E^Crr
+金曜日,きんようび,Friday,Genki Genki_Ln.4 JLPT JLPT_3 JLPT_5 JLPT_N5,H)-<3>G;wq
+九,く,nine,JLPT JLPT_3 JLPT_5 JLPT_N5,J.@??p5!Es
+薬,くすり,medicine,Genki Genki_Ln.9 Intermediate_Japanese Intermediate_Japanese_Ln.12 JLPT JLPT_5 JLPT_N5,e<qA>@afcN
+下さい,ください,(with te-form verb) please do for me,JLPT JLPT_5 JLPT_N5,wZXS53y~A
+果物,くだもの,fruit,Intermediate_Japanese Intermediate_Japanese_Ln.9 JLPT JLPT_5 JLPT_N5,"ff8}}%,}l0"
+口,くち,job opening; mouth,Intermediate_Japanese Intermediate_Japanese_Ln.11 Intermediate_Japanese_Ln.8 JLPT JLPT_5 JLPT_N5,ODcS@5Ag5;
+靴,くつ,"shoes, footwear",Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5,n}XPqtAFrb
+靴下,くつした,socks,Genki Genki_Ln.23 JLPT JLPT_5 JLPT_N5,"m{wv6,~qH4"
+国,くに,country; place of origin,Genki Genki_Ln.7 JLPT JLPT_5 JLPT_N5,qu43})1T{b
+曇り,くもり,"cloudiness, cloudy weather",Genki Genki_Ln.12 JLPT JLPT_3 JLPT_5 JLPT_N5,"J%t?_,0ZZ)"
+曇る,くもる,"to become cloudy, to become dim",JLPT JLPT_5 JLPT_N5,h68<#-5u4*
+暗い,くらい,"dark, gloomy",JLPT JLPT_3 JLPT_5 JLPT_N5,l[W6inIL/c
+～くらい; ぐらい,～くらい; ぐらい,approximate (quantity),JLPT JLPT_5 JLPT_N5,i|aE4l1U6h
+クラス,クラス,a class,Genki Genki_Ln.4 JLPT JLPT_5 JLPT_N5,I|[#&/BoM*
+グラム,グラム,gram,JLPT JLPT_5 JLPT_N5,wf@~Kdx9Mo
+来る,くる,to come,JLPT JLPT_5 JLPT_N5,t8%I(!NKuq
+車,くるま,"car, vehicle",Genki Genki_Ln.7 JLPT JLPT_5 JLPT_N5,Dp50G3U@L=
+黒,くろ,black,JLPT JLPT_5 JLPT_N5,eM3bqzySWE
+黒い,くろい,black; dark,Genki Genki_Ln.9 JLPT JLPT_5 JLPT_N5,y`TB7E}KvC
+警官,けいかん,police officer,JLPT JLPT_5 JLPT_N5,r|k<lg[-^X
+今朝,けさ,this morning,Genki Genki_Ln.8 Intermediate_Japanese Intermediate_Japanese_Ln.2 JLPT JLPT_5 JLPT_N5,Ojh!YT%>_O
+消す,けす,"to erase, to delete, to turn off power",JLPT JLPT_5 JLPT_N5,kyBQ8>]kOz
+結構,けっこう,"splendid; enough, tolerably",JLPT JLPT_3 JLPT_5 JLPT_N5,OhYc[d+;sX
+結婚,けっこん (する),marriage (get married),JLPT JLPT_5 JLPT_N5,yoFb9mQ>xx
+月曜日,げつようび,Monday,Genki Genki_Ln.4 JLPT JLPT_3 JLPT_5 JLPT_N5,py]#+qmS;#
+玄関,げんかん,entrance (to a house or a building),Intermediate_Japanese Intermediate_Japanese_Ln.5 JLPT JLPT_4 JLPT_5 JLPT_N5,nzna3U1d%4
+元気,げんき,"health(y), energetic",JLPT JLPT_5 JLPT_N5,C6oDoveAM%
+～個,～こ,"counter for small items (e.g., fruits, cups)",JLPT JLPT_2 JLPT_5 JLPT_N5,"L)v,!KJ|+1"
+五,ご,five,JLPT JLPT_3 JLPT_5 JLPT_N5,CPX]&C<[AA
+～語,～ご,"word, language",JLPT JLPT_5 JLPT_N5,OS-NJNma:q
+公園,こうえん,a park,Genki Genki_Ln.4 JLPT JLPT_3 JLPT_5 JLPT_N5,"I!nU=ub,Sv"
+交差点,こうさてん,intersection,JLPT JLPT_5 JLPT_N5,fB2Ek#M/vd
+紅茶,こうちゃ,black tea,Genki Genki_Ln.13 JLPT JLPT_5 JLPT_N5,k->[;qN`>7
+交番,こうばん,police box,JLPT JLPT_5 JLPT_N5,Opg/[%q+N8
+声,こえ,voice,Intermediate_Japanese Intermediate_Japanese_Ln.2 JLPT JLPT_5 JLPT_N5,In/Jo>[]?<
+コート,コート,"coat; court (e.g., tennis)",JLPT JLPT_5 JLPT_N5,"e4scbA,t~J"
+コーヒー,コーヒー,coffee,Genki Genki_Ln.3 JLPT JLPT_5 JLPT_N5,d<P1^SSa-:
+ここ,ここ,"here, this place",Genki Genki_Ln.4 JLPT JLPT_3 JLPT_5 JLPT_N5,Lq)wtpkam*
+午後,ごご,"afternoon, P.M.",Genki Genki_Ln.1 JLPT JLPT_5 JLPT_N5,C_ZC&#?>G!
+九日,ここのか,nine days; ninth day of the month,Genki Genki_Ln.13 JLPT JLPT_5 JLPT_N5,l7hYJ[~^44
+九つ,ここのつ,nine things,Genki Genki_Ln.9 JLPT JLPT_5 JLPT_N5,DvF}1X8pH=
+午前,ごぜん,"morning, A.M.",Genki Genki_Ln.1 JLPT JLPT_5 JLPT_N5,ue~BwANA9n
+答える,こたえる,"to answer, to reply",JLPT JLPT_5 JLPT_N5,x<$h-)|1km
+こちら,こちら,this person (polite); this way (polite),Genki Genki_Ln.11 Genki_Ln.19 JLPT JLPT_5 JLPT_N5,A^:pzWeFGD
+こっち,こっち,this person; this direction; this side,JLPT JLPT_4 JLPT_5 JLPT_N5,KZ(~KRGBCG
+コップ,コップ,a tumbler; a glass,Genki Genki_Ln.14 JLPT JLPT_5 JLPT_N5,fS_r5k@$Y6
+今年,ことし,this year,Genki Genki_Ln.10 JLPT JLPT_5 JLPT_N5,F4V9w7@Age
+言葉,ことば,language; word(s); expression(s),Genki Genki_Ln.13 Intermediate_Japanese Intermediate_Japanese_Ln.2 JLPT JLPT_5 JLPT_N5,EWtR7eO/R4
+子供,こども,child(ren),Genki Genki_Ln.4 Intermediate_Japanese Intermediate_Japanese_Ln.2 JLPT JLPT_5 JLPT_N5,CU[{wZ(D{$
+この,この,this,JLPT JLPT_3 JLPT_5 JLPT_N5,pPsd:zD9O?
+御飯,ごはん,rice (cooked); meal,Genki Genki_Ln.4 JLPT JLPT_5 JLPT_N5,biiyLkNokP
+コピーする,コピーする,to copy,JLPT JLPT_3 JLPT_5 JLPT_N5,pIfdJ-gQ=x
+困る,こまる,"to be bothered, to have difficulty",Genki Genki_Ln.16 JLPT JLPT_5 JLPT_N5,QJ1l#P3oS5
+これ,これ,this one,Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5,CY7%/#&PC;
+～ころ; ～ごろ,～ころ; ～ごろ,"about, toward, approximately (time)",JLPT JLPT_5 JLPT_N5,ygFZGug3gm
+今月,こんげつ,this month,Genki Genki_Ln.8 JLPT JLPT_5 JLPT_N5,m1R02~~j[
+今週,こんしゅう,this week,Genki Genki_Ln.6 JLPT JLPT_5 JLPT_N5,DK9g?(!36`
+こんな,こんな,"such, like this",JLPT JLPT_5 JLPT_N5,DuEU98EMih
+今晩,こんばん,"tonight, this evening",Genki Genki_Ln.3 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5,F3};?W>+5Y
+さあ,さあ,"come now, well",JLPT JLPT_5 JLPT_N5,Ag`@=t><OI
+～歳,～さい,~ years old,JLPT JLPT_2 JLPT_5 JLPT_N5,yIt4LQzbb!
+財布,さいふ,wallet,Genki Genki_Ln.2 Intermediate_Japanese Intermediate_Japanese_Ln.4 JLPT JLPT_5 JLPT_N5,xwbRMO4c<;
+魚,さかな,fish,Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5,zzI@?Uq@Z[
+先,さき,"future; recent, previous",JLPT JLPT_5 JLPT_N5,tGm0X7=@hF
+咲く,さく,to bloom,Genki Genki_Ln.18 JLPT JLPT_3 JLPT_5 JLPT_N5,F>Pt~gStbR
+作文,さくぶん,essay; composition,Genki Genki_Ln.9 JLPT JLPT_5 JLPT_N5,fOn$od$Eoc
+差す,さす,"to raise (stretch out) hands, to raise (e.g., umbrella)",JLPT JLPT_3 JLPT_5 JLPT_N5,b|c|&{UKxH
+～冊,～さつ,counter for books,JLPT JLPT_5 JLPT_N5,DJ:3n{-XN%
+雑誌,ざっし,"magazine, journal",Genki Genki_Ln.3 Intermediate_Japanese Intermediate_Japanese_Ln.8 JLPT JLPT_5 JLPT_N5,gVzfIhXfBF
+砂糖,さとう,sugar,Genki Genki_Ln.16 JLPT JLPT_5 JLPT_N5,M]8mQGX#}E
+寒い,さむい,cold (in reference to weather),Genki Genki_Ln.5 Intermediate_Japanese Intermediate_Japanese_Ln.2 JLPT JLPT_5 JLPT_N5,x@[mMxA?Z}
+さ来年,さらいねん,year after next,JLPT JLPT_5 JLPT_N5,C4/Z2oi:V>
+～さん,～さん,"Mr. ~, Ms. ~",JLPT JLPT_2 JLPT_5 JLPT_N5,i|L#.MVmNG
+三,さん,three,JLPT JLPT_5 JLPT_N5,jB}%X}YQ)P
+散歩,さんぽ (する),"walk, stroll",JLPT JLPT_3 JLPT_5 JLPT_N5,C7E%FY>8|T
+四,し,four,JLPT JLPT_3 JLPT_5 JLPT_N5,q%G#*K^0R+
+～時,～じ,~ o'clock (time),JLPT JLPT_1 JLPT_5 JLPT_N5,m]7PVW-h[^
+塩,しお,salt,JLPT JLPT_5 JLPT_N5,mQXb>=tTk}
+しかし,しかし,however; but,Intermediate_Japanese Intermediate_Japanese_Ln.3 JLPT JLPT_5 JLPT_N5,g2(en9wt=#
+時間,じかん,time,Genki Genki_Ln.14 JLPT JLPT_2 JLPT_5 JLPT_N5,rl<d#jP#zf
+～時間,～じかん,~ hours,JLPT JLPT_5 JLPT_N5,PfD-$$uDhD
+仕事,しごと,"work, job, occupation, employment",Genki Genki_Ln.1 Genki_Ln.8 JLPT JLPT_5 JLPT_N5,BpR$XStq*~
+辞書,じしょ,dictionary,Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5,Ls?+XP<x!7
+静か,しずか,"quiet, calm",JLPT JLPT_5 JLPT_N5,P>BDZl[pK4
+下,した,"under, below, beneath",JLPT JLPT_3 JLPT_5 JLPT_N5,j8V7%&V*V9
+七,しち,seven,JLPT JLPT_3 JLPT_5 JLPT_N5,d9Ei.i(]l3
+質問,しつもん,"question, inquiry",Intermediate_Japanese Intermediate_Japanese_Ln.2 JLPT JLPT_5 JLPT_N5,hbG&tzjk([
+自転車,じてんしゃ,bicycle,Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5,cQ/jE!IBMW
+自動車,じどうしゃ,automobile,JLPT JLPT_5 JLPT_N5,s>B81r@vvP
+死ぬ,しぬ,to die,Genki Genki_Ln.6 JLPT JLPT_5 JLPT_N5,DTv8zMSE:A
+字引,じびき,dictionary,JLPT JLPT_5 JLPT_N5,"q(KV,tLbs@"
+自分,じぶん,"myself, oneself",Genki Genki_Ln.17 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5,PVgO:!yY%&
+閉まる,しまる,"to close, to be closed",JLPT JLPT_5 JLPT_N5,gcQz%z-FEM
+閉める,しめる,"to close, to shut",JLPT JLPT_3 JLPT_5 JLPT_N5,gf.^6?5[K1
+締める,しめる,"to tie, to fasten, to tighten",JLPT JLPT_3 JLPT_5 JLPT_N5,zslBUbe/:)
+じゃ; じゃあ,じゃ; じゃあ,"well, well then",JLPT JLPT_3 JLPT_5 JLPT_N5,I*;H$6{i?j
+写真,しゃしん,a picture; a photograph,Genki Genki_Ln.4 Intermediate_Japanese Intermediate_Japanese_Ln.4 JLPT JLPT_5 JLPT_N5,uE&XA7mYm9
+シャツ,シャツ,shirt,Genki Genki_Ln.10 JLPT JLPT_5 JLPT_N5,ubVcrQ$8%@
+シャワー,シャワー,shower,JLPT JLPT_5 JLPT_N5,op46S^HFU7
+十,じゅう,ten,JLPT JLPT_3 JLPT_5 JLPT_N5,t#RE}A*?;i
+～中,～じゅう,"during, while",JLPT JLPT_2 JLPT_5 JLPT_N5,GjJjAMMc<N
+～週間,～しゅうかん,~ weeks,JLPT JLPT_5 JLPT_N5,B5/n=cEC&j
+授業,じゅぎょう,a class (of school),Genki Genki_Ln.11 Intermediate_Japanese Intermediate_Japanese_Ln.3 JLPT JLPT_2 JLPT_5 JLPT_N5,In^9^.q{~0
+宿題,しゅくだい,homework,Genki Genki_Ln.5 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5,PE;OT+iIoY
+上手,じょうず,"be good at, skillful",JLPT JLPT_5 JLPT_N5,zE7uPe$TPk
+丈夫,じょうぶ,"strong, solid, durable",JLPT JLPT_5 JLPT_N5,"rzxPYrs,=L"
+醤油,しょうゆ,soy sauce,Genki Genki_Ln.18 JLPT JLPT_5 JLPT_N5,Cx=6Q3yGAf
+食堂,しょくどう,"cafeteria, dining hall",Genki Genki_Ln.7 JLPT JLPT_5 JLPT_N5,q/e+PknS.X
+知る,しる,"to know, to understand",Genki Genki_Ln.7 JLPT JLPT_5 JLPT_N5,jmoS>4h`&Q
+白,しろ,white,JLPT JLPT_3 JLPT_5 JLPT_N5,?4vV_taj)
+白い,しろい,white,Genki Genki_Ln.9 JLPT JLPT_5 JLPT_N5,yL-#%FMe~@
+～人,～じん,counter for people,JLPT JLPT_5 JLPT_N5,cRB`piJTT=
+新聞,しんぶん,newspaper,Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5,u)<uacY_Qa
+水曜日,すいようび,Wednesday,Genki Genki_Ln.4 JLPT JLPT_5 JLPT_N5,kl%)(*`5]a
+吸う,すう,"to breathe in, to suck",JLPT JLPT_3 JLPT_5 JLPT_N5,wwi3CXCv2|
+スカート,スカート,skirt,Genki Genki_Ln.18 JLPT JLPT_5 JLPT_N5,NE$eFg+K&Y
+好き,すき,"liking, fondness, love",JLPT JLPT_5 JLPT_N5,B}kz{&9>=0
+～すぎ,～すぎ,"past; to exceed, ~ too much",JLPT JLPT_5 JLPT_N5,D/A*oT1;-^
+少ない,すくない,a little; a few,Genki Genki_Ln.17 JLPT JLPT_5 JLPT_N5,O}E#|bt5>=
+すぐに,すぐに,"immediately, soon",JLPT JLPT_5 JLPT_N5,c+_z#9>We^
+少し,すこし,"little, few",Genki Genki_Ln.21 JLPT JLPT_5 JLPT_N5,LEWblI/l<)
+涼しい,すずしい,"cool, refreshing (in reference to weather)",Genki Genki_Ln.10 JLPT JLPT_5 JLPT_N5,y%0&)B2:*;
+～ずつ,～ずつ,at a time,JLPT JLPT_5 JLPT_N5,e7*dq)(1^5
+ストーブ,ストーブ,heater (lit: stove),Genki Genki_Ln.17 JLPT JLPT_5 JLPT_N5,xw_f78(-:7
+スプーン,スプーン,spoon,JLPT JLPT_5 JLPT_N5,FjQLk(n?P#
+スポーツ,スポーツ,sport(s),Genki Genki_Ln.3 JLPT JLPT_5 JLPT_N5,F^wO!?E%?^
+ズボン,ズボン,trousers,JLPT JLPT_5 JLPT_N5,"FU-<z{1,6("
+住む,すむ,"to reside, to live in",JLPT JLPT_3 JLPT_5 JLPT_N5,ym>?}%jeF+
+する,する,"to do, to try; to wear small items (e.g., necktie, watch, etc.)",Genki Genki_Ln.17 JLPT JLPT_3 JLPT_5 JLPT_N5,"LT|A_z,G+T"
+座る,すわる,to sit,JLPT JLPT_5 JLPT_N5,dn)bcr6wXa
+背,せい,"(one's) height, stature",Intermediate_Japanese Intermediate_Japanese_Ln.4 JLPT JLPT_3 JLPT_5 JLPT_N5,xQDy{9R)S2
+生徒,せいと,student; pupil,Intermediate_Japanese Intermediate_Japanese_Ln.5 JLPT JLPT_5 JLPT_N5,c2wTXo?)*o
+セーター,セーター,sweater,Genki Genki_Ln.13 JLPT JLPT_5 JLPT_N5,NSeOhKH2D6
+石鹸,せっけん,soap,JLPT JLPT_5 JLPT_N5,tY/1~r6Mz5
+背広,せびろ,men's suit,Intermediate_Japanese Intermediate_Japanese_Ln.9 JLPT JLPT_5 JLPT_N5,w`:i7/YHYU
+狭い,せまい,narrow; not spacious,Genki Genki_Ln.12 Intermediate_Japanese Intermediate_Japanese_Ln.15 JLPT JLPT_5 JLPT_N5,yDZurM]5mn
+ゼロ,ゼロ,zero,JLPT JLPT_5 JLPT_N5,G~4~zg|xJJ
+千,せん,thousand,JLPT JLPT_5 JLPT_N5,IvU;IZmo9!
+先月,せんげつ,last month,Genki Genki_Ln.9 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5,RcD!zS6[>I
+先週,せんしゅう,last week,Genki Genki_Ln.4 JLPT JLPT_5 JLPT_N5,EbyugR;^Rz
+先生,せんせい,"teacher, professor; master; doctor",Genki Genki_Ln.1 JLPT JLPT_5 JLPT_N5,A`19t`6J6t
+洗濯,せんたく,"washing, laundry",Intermediate_Japanese Intermediate_Japanese_Ln.11 JLPT JLPT_3 JLPT_5 JLPT_N5,vQ&mbAJqN7
+全部,ぜんぶ,"all, entire, whole",Genki Genki_Ln.13 Intermediate_Japanese Intermediate_Japanese_Ln.3 JLPT JLPT_5 JLPT_N5,MgJu@!Fk&_
+そう; そうです,そう; そうです,"yes; appears, to be the case",JLPT JLPT_5 JLPT_N5,kkfDg[|_Yb
+掃除,そうじ (する),"cleaning, sweeping",JLPT JLPT_3 JLPT_5 JLPT_N5,LKKhbs9g8/
+そうして; そして,そうして; そして,"and, like that",JLPT JLPT_5 JLPT_N5,C/Lx0#`!+J
+そこ,そこ,"that place, there; bottom, sole",Genki Genki_Ln.4 JLPT JLPT_2 JLPT_3 JLPT_5 JLPT_N5,v56KFY.>v@
+そちら,そちら,over there,JLPT JLPT_5 JLPT_N5,xbjis~A;+*
+そっち,そっち,over there,JLPT JLPT_5 JLPT_N5,#PXdxM^5L
+外,そと,"outside, exterior",Genki Genki_Ln.18 Intermediate_Japanese Intermediate_Japanese_Ln.2 JLPT JLPT_5 JLPT_N5,AFB3>g85F]
+その,その,that,JLPT JLPT_3 JLPT_5 JLPT_N5,C2OIF=[)E_
+そば,そば,"near, close, beside; Japanese traditional buckwheat noodle",Genki Genki_Ln.15 JLPT JLPT_3 JLPT_5 JLPT_N5,M)]t*`<F@c
+空,そら,sky,JLPT JLPT_5 JLPT_N5,D.6b;1{88^
+それ,それ,that one,Genki Genki_Ln.2 JLPT JLPT_3 JLPT_5 JLPT_N5,t%n)3@@XX+
+それから,それから,"and then, after that",Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5,sV(hn]KLzr
+それでは,それでは,"in that situation, well then...",JLPT JLPT_5 JLPT_N5,"v[]T|jw&,["
+～台,～だい,counter for vehicles; machines,JLPT JLPT_5 JLPT_N5,ztM0ejgNN~
+大学,だいがく,college; university,Genki Genki_Ln.1 JLPT JLPT_5 JLPT_N5,kHyc<WfmUQ
+大使館,たいしかん,embassy,JLPT JLPT_5 JLPT_N5,"n?Lz{tQ,#T"
+大丈夫,だいじょうぶ,It's ok (all right); No need to worry; Everything is under control,Genki Genki_Ln.5 Intermediate_Japanese Intermediate_Japanese_Ln.3 JLPT JLPT_5 JLPT_N5,nEIlSJfx#r
+大好き,だいすき,"very like-able, like very much",JLPT JLPT_5 JLPT_N5,"AZ,CM~A,0E"
+大切,たいせつ,important,JLPT JLPT_5 JLPT_N5,tu70?MYeL5
+台所,だいどころ,kitchen,JLPT JLPT_5 JLPT_N5,bbB25MOf:$
+大変,たいへん,"very; difficult, hard",JLPT JLPT_3 JLPT_5 JLPT_N5,NIbD<|-[1y
+高い,たかい,"tall, high; expensive",Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5,veG&GbRNS(
+～だけ,～だけ,"only ~, just ~, as ~",JLPT JLPT_1 JLPT_5 JLPT_N5,Lcbr*3r3b5
+沢山,たくさん,"many, much",JLPT JLPT_5 JLPT_N5,v7m[:9zL*Y
+タクシー,タクシー,taxi,JLPT JLPT_5 JLPT_N5,k8!n/<-@<9
+出す,だす,to take (something) out; to hand in (something),Genki Genki_Ln.16 JLPT JLPT_5 JLPT_N5,bt0(EU(<V_
+～たち,～たち,plural suffix,JLPT JLPT_5 JLPT_N5,Opbd!87m@p
+立つ,たつ,to stand up,Genki Genki_Ln.6 JLPT JLPT_3 JLPT_5 JLPT_N5,z+IsiLqO4K
+たて,たて,"length, height",JLPT JLPT_3 JLPT_5 JLPT_N5,L8wVt#MfRS
+建物,たてもの,building,Intermediate_Japanese Intermediate_Japanese_Ln.5 JLPT JLPT_5 JLPT_N5,mty2M&KETp
+楽しい,たのしい,"enjoyable, fun",Genki Genki_Ln.5 JLPT JLPT_5 JLPT_N5,eD~FeZpJXC
+頼む,たのむ,"to request, to ask (a favor)",Genki Genki_Ln.18 Intermediate_Japanese Intermediate_Japanese_Ln.3 JLPT JLPT_5 JLPT_N5,zjk+2%xAp%
+たばこ,たばこ,"tobacco, cigarettes",JLPT JLPT_5 JLPT_N5,y<?W4xcfCN
+多分,たぶん,"perhaps, probably, maybe",Genki Genki_Ln.12 Intermediate_Japanese Intermediate_Japanese_Ln.2 JLPT JLPT_3 JLPT_5 JLPT_N5,pNDK+)ARo
+食べ物,たべもの,food,Genki Genki_Ln.5 JLPT JLPT_5 JLPT_N5,ODKLC3jdI>
+食べる,たべる,to eat,JLPT JLPT_5 JLPT_N5,c.+pIV(7xY
+卵,たまご,egg,Intermediate_Japanese Intermediate_Japanese_Ln.6 JLPT JLPT_5 JLPT_N5,c|(S)f_).K
+誰,だれ,who,Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5,gDqm6J+#/O
+誰か,だれか,someone,JLPT JLPT_3 JLPT_5 JLPT_N5,K{JPl*mB/&
+誕生日,たんじょうび,birthday,Genki Genki_Ln.5 JLPT JLPT_5 JLPT_N5,HV8#h@HniT
+段々,だんだん,"gradually, by degrees",JLPT JLPT_5 JLPT_N5,O8dRR}CL>
+小さい,ちいさい,"small, little",Genki Genki_Ln.5 JLPT JLPT_5 JLPT_N5,LNu9:vy!G1
+小さな,ちいさな,"small, little",JLPT JLPT_5 JLPT_N5,lc*~Cd~D@4
+近い,ちかい,"near, close by, short",Genki Genki_Ln.13 JLPT JLPT_5 JLPT_N5,"ttC.1]n,0|"
+違う,ちがう,to be different; to differ; wrong,Genki Genki_Ln.23 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5,N2Hj9)qK/l
+近く,ちかく,nearby; in the neighborhood,Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5,y)Y*_^+)&<
+地下鉄,ちかてつ,"underground train, subway",Genki Genki_Ln.10 JLPT JLPT_5 JLPT_N5,MEsyrZ*cPc
+地図,ちず,a map,Genki Genki_Ln.15 Intermediate_Japanese Intermediate_Japanese_Ln.12 JLPT JLPT_5 JLPT_N5,dhY*~Tx!fs
+父,ちち,(my) father,Genki Genki_Ln.7 JLPT JLPT_5 JLPT_N5,QKI#T(oT`t
+茶色,ちゃいろ,brown,JLPT JLPT_5 JLPT_N5,h<Se0W>cwB
+茶碗,ちゃわん,rice bowl,JLPT JLPT_5 JLPT_N5,p6c8>jnMm!
+～中,～ちゅう,"during, while ~ing",JLPT JLPT_5 JLPT_N5,J]E)zcwU%w
+丁度,ちょうど,"just, right, exactly",JLPT JLPT_5 JLPT_N5,K@fxH}$AC8
+ちょっと,ちょっと,"a little, somewhat; just a little, somewhat",Genki Genki_Ln.3 JLPT JLPT_2 JLPT_5 JLPT_N5,j)OcO!#[%u
+一日,ついたち,one day; first day of the month,JLPT JLPT_5 JLPT_N5,qK&D4iveg
+使う,つかう,to use,JLPT JLPT_5 JLPT_N5,B(Ve/L8[z5
+疲れる,つかれる,to get (become) tired; to become fatigued,Genki Genki_Ln.11 Intermediate_Japanese Intermediate_Japanese_Ln.10 JLPT JLPT_5 JLPT_N5,Oil7l6nt$n
+次,つぎ,next,Genki Genki_Ln.6 JLPT JLPT_5 JLPT_N5,IPls}w5_e-
+着く,つく,"to arrive at, to reach",JLPT JLPT_3 JLPT_5 JLPT_N5,hc-pfPX>PQ
+机,つくえ,desk,Genki Genki_Ln.4 Intermediate_Japanese Intermediate_Japanese_Ln.10 JLPT JLPT_5 JLPT_N5,G!9kEn9Y>c
+作る,つくる,"to make, to create",Genki Genki_Ln.8 JLPT JLPT_5 JLPT_N5,dlanfH_M#M
+つける,つける,"to turn on (e.g., a light); to take",JLPT JLPT_3 JLPT_4 JLPT_5 JLPT_N5,o}z*=/A8o~
+勤める,つとめる,to work (for),JLPT JLPT_5 JLPT_N5,xKU$$gsQPF
+つまらない,つまらない,"boring, dull; insignificant",Genki Genki_Ln.5 JLPT JLPT_5 JLPT_N5,HL~a;+T`kY
+冷たい,つめたい,"cold (things, people)",Genki Genki_Ln.10 JLPT JLPT_5 JLPT_N5,v8vDEW[6Rh
+強い,つよい,"strong, powerful",Genki Genki_Ln.17 Intermediate_Japanese Intermediate_Japanese_Ln.13 JLPT JLPT_5 JLPT_N5,d[wde~o@q(
+手,て,hand,JLPT JLPT_5 JLPT_N5,CAHcCP96BY
+テープ,テープ,tape,Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5,"H|,pBh(;BD"
+テープレコーダー,テープレコーダー,tape recorder,JLPT JLPT_5 JLPT_N5,izd^3[1~Pe
+テーブル,テーブル,table,JLPT JLPT_5 JLPT_N5,n-.M5OZr5!
+出かける,でかける,to go out; to depart,Genki Genki_Ln.5 JLPT JLPT_5 JLPT_N5,Fx}b2N2gun
+手紙,てがみ,letter,Genki Genki_Ln.4 JLPT JLPT_5 JLPT_N5,M#PC#!OTka
+できる,できる,to be able to (to accomplish),JLPT JLPT_3 JLPT_4 JLPT_5 JLPT_N5,vB~NGv+*>H
+出口,でぐち,an exit,Intermediate_Japanese Intermediate_Japanese_Ln.7 JLPT JLPT_5 JLPT_N5,sv__368x5>
+テスト,テスト,test,Genki Genki_Ln.5 JLPT JLPT_5 JLPT_N5,Lhy<!{J6SG
+では,では,"then, well, so",JLPT JLPT_3 JLPT_5 JLPT_N5,NY{|SsdlKz
+デパート,デパート,(abbr.) department store,Genki Genki_Ln.4 JLPT JLPT_5 JLPT_N5,rd.b%pP~B0
+でも,でも,"but, however",JLPT JLPT_3 JLPT_5 JLPT_N5,izQ~3T7Pp}
+出る,でる,"to appear, to leave",JLPT JLPT_5 JLPT_N5,A23ctPX1n^
+テレビ,テレビ,"television, TV",Genki Genki_Ln.3 JLPT JLPT_5 JLPT_N5,pQXZQB+G|d
+天気,てんき,weather,Genki Genki_Ln.5 JLPT JLPT_5 JLPT_N5,vm1l+4c[9
+電気,でんき,"electricity, (electric) light",Genki Genki_Ln.6 JLPT JLPT_5 JLPT_N5,HsW5jIb;SC
+電車,でんしゃ,electric train,Genki Genki_Ln.6 JLPT JLPT_5 JLPT_N5,e?+NxLTOv
+電話,でんわ,a telephone,Genki Genki_Ln.1 JLPT JLPT_5 JLPT_N5,"Q,geq&8^pJ"
+戸,と,door (Japanese style),JLPT JLPT_5 JLPT_N5,o.K?EMap~;
+～度,～ど,counter for occurrences; ~ degree; ~ point,JLPT JLPT_1 JLPT_5 JLPT_N5,K9|0UgYaJ_
+ドア,ドア,door (Western style),JLPT JLPT_5 JLPT_N5,l[rk}4@PVD
+トイレ,トイレ,bathroom; toilet,Intermediate_Japanese Intermediate_Japanese_Ln.10 JLPT JLPT_5 JLPT_N5,hv_ThfFsjj
+どう,どう,"how, in what way",JLPT JLPT_5 JLPT_N5,FZt/a?Mnu^
+どうして,どうして,"why, for what reason",Genki Genki_Ln.4 JLPT JLPT_5 JLPT_N5,s<(2V@f6ff
+どうぞ,どうぞ,"please, kindly, by all means",JLPT JLPT_5 JLPT_N5,CXiSJodxs@
+動物,どうぶつ,animal,Intermediate_Japanese Intermediate_Japanese_Ln.10 JLPT JLPT_5 JLPT_N5,Q~mPY;2upw
+どうも,どうも,Thank you; somehow; no matter how hard one may try,Genki Genki_Ln.2 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5,"Maz]_B`w,4"
+十,(〜を) とお,ten (~),Genki Genki_Ln.9 JLPT JLPT_3 JLPT_5 JLPT_N5,BjWdBTc)9!
+遠い,とおい,"far (away), distant",Genki Genki_Ln.21 JLPT JLPT_5 JLPT_N5,Jl9yYXnyJ<
+十日,とおか,ten days; tenth day of the month,Genki Genki_Ln.13 JLPT JLPT_5 JLPT_N5,g[CNT&GA2[
+～時,～とき,at the time of ~,JLPT JLPT_3 JLPT_5 JLPT_N5,bGLp[lZC.;
+時々,ときどき,sometimes,Genki Genki_Ln.3 JLPT JLPT_5 JLPT_N5,s+W64X?THZ
+時計,とけい,a watch; a clock,Genki Genki_Ln.2 Intermediate_Japanese Intermediate_Japanese_Ln.2 JLPT JLPT_5 JLPT_N5,u/fL<ne:Cb
+どこ,どこ,"where, what place",Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5,h_Fa6?Ps@9
+所,ところ,place,Genki Genki_Ln.8 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5,J`^6YmuA-0
+年,とし,"year, age",JLPT JLPT_3 JLPT_5 JLPT_N5,N=hcG9wG3;
+図書館,としょかん,library,Genki Genki_Ln.2 Intermediate_Japanese Intermediate_Japanese_Ln.5 JLPT JLPT_5 JLPT_N5,mp0X0~7Y`^
+どちら,どちら,which (one) (way); where (polite),Genki Genki_Ln.10 Genki_Ln.19 JLPT JLPT_5 JLPT_N5,pW(ud@AhIx
+どっち,どっち,"which one, which way",Genki Genki_Ln.10 JLPT JLPT_5 JLPT_N5,"PxI,t`JQ.N"
+とても,とても,"very (much), greatly, exceedingly",Genki Genki_Ln.5 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_3 JLPT_5 JLPT_N5,t]2-1h#)V/
+どなた,どなた,who,JLPT JLPT_5 JLPT_N5,Ll)TbcW$yb
+隣,となり,"next to, next door to",Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5,GigT2yQ[2E
+どの,どの,which,JLPT JLPT_5 JLPT_N5,H+g1ci<Mvc
+飛ぶ,とぶ,"to fly, to hop",JLPT JLPT_5 JLPT_N5,wLF5gUV](>
+止まる,とまる,to come to a halt,JLPT JLPT_5 JLPT_N5,Q+OrrzleWd
+友達,ともだち,friend,Genki Genki_Ln.1 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5,E)w$/p&I#O
+土曜日,どようび,Saturday,Genki Genki_Ln.3 JLPT JLPT_3 JLPT_5 JLPT_N5,Q%+.*M.E9m
+鳥,とり,"chicken (lit., bird)",Intermediate_Japanese Intermediate_Japanese_Ln.6 JLPT JLPT_5 JLPT_N5,lc>;F##&%m
+鶏肉,とりにく,chicken meat,JLPT JLPT_5 JLPT_N5,dL<c9&FvJF
+取る,とる,to take (a class); to get (a grade),Genki Genki_Ln.11 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5,bLpD3ABv2g
+撮る,とる,"to take (a photo), to make (a film)",JLPT JLPT_5 JLPT_N5,w7O/i=vkEI
+どれ,どれ,which one,Genki Genki_Ln.2 JLPT JLPT_3 JLPT_5 JLPT_N5,icGG-;4x}M
+どんな,どんな,"what, what kind of",JLPT JLPT_3 JLPT_5 JLPT_N5,PZ~[>!hd8m
+ない,ない,"there isn't, doesn't have",JLPT JLPT_5 JLPT_N5,I08@<2+DPk
+ナイフ,ナイフ,knife,JLPT JLPT_5 JLPT_N5,domhg)5M&Q
+中,なか,"inside, middle, among",JLPT JLPT_3 JLPT_5 JLPT_N5,rVjcK=lE15
+長い,ながい,"long, lengthy",Genki Genki_Ln.7 Intermediate_Japanese Intermediate_Japanese_Ln.4 JLPT JLPT_2 JLPT_5 JLPT_N5,EHO`14{d-(
+鳴く,なく,to make sound (animal),JLPT JLPT_5 JLPT_N5,"ivpv*G,Zm%"
+無くす,なくす,to lose something,JLPT JLPT_3 JLPT_5 JLPT_N5,dteDI+R~`W
+なぜ,なぜ,why (same as どうして),Genki Genki_Ln.19 JLPT JLPT_5 JLPT_N5,Cvs*YiG5BD
+夏,なつ,summer,Genki Genki_Ln.8 Intermediate_Japanese Intermediate_Japanese_Ln.4 JLPT JLPT_5 JLPT_N5,"P,[b8Eh|6R"
+夏休み,なつやすみ,summer vacation,JLPT JLPT_5 JLPT_N5,D=cA)b0@~(
+～など,～など,et cetera,JLPT JLPT_3 JLPT_5 JLPT_N5,"e(]O3py,;2"
+七つ,ななつ,seven things,Genki Genki_Ln.9 JLPT JLPT_3 JLPT_5 JLPT_N5,G25u:w`9Xu
+何,なん; なに,what,Genki Genki_Ln.1 JLPT JLPT_3 JLPT_5 JLPT_N5,g<hW@mElnM
+七日,なのか,seven days; seventh day (of the month),Genki Genki_Ln.13 JLPT JLPT_5 JLPT_N5,I|+G2AT>J]
+名前,なまえ,name,Genki Genki_Ln.1 JLPT JLPT_5 JLPT_N5,e6o_CEx8)b
+習う,ならう,to learn,Genki Genki_Ln.11 JLPT JLPT_5 JLPT_N5,iV+xor)WZT
+並ぶ,ならぶ,"to line up, to stand in a line (v.i.)",Intermediate_Japanese Intermediate_Japanese_Ln.7 JLPT JLPT_5 JLPT_N5,nIHPO#>_}+
+並べる,ならべる,to put (things) side by side; to line up,Intermediate_Japanese Intermediate_Japanese_Ln.15 JLPT JLPT_5 JLPT_N5,n!B94UfoT6
+なる,なる,to become,Genki Genki_Ln.10 JLPT JLPT_3 JLPT_5 JLPT_N5,ukKTUxR2lk
+何～,なん～,what sort of ~,JLPT JLPT_5 JLPT_N5,C!@pB0L*^>
+二,に,two,JLPT JLPT_5 JLPT_N5,uzD!:&B)8|
+にぎやか,にぎやか,"bustling, busy",JLPT JLPT_5 JLPT_N5,cIb<bg#^)L
+肉,にく,meat,Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5,Go(gh2eIxK
+西,にし,west,JLPT JLPT_5 JLPT_N5,D!YA^58RBg
+～日,～にち,"~ day of the month, for ~ days",JLPT JLPT_5 JLPT_N5,DbJ@Azg05L
+日曜日,にちようび,Sunday,Genki Genki_Ln.3 JLPT JLPT_3 JLPT_5 JLPT_N5,XSi31p{-G
+荷物,にもつ,luggage; baggage,Genki Genki_Ln.6 Intermediate_Japanese Intermediate_Japanese_Ln.6 JLPT JLPT_5 JLPT_N5,MH72iI!<]q
+ニュース,ニュース,news,Genki Genki_Ln.17 JLPT JLPT_5 JLPT_N5,"iHtE.]1*,&"
+庭,にわ,garden,Genki Genki_Ln.15 JLPT JLPT_5 JLPT_N5,f&>q3YTU?H
+～人,～にん,counter for people,JLPT JLPT_5 JLPT_N5,FNnJ8yNPin
+脱ぐ,ぬぐ,to take off (clothes),Genki Genki_Ln.17 JLPT JLPT_5 JLPT_N5,cM_g)oAQIs
+温い,ぬるい,lukewarm,JLPT JLPT_3 JLPT_5 JLPT_N5,"gfQAF/k(q,"
+ネクタイ,ネクタイ,"tie, necktie",Genki Genki_Ln.14 JLPT JLPT_5 JLPT_N5,AQO{m&veen
+猫,ねこ,cat,Genki Genki_Ln.4 JLPT JLPT_5 JLPT_N5,x^.ijbc4Mz
+寝る,ねる,to sleep; to go to sleep; to go to bed,Genki Genki_Ln.3 Intermediate_Japanese Intermediate_Japanese_Ln.2 JLPT JLPT_5 JLPT_N5,PAI>}YTMT!
+～年,～ねん,~ years,JLPT JLPT_5 JLPT_N5,"gYAXz}z6O,"
+ノート,ノート,notebook,Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5,Go~p$PSFcm
+登る,のぼる,to climb,JLPT JLPT_3 JLPT_5 JLPT_N5,unM=ha?S3d
+飲み物,のみもの,"drink, beverage",Genki Genki_Ln.5 JLPT JLPT_5 JLPT_N5,"k?X,84{EZ8"
+飲む,のむ,to drink,JLPT JLPT_5 JLPT_N5,C;cf;f4#r6
+乗る,のる,"to get on, to ride in, to board",JLPT JLPT_3 JLPT_5 JLPT_N5,J~ykS_Bo0m
+歯,は,tooth,Genki Genki_Ln.12 Intermediate_Japanese Intermediate_Japanese_Ln.12 JLPT JLPT_5 JLPT_N5,J1;2F+tdr`
+パーティー,パーティー,a party,Genki Genki_Ln.8 JLPT JLPT_5 JLPT_N5,O}o_r|!syk
+はい,はい,yes,Genki Genki_Ln.1 JLPT JLPT_3 JLPT_5 JLPT_N5,Q.;:Q&Nmh}
+～杯,～はい,counter for cupfuls,JLPT JLPT_5 JLPT_N5,JTOz#Az0jW
+灰皿,はいざら,ashtray,JLPT JLPT_5 JLPT_N5,mAdBNp<Jp$
+入る,はいる,"to enter, to contain, to hold",JLPT JLPT_5 JLPT_N5,zZFQIc).TB
+葉書,はがき,postcard,Genki Genki_Ln.5 JLPT JLPT_5 JLPT_N5,jer83m7P=.
+はく,はく,to put on (items below your waist),Genki Genki_Ln.7 JLPT JLPT_3 JLPT_5 JLPT_N5,oRjJ`o{id)
+箱,はこ,box,JLPT JLPT_5 JLPT_N5,D@BX&%Fydt
+橋,はし,bridge,JLPT JLPT_3 JLPT_5 JLPT_N5,gMcz>SvPjQ
+箸,はし,chopsticks,Genki Genki_Ln.8 JLPT JLPT_3 JLPT_5 JLPT_N5,vlWz[4OAnE
+始まる,はじまる,(something) begins,Genki Genki_Ln.9 JLPT JLPT_5 JLPT_N5,g7#i$_:K%6
+初め; 始め,はじめ,"beginning, start",JLPT JLPT_3 JLPT_5 JLPT_N5,Po{k$4o=i}
+初めて,はじめて,for the first time,Genki Genki_Ln.12 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5,FM~Al0*F*3
+走る,はしる,to run,Genki Genki_Ln.22 Intermediate_Japanese Intermediate_Japanese_Ln.10 JLPT JLPT_5 JLPT_N5,"B)($ycG+,c"
+バス,バス,bus; bath; bass,Genki Genki_Ln.5 Intermediate_Japanese Intermediate_Japanese_Ln.10 JLPT JLPT_1 JLPT_5 JLPT_N5,nF2zK|?mh~
+バター,バター,butter,JLPT JLPT_5 JLPT_N5,bep_D~c3Ed
+二十歳,はたち,20 years old,JLPT JLPT_3 JLPT_5 JLPT_N5,"s,}HT(8Tzb"
+働く,はたらく,to work,Genki Genki_Ln.11 Intermediate_Japanese Intermediate_Japanese_Ln.9 JLPT JLPT_5 JLPT_N5,fCkP4x.Nco
+八,はち,eight,JLPT JLPT_5 JLPT_N5,maEI.lHT3>
+二十日,はつか,"twenty days, twentieth (day of the month)",JLPT JLPT_5 JLPT_N5,mmn=3%}>}J
+花,はな,flower,JLPT JLPT_5 JLPT_N5,js_smr~4Ak
+鼻,はな,nose,JLPT JLPT_5 JLPT_N5,"Ft8Z7qnLG,"
+話,はなし,"talk (chat), story",Genki Genki_Ln.19 JLPT JLPT_5 JLPT_N5,A(<B}*ZSa_
+話す,はなす,to speak,JLPT JLPT_3 JLPT_5 JLPT_N5,d]>`2&`x#1
+母,はは,(my) mother,Genki Genki_Ln.14 JLPT JLPT_5 JLPT_N5,I?S_Xs1PT;
+早い,はやい,early,Genki Genki_Ln.3 JLPT JLPT_5 JLPT_N5,J6yYVxGFN*
+速い,はやい,"fast, quick",Genki Genki_Ln.7 Intermediate_Japanese Intermediate_Japanese_Ln.4 JLPT JLPT_5 JLPT_N5,pfU@DZ;h3^
+春,はる,spring,Genki Genki_Ln.10 Intermediate_Japanese Intermediate_Japanese_Ln.4 JLPT JLPT_3 JLPT_5 JLPT_N5,mlEwn=b[H<
+貼る,はる,to post; to paste; to attach,Genki Genki_Ln.21 Intermediate_Japanese Intermediate_Japanese_Ln.3 JLPT JLPT_3 JLPT_5 JLPT_N5,zI5j%aDV0.
+晴れ,はれ,clear (sunny) weather,Genki Genki_Ln.12 JLPT JLPT_5 JLPT_N5,nBD2D7_?kw
+晴れる,はれる,to be sunny,Genki Genki_Ln.19 JLPT JLPT_5 JLPT_N5,ATM=j&::X;
+半,はん,"half (e.g., にじはん | half-past two)",Genki Genki_Ln.1 JLPT JLPT_3 JLPT_5 JLPT_N5,s%lRHov]`n
+晩,ばん,evening,JLPT JLPT_3 JLPT_5 JLPT_N5,hO?dVEN`5B
+～番,～ばん,~st; ~th best,JLPT JLPT_5 JLPT_N5,b/wgPDiVBg
+パン,パン,bread,Genki Genki_Ln.4 JLPT JLPT_5 JLPT_N5,FI2Z[9I*9Q
+ハンカチ,ハンカチ,handkerchief,JLPT JLPT_5 JLPT_N5,yU4LCXkUnv
+番号,ばんごう,"number, series of digits",Genki Genki_Ln.1 JLPT JLPT_5 JLPT_N5,c^xE))av$-
+晩御飯,ばんごはん,"dinner, evening meal",Genki Genki_Ln.3 JLPT JLPT_5 JLPT_N5,HihAr>C::*
+半分,はんぶん,half,JLPT JLPT_5 JLPT_N5,DN!/&cg9bL
+東,ひがし,east,JLPT JLPT_5 JLPT_N5,"pI3YEa2,3t"
+～匹,～ひき,counter for small animals,JLPT JLPT_5 JLPT_N5,ivmKu+!yZ}
+引く,ひく,"to pull, to draw; subtract",JLPT JLPT_2 JLPT_3 JLPT_5 JLPT_N5,tVVM)ZI7wM
+弾く,ひく,to play (a string instrument or piano),Genki Genki_Ln.9 JLPT JLPT_3 JLPT_5 JLPT_N5,HK}b0#P-HS
+低い,ひくい,"short, low",JLPT JLPT_5 JLPT_N5,BBr{:lP!;x
+飛行機,ひこうき,airplane,Genki Genki_Ln.5 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5,OUQ4o:]Va=
+左,ひだり,left hand side,JLPT JLPT_5 JLPT_N5,h_@t6d`1:*
+人,ひと,"man, person",Genki Genki_Ln.4 JLPT JLPT_5 JLPT_N5,ya&#4:D}>{
+一つ,ひとつ,one thing,Genki Genki_Ln.9 JLPT JLPT_5 JLPT_N5,lMwiFE;gTW
+一月,ひとつき,one month,JLPT JLPT_5 JLPT_N5,JU.k{Nz*{h
+一人,ひとり,one person,Genki Genki_Ln.7 JLPT JLPT_3 JLPT_5 JLPT_N5,rOUMQ8LZ5<
+暇,ひま,"free time, leisure",JLPT JLPT_5 JLPT_N5,urDxNZnrq<
+百,ひゃく,hundred,JLPT JLPT_5 JLPT_N5,J;(UasY_=O
+病院,びょういん,hospital,Genki Genki_Ln.4 JLPT JLPT_5 JLPT_N5,<+#t;D=L-
+病気,びょうき,illness; sickness,Genki Genki_Ln.9 Intermediate_Japanese Intermediate_Japanese_Ln.2 JLPT JLPT_5 JLPT_N5,Ibs3I0!xB|
+平仮名,ひらがな,hiragana,JLPT JLPT_5 JLPT_N5,k}y1F@5e8u
+昼,ひる,"noon, daytime",JLPT JLPT_5 JLPT_N5,i8$:v@D8x1
+昼御飯,ひるごはん,"lunch, midday meal",Genki Genki_Ln.3 JLPT JLPT_5 JLPT_N5,JGK7M1P.PA
+広い,ひろい,spacious; wide; broad,Genki Genki_Ln.15 Intermediate_Japanese Intermediate_Japanese_Ln.15 JLPT JLPT_5 JLPT_N5,nThxsh#3~a
+フィルム,フィルム,film (roll of),JLPT JLPT_5 JLPT_N5,w#JO*~D@<H
+封筒,ふうとう,envelope,Intermediate_Japanese Intermediate_Japanese_Ln.3 JLPT JLPT_5 JLPT_N5,JaXU6BSc-h
+プール,プール,swimming pool,Genki Genki_Ln.15 JLPT JLPT_5 JLPT_N5,J.!iKtAY)1
+フォーク,フォーク,fork,JLPT JLPT_5 JLPT_N5,Q#>HBX67;#
+吹く,ふく,"to blow (wind, etc.)",Genki Genki_Ln.22 JLPT JLPT_3 JLPT_5 JLPT_N5,mo@qiT7%d3
+服,ふく,clothes,Genki Genki_Ln.12 JLPT JLPT_3 JLPT_5 JLPT_N5,G;N&<jI3Ep
+二つ,ふたつ,two things,Genki Genki_Ln.9 JLPT JLPT_5 JLPT_N5,A@M*oG}Fjm
+豚肉,ぶたにく,pork,JLPT JLPT_5 JLPT_N5,N1fM*9;kPY
+二人,ふたり,two people,Genki Genki_Ln.7 JLPT JLPT_5 JLPT_N5,yRF#3ntAGH
+二日,ふつか,two days; second day of the month,Genki Genki_Ln.13 JLPT JLPT_5 JLPT_N5,dRYcz7jSL;
+太い,ふとい,"fat, thick",JLPT JLPT_5 JLPT_N5,LD`2@7dG9a
+冬,ふゆ,winter,Genki Genki_Ln.8 Intermediate_Japanese Intermediate_Japanese_Ln.4 JLPT JLPT_5 JLPT_N5,reZ;<Y^{LL
+降る,ふる,"to precipitate, to fall (e.g., rain, snow, etc.)",Intermediate_Japanese Intermediate_Japanese_Ln.2 JLPT JLPT_3 JLPT_5 JLPT_N5,q(<}4NV?U@
+古い,ふるい,"old (in reference to objects, not people), aged, ancient",Genki Genki_Ln.5 JLPT JLPT_5 JLPT_N5,gH<g@fkLje
+～分,～ふん,~ minutes,JLPT JLPT_5 JLPT_N5,chUnU+#xr]
+文章,ぶんしょう,"sentence, text",JLPT JLPT_5 JLPT_N5,F&}@z14/*V
+ページ,ページ,a page,Genki Genki_Ln.6 JLPT JLPT_5 JLPT_N5,jR*]a[JBx$
+下手,へた,"unskillful, poor",JLPT JLPT_5 JLPT_N5,zx]n<UpO/Q
+ベッド,ベッド,bed,JLPT JLPT_5 JLPT_N5,mm(#F~5?W7
+ペット,ペット,pet,Genki Genki_Ln.15 JLPT JLPT_3 JLPT_5 JLPT_N5,Gm:f8t8t/V
+部屋,へや,a room,Genki Genki_Ln.5 Intermediate_Japanese Intermediate_Japanese_Ln.2 JLPT JLPT_5 JLPT_N5,"cB,rGZ.;c."
+辺,へん,"area, vicinity",JLPT JLPT_5 JLPT_N5,"v^uJ@o,r7C"
+ペン,ペン,pen,Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5,PpbmxKp]%S
+勉強,べんきょう (する),study,JLPT JLPT_3 JLPT_5 JLPT_N5,P|N-mC4itp
+便利,べんり,"convenient, handy",JLPT JLPT_5 JLPT_N5,NSM1sxi#q3
+帽子,ぼうし,hat; cap,Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5,whud$h6Xsa
+ボールペン,ボールペン,ball-point pen,JLPT JLPT_5 JLPT_N5,A1a57pRAi*
+外,ほか,"other, the rest",JLPT JLPT_3 JLPT_5 JLPT_N5,q-Rsw+YG/*
+ポケット,ポケット,pocket,JLPT JLPT_5 JLPT_N5,PrdL>hhb^[
+欲しい,ほしい,"to want, in need of",JLPT JLPT_5 JLPT_N5,"IB/)D,[pe$"
+ポスト,ポスト,"mailbox; post, position",JLPT JLPT_5 JLPT_N5,CSDW$^FNBN
+細い,ほそい,"thin, slender, fine",JLPT JLPT_5 JLPT_N5,zm=f9J*i)W
+ボタン,ボタン,button,JLPT JLPT_5 JLPT_N5,o=Cnvf:%>b
+ホテル,ホテル,hotel,Genki Genki_Ln.4 JLPT JLPT_5 JLPT_N5,n#S=W;:k;`
+本,ほん,book,Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5,PgM`&0<&bX
+～本,～ほん,counter for long cylindrical things,JLPT JLPT_2 JLPT_5 JLPT_N5,Aln2n5Y6m$
+本棚,ほんだな,bookshelf,JLPT JLPT_5 JLPT_N5,LlS7xyP)^9
+本当,ほんとう,"real, true",JLPT JLPT_3 JLPT_5 JLPT_N5,mp{CGAM3}E
+～枚,～まい,counter for flat things,JLPT JLPT_5 JLPT_N5,eZ7Lx)q}m
+毎朝,まいあさ,every morning,Genki Genki_Ln.19 JLPT JLPT_5 JLPT_N5,FY8YY]~jH+
+毎月,まいげつ; まいつき,"every month, monthly",JLPT JLPT_5 JLPT_N5,x6m6aNH)Wj
+毎週,まいしゅう,every week,Genki Genki_Ln.8 JLPT JLPT_5 JLPT_N5,Lp7~a9~`1G
+毎日,まいにち,every day,Genki Genki_Ln.3 JLPT JLPT_5 JLPT_N5,"b}uYG),?~1"
+毎年,まいねん; まいとし,"every year, yearly, annually",JLPT JLPT_5 JLPT_N5,cLTCt({=p{
+毎晩,まいばん,every night,Genki Genki_Ln.3 JLPT JLPT_5 JLPT_N5,s&rZqJP=be
+前,まえ,"before, in front",Genki Genki_Ln.17 JLPT JLPT_5 JLPT_N5,AcNx(A=]3O
+～前,～まえ,in front of ~,JLPT JLPT_5 JLPT_N5,Jh#_2I1KK<
+曲る,まがる,"to turn, to bend",JLPT JLPT_3 JLPT_5 JLPT_N5,fZb*Dqk8+n
+まずい,まずい,"terrible (in reference to food), unappetizing, unpleasant (taste)",Genki Genki_Ln.23 JLPT JLPT_5 JLPT_N5,y=A8n$:VZF
+また,また,and; furthermore,Genki Genki_Ln.20 Intermediate_Japanese Intermediate_Japanese_Ln.5 JLPT JLPT_3 JLPT_5 JLPT_N5,H#sUyG^B<2
+まだ,まだ,"yet, still, besides",Genki Genki_Ln.19 JLPT JLPT_3 JLPT_5 JLPT_N5,xr/3DB/ghC
+町,まち,town; city,Genki Genki_Ln.4 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_3 JLPT_5 JLPT_N5,xztbV5AMZZ
+待つ,まつ,to wait,JLPT JLPT_3 JLPT_5 JLPT_N5,N6<)T3m*1$
+まっすぐ,まっすぐ,"straight (ahead), direct",JLPT JLPT_3 JLPT_5 JLPT_N5,o(%GCd@4cN
+マッチ,マッチ,match,JLPT JLPT_5 JLPT_N5,r{cxPi6M{l
+窓,まど,window,Genki Genki_Ln.6 JLPT JLPT_5 JLPT_N5,dZZ^@1iCkq
+丸い; 円い,まるい,"round, circular",JLPT JLPT_3 JLPT_5 JLPT_N5,kXV&n*v-w~
+万,まん,ten thousand,JLPT JLPT_5 JLPT_N5,k%8Ts^<^Df
+万年筆,まんねんひつ,fountain pen,JLPT JLPT_5 JLPT_N5,pjtI#>[G;I
+磨く,みがく,to brush (teeth); to polish,Genki Genki_Ln.13 JLPT JLPT_5 JLPT_N5,f*XbBCL&y-
+右,みぎ,right hand side,JLPT JLPT_5 JLPT_N5,Dx]?1r0B)6
+短い,みじかい,short (length),Genki Genki_Ln.7 Intermediate_Japanese Intermediate_Japanese_Ln.11 JLPT JLPT_5 JLPT_N5,CoDv|eMw1>
+水,みず,water,Genki Genki_Ln.3 JLPT JLPT_5 JLPT_N5,Psad>Q=[fe
+店,みせ,"store, shop",Genki Genki_Ln.13 Intermediate_Japanese Intermediate_Japanese_Ln.6 JLPT JLPT_5 JLPT_N5,w{yPQLxrpZ
+見せる,みせる,"to show, to display",Genki Genki_Ln.16 JLPT JLPT_5 JLPT_N5,u/XQDC4A&:
+道,みち,"road, street; way, directions",Genki Genki_Ln.16 JLPT JLPT_5 JLPT_N5,g*1iadY2;L
+三日,みっか,"three days, third day of the month",Genki Genki_Ln.13 JLPT JLPT_5 JLPT_N5,"BQ,4DuKr8>"
+三つ,みっつ,three things,Genki Genki_Ln.9 JLPT JLPT_5 JLPT_N5,E%f95v%koQ
+緑,みどり,green,JLPT JLPT_5 JLPT_N5,d@$Uu~dQl-
+皆さん,みなさん,"all of you, everyone",Intermediate_Japanese Intermediate_Japanese_Ln.4 JLPT JLPT_5 JLPT_N5,xUxg44IBk/
+南,みなみ,South,Intermediate_Japanese Intermediate_Japanese_Ln.10 JLPT JLPT_5 JLPT_N5,tmB.Hd2Sk_
+耳,みみ,ear,Intermediate_Japanese Intermediate_Japanese_Ln.5 JLPT JLPT_5 JLPT_N5,c2VG#0omOo
+見る,みる,"to see, to look",JLPT JLPT_3 JLPT_5 JLPT_N5,LJ*9Zy3g--
+みんな,みんな,"all, everyone, everybody",Genki Genki_Ln.9 JLPT JLPT_3 JLPT_5 JLPT_N5,NO(9_g@4E)
+六日,むいか,six days; sixth day of month,Genki Genki_Ln.13 JLPT JLPT_5 JLPT_N5,cT@R(=%:PY
+向こう,むこう,"beyond, over there",JLPT JLPT_5 JLPT_N5,mQG@k1[%|C
+難しい,むずかしい,difficult,Genki Genki_Ln.5 Intermediate_Japanese Intermediate_Japanese_Ln.2 JLPT JLPT_5 JLPT_N5,cp|.gBg]*Y
+六つ,むっつ,six things,Genki Genki_Ln.9 JLPT JLPT_5 JLPT_N5,",[k`qyR3)"
+村,むら,village,Intermediate_Japanese Intermediate_Japanese_Ln.10 JLPT JLPT_5 JLPT_N5,INP.Ccu#He
+目,め,eye(s),Genki Genki_Ln.7 JLPT JLPT_3 JLPT_5 JLPT_N5,dhfW}%pIM+
+メートル,メートル,meter,JLPT JLPT_5 JLPT_N5,BPMIO$2k{i
+眼鏡,めがね,eye glasses,Genki Genki_Ln.7 JLPT JLPT_5 JLPT_N5,OGc^3PJcd3
+もう,もう,already; again; more,Genki Genki_Ln.9 JLPT JLPT_2 JLPT_5 JLPT_N5,C9[8>(KXKL
+木曜日,もくようび,Thursday,Genki Genki_Ln.4 JLPT JLPT_3 JLPT_5 JLPT_N5,k#-z20ZxXI
+もしもし,もしもし,Hello? (used on the phone),Genki Genki_Ln.4 JLPT JLPT_5 JLPT_N5,nnhl#WnLYa
+持つ,もつ,"to hold, to carry; to possess",JLPT JLPT_5 JLPT_N5,A&O@O/^cS;
+もっと,もっと,more,Genki Genki_Ln.11 JLPT JLPT_3 JLPT_5 JLPT_N5,OqdI=b3^K`
+物,もの,thing (concrete object),Genki Genki_Ln.12 JLPT JLPT_3 JLPT_5 JLPT_N5,"z6=4|ALO,V"
+門,もん,gate,JLPT JLPT_5 JLPT_N5,H&[yCKRvgq
+問題,もんだい,a problem,Intermediate_Japanese Intermediate_Japanese_Ln.11 JLPT JLPT_5 JLPT_N5,Eh6&Bnk+Z%
+～屋,～や,~ shop,JLPT_N5,ht#2@^87+]
+八百屋,やおや,greengrocer,JLPT JLPT_5 JLPT_N5,C[.TX0anRy
+野菜,やさい,vegetable,Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5,qVg2VfFKQ;
+易しい,やさしい,"easy, plain, simple",JLPT JLPT_5 JLPT_N5,O&W|&R47Dm
+安い,やすい,inexpensive; cheap (things),Genki Genki_Ln.5 JLPT JLPT_5 JLPT_N5,ie=X%ZqpqO
+休み,やすみ,holiday; day off; absence,Genki Genki_Ln.5 JLPT JLPT_5 JLPT_N5,J*/c5_R!J=
+休む,やすむ,"to rest, to have a break, to get time off",JLPT JLPT_5 JLPT_N5,i~a&f>8]D[
+八つ,やっつ,eight things,Genki Genki_Ln.9 JLPT JLPT_5 JLPT_N5,F=`<QfuMn*
+山,やま,mountain,Genki Genki_Ln.11 JLPT JLPT_5 JLPT_N5,FM#``XMUDZ
+やる,やる,"to do; to give (to pets, parents, siblings, etc.)",Genki Genki_Ln.21 JLPT JLPT_4 JLPT_5 JLPT_N5,"ee,Y5GOGX?"
+夕方,ゆうがた,"late afternoon (typically just before dinner time), evening",Genki Genki_Ln.18 Intermediate_Japanese Intermediate_Japanese_Ln.10 JLPT JLPT_5 JLPT_N5,wr(&N+9Gfn
+夕飯,ゆうはん,"dinner, supper, evening meal",JLPT JLPT_4 JLPT_5 JLPT_N5,x@-+;z#Bdx
+郵便局,ゆうびんきょく,post office,Genki Genki_Ln.2 JLPT JLPT_5 JLPT_N5,E9^vm]j#7*
+昨夜,ゆうべ,last night,JLPT JLPT_3 JLPT_5 JLPT_N5,h5wsUbx`&$
+有名,ゆうめい,famous,JLPT JLPT_5 JLPT_N5,cV2lu-%dm7
+雪,ゆき,snow,Genki Genki_Ln.12 JLPT JLPT_3 JLPT_5 JLPT_N5,jr0utv~KvB
+ゆっくりと,ゆっくりと,"slowly, at ease",JLPT JLPT_5 JLPT_N5,w_ef65R9#}
+八日,ようか,eight days; eighth day of the month,Genki Genki_Ln.13 JLPT JLPT_5 JLPT_N5,Fd}WQ7nZj^
+洋服,ようふく,Western-style clothes,JLPT JLPT_5 JLPT_N5,uv*)pIfBA|
+よく,よく,"frequently, often (much); well, skillfully",Genki Genki_Ln.14 Genki_Ln.3 JLPT JLPT_5 JLPT_N5,Fz[l>+!/Hl
+横,よこ,beside; side; width,Intermediate_Japanese Intermediate_Japanese_Ln.11 JLPT JLPT_5 JLPT_N5,C?K**~xaVS
+四日,よっか,four days; fourth day of the month,Genki Genki_Ln.13 JLPT JLPT_5 JLPT_N5,s(2D4IDk2]
+四つ,よっつ,four things,Genki Genki_Ln.9 JLPT JLPT_2 JLPT_5 JLPT_N5,BL9b_E4!L$
+呼ぶ,よぶ,to call (one's name); to invite,Genki Genki_Ln.19 JLPT JLPT_3 JLPT_5 JLPT_N5,zV4mur-%tO
+読む,よむ,to read,JLPT JLPT_5 JLPT_N5,G8F?CvYLz|
+夜,よる,"evening, night",Genki Genki_Ln.6 JLPT JLPT_3 JLPT_5 JLPT_N5,lj*phUSR[b
+弱い,よわい,weak,JLPT JLPT_5 JLPT_N5,x)3Ur1<az7
+来月,らいげつ,next month,Genki Genki_Ln.8 JLPT JLPT_5 JLPT_N5,O/Q*jP:8c|
+来週,らいしゅう,next week,Genki Genki_Ln.6 JLPT JLPT_5 JLPT_N5,h}c~#8X!n;
+来年,らいねん,next year,Genki Genki_Ln.6 JLPT JLPT_5 JLPT_N5,"mvNiHK,T4b"
+ラジオ,ラジオ,radio,Genki Genki_Ln.14 JLPT JLPT_5 JLPT_N5,wyqA~/nA@+
+ラジオカセ,ラジオカセ,radio cassette player,JLPT JLPT_5 JLPT_N5,"eBPF6I+,&0"
+りっぱ,りっぱ,"splendid, fine",JLPT JLPT_3 JLPT_5 JLPT_N5,J%`%&)W1.O
+留学生,りゅうがくせい,international student,Genki Genki_Ln.1 JLPT JLPT_5 JLPT_N5,n89-KYTMQf
+両親,りょうしん,"parents (lit., both parents)",Genki Genki_Ln.14 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5,L.[<hVhM?f
+料理,りょうり,cooking; cuisine,Intermediate_Japanese Intermediate_Japanese_Ln.4 JLPT JLPT_5 JLPT_N5,G!~TK}MKdj
+旅行,りょこう,"travel, trip",Genki Genki_Ln.5 JLPT JLPT_5 JLPT_N5,KmCEi1#qL@
+零,れい,"zero, nought",JLPT JLPT_3 JLPT_5 JLPT_N5,rc1t]Q^qI(
+冷蔵庫,れいぞうこ,refrigerator,Genki Genki_Ln.18 JLPT JLPT_5 JLPT_N5,j*=Z=Hk4*w
+レコード,レコード,record,JLPT JLPT_5 JLPT_N5,xn:3qV.c32
+レストラン,レストラン,restaurant,Genki Genki_Ln.4 JLPT JLPT_5 JLPT_N5,s3y4P[QtRd
+練習,れんしゅう (する),(to) practice,JLPT JLPT_5 JLPT_N5,KaUYN0c91a
+廊下,ろうか,corridor,JLPT JLPT_5 JLPT_N5,AsH$#BLZ{M
+六,ろく,six,JLPT JLPT_5 JLPT_N5,w>WY?cJ:VM
+ワイシャツ,ワイシャツ,"shirt (lit: white shirt), business shirt",JLPT JLPT_5 JLPT_N5,x|nJIKNm*T
+若い,わかい,young,Genki Genki_Ln.9 Intermediate_Japanese Intermediate_Japanese_Ln.1 JLPT JLPT_5 JLPT_N5,xN9[eu+8aY
+分かる,わかる,to understand,JLPT JLPT_5 JLPT_N5,vF3#$3|-lu
+忘れる,わすれる,to forget,Intermediate_Japanese Intermediate_Japanese_Ln.3 JLPT JLPT_5 JLPT_N5,HW)xrzU[Z4
+私,わたし,"I, myself",Genki Genki_Ln.1 JLPT JLPT_5 JLPT_N5,I+Y7lySy.4
+私,わたくし,"I (formal), myself, private affairs",Genki Genki_Ln.13 JLPT JLPT_2 JLPT_5 JLPT_N5,m!I5:hHt<W
+渡す,わたす,to hand (something) over (v.t.); to get across,Intermediate_Japanese Intermediate_Japanese_Ln.6 JLPT JLPT_5 JLPT_N5,KvDHRUZ*r&
+渡る,わたる,"to cross over, to go across",JLPT JLPT_5 JLPT_N5,z9kLvI4/{d
+悪い,わるい,"bad, sinful; inferior",Genki Genki_Ln.12 Intermediate_Japanese Intermediate_Japanese_Ln.3 JLPT JLPT_5 JLPT_N5,rxV$$v%QZ;


### PR DESCRIPTION
## Summary

This a long overdue to change to include the GUID in all the CSV files.

To quote the AnkiWeb documentation:
> When you create notes in Anki, Anki assigns each note a unique ID, which can be used for duplicate checking. If you export your notes with the GUID included, you can make changes to the notes, and as long as you do not modify the GUID field, you'll be able to import the notes back in to update the existing notes.
> - Source: https://docs.ankiweb.net/importing.html#guid-column

The current anki library I use creates the GUID based on all the fields. If we were to change readings or kanji it would result in a new GUID being created and would disrupt a user's experience if they were to re-import an updated deck.

To protect against this, I've fetched all the GUIDs from the [first deck notes](https://github.com/jamsinclair/open-anki-jlpt-decks/releases/tag/v0.1.1) that were created and stored them in a new `guid` column in all CSVs.

I've also added CI scripts to enforce and allow easy maintenance of these GUIDs. 

#### tldr; We store a stable ID for each note. Which means updates to Note readings, kanji and tags etc won't affect users decks when they update to newer decks from this Repo.